### PR TITLE
Majority of army lists reviewed and updated - order dice added

### DIFF
--- a/Barbarians.cat
+++ b/Barbarians.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ffc5-6ea8-b36a-e2b6" name="Barbarians" revision="1" battleScribeVersion="2.02" authorName="the3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ffc5-6ea8-b36a-e2b6" name="Barbarians" revision="2" battleScribeVersion="2.02" authorName="the3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="090d-26e8-01c2-073e" name="Barbarian Chieftain" hidden="false" collective="false" targetId="8cff-0404-da51-b2e6" type="selectionEntry"/>
     <entryLink id="5c9d-4182-2a3c-956a" name="Mounted Barbarian Chieftain [122 pts]" hidden="false" collective="false" targetId="1e97-78f9-80b5-65b0" type="selectionEntry"/>
@@ -37,6 +37,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="72.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="448e-61aa-1e28-6534" name="Barbarian Bodyguard" hidden="false" collective="false" type="model">
@@ -49,6 +50,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -65,6 +67,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="03ad-0449-908c-e4b2" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -73,6 +76,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99c9-a2c3-4b56-ae46" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -81,6 +85,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27bc-085f-badb-3f7c" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -89,6 +94,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -105,6 +111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4658-2d35-b252-8ebd" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -113,6 +120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -129,6 +137,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9c55-4d4a-594a-d2ed" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -137,6 +146,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -159,6 +169,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fdfe-2150-523d-1b99" name="Berserk" hidden="false" collective="false" type="upgrade">
@@ -174,6 +185,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -187,6 +199,7 @@
             <selectionEntry id="4c9e-5051-6bfa-8742" name="Light Armour  RES 5(6)" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0144-1450-ec97-ad00" name="Medium Armour RES 5(7)" hidden="false" collective="false" type="upgrade">
@@ -199,6 +212,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -214,6 +228,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f754-8aa7-5ea5-2641" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -222,6 +237,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e55-900e-ddf6-8a79" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -230,6 +246,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53ca-b9ea-3ba9-800d" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -238,6 +255,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e2cc-4966-954c-5448" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -246,6 +264,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="08cc-3338-e7b8-2c18" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -254,6 +273,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da5a-3213-7f61-d47a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -262,6 +282,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -269,6 +290,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1e97-78f9-80b5-65b0" name="Mounted Barbarian Chieftain [122 pts]" hidden="false" collective="false" type="unit">
@@ -289,6 +311,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2192-e0af-7b14-a694" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -297,6 +320,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fbe7-bc68-76a9-bedf" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -305,6 +329,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c252-baf8-83ac-2b82" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -313,6 +338,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8223-025c-7df6-e2ce" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -321,6 +347,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -337,6 +364,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73ad-6c90-c850-31cb" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -345,6 +373,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -361,6 +390,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f22f-4ef4-5c4b-7676" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -369,6 +399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -391,6 +422,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fab6-c2b3-0337-f201" name="Berserk" hidden="false" collective="false" type="upgrade">
@@ -406,6 +438,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -419,6 +452,7 @@
             <selectionEntry id="eeee-a520-48d3-8083" name="Light Armour  RES 6(7)" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e05-b856-da6c-cc21" name="Medium Armour RES 6(8)" hidden="false" collective="false" type="upgrade">
@@ -431,6 +465,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -449,6 +484,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="82.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6b71-900e-77b7-4c85" name="Mounted Barbarian Bodyguard" hidden="false" collective="false" type="model">
@@ -461,6 +497,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -474,6 +511,7 @@
             <selectionEntry id="da75-4238-0b55-f7a1" name="Horses" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e25d-99eb-2532-2fa6" name="Warhorses" hidden="false" collective="false" type="upgrade">
@@ -489,6 +527,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -504,6 +543,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ab6-051c-4b04-1fd3" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -512,6 +552,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5da5-5651-3916-ca7c" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -520,6 +561,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a176-0509-e7a0-b39f" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -528,6 +570,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8a92-7c94-b9b2-24a1" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -536,6 +579,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5cfd-e18b-6590-54e1" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -544,6 +588,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b3cb-4411-a174-f3e6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -552,6 +597,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -559,6 +605,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8b28-5f08-d158-e945" name="Barbarian Chieftain in Chariot [152 pts]" hidden="false" collective="false" type="unit">
@@ -588,6 +635,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="147.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa69-8aa1-01c0-8832" name="Barbarian Chieftain, Medium Armour" hidden="false" collective="false" type="model">
@@ -598,6 +646,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="147.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -614,6 +663,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3078-4805-bc20-2ca9" name="Warhorses" hidden="false" collective="false" type="upgrade">
@@ -622,6 +672,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -637,6 +688,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -653,6 +705,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51df-f0f9-fbe6-14b2" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -661,6 +714,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -677,6 +731,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="322e-1a48-e326-c241" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -685,6 +740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -707,6 +763,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -723,6 +780,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="efb5-b1aa-fb9c-282b" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -731,6 +789,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fd2d-306d-910b-c82e" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -739,6 +798,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -755,6 +815,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -770,6 +831,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dc39-d931-f98d-ff4b" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -778,6 +840,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a121-a529-37a3-be6a" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -786,6 +849,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30ed-3ec9-0f0a-af32" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -794,6 +858,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="032f-893c-a2e4-af50" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -802,6 +867,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="42c7-ce0c-f04f-fd15" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -810,6 +876,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5b36-4340-dedf-212c" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -818,6 +885,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -825,6 +893,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f4f0-85af-cb96-c03e" name="Barbarian Shaman [57 pts]" hidden="false" collective="false" type="unit">
@@ -845,6 +914,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1d88-fb7d-f333-3340" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -853,6 +923,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e099-d1ef-e4ab-d838" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -861,6 +932,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -877,6 +949,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="870d-d7ee-ee71-4088" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -885,6 +958,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -907,6 +981,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -930,6 +1005,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="636f-ffc3-e138-be00" name="Barbarian Bodyguards in Light Armour" hidden="false" collective="false" type="model">
@@ -941,6 +1017,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -948,6 +1025,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ca4-a642-4d45-001b" name="Elemental Spirits" hidden="false" collective="false" type="upgrade">
@@ -963,6 +1041,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -970,6 +1049,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -987,6 +1067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="57.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1003,6 +1084,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="65ea-20aa-3624-2bf2" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1011,6 +1093,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dc70-bc37-58ad-e234" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1019,6 +1102,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ea8-4499-acc1-80bb" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1027,6 +1111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3dfc-cecf-efcc-8c6b" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1035,6 +1120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9202-3bbe-c958-0a2c" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1043,6 +1129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fe7a-8d15-cc91-71b9" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1051,6 +1138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2452-d7a3-9d6f-33b8" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1059,6 +1147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="779e-6b1a-f1c6-933f" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1067,6 +1156,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0a9-fe89-2cc5-bc13" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1075,6 +1165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62ae-9021-e19a-1040" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1083,6 +1174,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ec6-2e06-a04e-a0ea" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1091,6 +1183,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e1f-0d38-0e08-a762" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1099,6 +1192,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3a95-2ae1-704f-9cea" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1107,6 +1201,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1122,6 +1217,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8699-5f6c-ecc5-5db2" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1133,6 +1229,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f20a-5ca4-2a65-e34a" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1144,6 +1241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d1ce-df6a-846b-a537" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1155,6 +1253,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5814-d44b-856c-e1b6" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1166,6 +1265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ab30-e561-d43a-799a" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1177,6 +1277,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b4b1-9320-ee31-5cfa" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1188,6 +1289,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aebe-67f6-13ad-e045" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1199,6 +1301,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bfea-0896-d95a-3613" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1210,6 +1313,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4a8e-b3d9-86fb-0189" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1221,6 +1325,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd0a-a534-5475-9130" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1232,6 +1337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa2a-5dca-d862-761c" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1243,6 +1349,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f671-f6c1-4cc8-16ac" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1254,6 +1361,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ee8-a565-2e9e-a9e7" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1265,6 +1373,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1281,6 +1390,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bf2a-7552-136f-28e8" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1289,6 +1399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1304,6 +1415,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c6f2-ddc7-77bc-fd0a" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1312,6 +1424,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="20.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1200-3c7c-f444-1943" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1320,6 +1433,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="526d-156c-578c-9772" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1328,6 +1442,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="64bd-b461-8c78-8226" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1336,6 +1451,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="20.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f337-9461-f4a1-ef39" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1344,6 +1460,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dd0a-0820-e6b3-69c3" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1352,6 +1469,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="15.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -1361,6 +1479,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4d21-f575-3538-c572" name="Barbarian Hero [81 pts]" hidden="false" collective="false" type="unit">
@@ -1383,6 +1502,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7ff5-1641-bac9-f3cc" name="Barbarian Hero in Medium Armour" hidden="false" collective="false" type="model">
@@ -1391,6 +1511,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="91.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1407,6 +1528,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac10-8e66-0b07-3d5d" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1415,6 +1537,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="09b8-7215-3525-09cb" name="Wounds 3" hidden="false" collective="false" type="upgrade">
@@ -1423,6 +1546,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1439,6 +1563,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d4fe-b3df-629a-edd3" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1447,6 +1572,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1462,6 +1588,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d2c6-b125-c60d-92fe" name="Berserk" hidden="false" collective="false" type="upgrade">
@@ -1470,6 +1597,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1486,6 +1614,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4b4e-55d9-ecfd-a4c6" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1494,6 +1623,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e0c6-f503-34b2-e3a9" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1502,6 +1632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="470a-1f59-6b0d-abf9" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -1510,6 +1641,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="33d4-409d-966e-fdb1" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1518,6 +1650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="26e9-a974-9203-5236" name="Magic Weapon" hidden="false" collective="false" type="upgrade">
@@ -1533,6 +1666,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b4e9-cc99-8c07-10ac" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1541,6 +1675,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4d4c-ef22-fa86-888e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1549,6 +1684,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="26a5-8c78-cbc8-a1bb" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1557,6 +1693,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="cf65-d34a-e630-00fd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1565,6 +1702,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="51e6-8117-f30a-3319" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1573,6 +1711,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0e02-ec58-300f-1d6a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1581,6 +1720,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1588,6 +1728,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1595,6 +1736,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="49e7-fbb8-9ff8-91d7" name="Barbarian Hero in Chariot [158 pts]" hidden="false" collective="false" type="unit">
@@ -1620,6 +1762,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1636,6 +1779,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0076-c227-f443-6ab1" name="Warhorses" hidden="false" collective="false" type="upgrade">
@@ -1644,6 +1788,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1666,6 +1811,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1682,6 +1828,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1698,6 +1845,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="153.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d180-1388-e274-0a57" name="Hero with Medium Armour" hidden="false" collective="false" type="model">
@@ -1706,6 +1854,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="163.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1722,6 +1871,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ae1-a596-acf1-5588" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1730,6 +1880,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c9d-d8f6-c75a-2ad3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1738,6 +1889,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1753,6 +1905,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e8b8-7b86-ce62-d8a6" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1761,6 +1914,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9915-d889-b926-ba5c" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1769,6 +1923,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3233-e5c5-d1a7-34c0" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1777,6 +1932,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04e9-0cb4-6333-aec0" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1785,6 +1941,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a459-9289-2252-7a33" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1793,6 +1950,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8040-c0df-87d9-29d5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1801,6 +1959,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1808,6 +1967,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2ca7-6f0b-7006-5d2c" name="Barbarian Warriors [72 pts]" hidden="false" collective="false" type="unit">
@@ -1830,6 +1990,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2e18-9a8c-a538-6a38" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1838,6 +1999,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5324-95ce-d159-b21e" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1846,6 +2008,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9523-d203-22be-1d6b" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1854,6 +2017,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7768-8b64-f829-a837" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1862,6 +2026,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1884,6 +2049,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1908,6 +2074,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="36cf-6696-6b1e-760e" name="Warrior" hidden="false" collective="false" type="model">
@@ -1920,6 +2087,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1927,6 +2095,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf71-76a9-b881-ec20" name="Warriors in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1943,6 +2112,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f8c9-ea20-c0dd-c839" name="Warriors" hidden="false" collective="false" type="model">
@@ -1955,6 +2125,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1962,6 +2133,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1969,6 +2141,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="35b0-f975-d3b5-955f" name="Barbarian Archers [72 pts]" hidden="false" collective="false" type="unit">
@@ -1991,6 +2164,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b78-c9ce-3169-fc1c" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1999,6 +2173,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2021,6 +2196,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2045,6 +2221,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d800-da74-6f53-3f8d" name="Archer" hidden="false" collective="false" type="model">
@@ -2057,6 +2234,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2064,6 +2242,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="946c-598e-41a4-4a02" name="Archers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2080,6 +2259,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c5e3-942f-0852-3c62" name="Archers in Light Armour" hidden="false" collective="false" type="model">
@@ -2092,6 +2272,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2099,6 +2280,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2115,6 +2297,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2122,6 +2305,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="eec3-cdab-e67f-de60" name="Barbarian Horsemen [72 pts]" hidden="false" collective="false" type="unit">
@@ -2142,6 +2326,7 @@
             <selectionEntry id="845a-60e8-e4f7-f3fa" name="Horses" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91b8-7038-0e4c-9c7e" name="Warhorses" hidden="false" collective="false" type="upgrade">
@@ -2157,6 +2342,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2179,6 +2365,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2195,6 +2382,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e82d-4513-61d6-0f0f" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2203,6 +2391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9d96-dba6-c6d7-51e5" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2211,6 +2400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2233,6 +2423,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2257,6 +2448,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a2f3-61ab-e31b-168e" name="Horsemen" hidden="false" collective="false" type="model">
@@ -2269,6 +2461,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2276,6 +2469,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6157-a47c-ed44-ca25" name="Horsemen in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2292,6 +2486,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="604e-4e04-7052-b03d" name="Horsemen" hidden="false" collective="false" type="model">
@@ -2304,6 +2499,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2311,6 +2507,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2318,6 +2515,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2bad-a623-9159-2ff5" name="Barbarian Berserkers [97 pts]" hidden="false" collective="false" type="unit">
@@ -2347,6 +2545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2363,6 +2562,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4e39-4b92-5418-2f60" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2371,6 +2571,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b264-460b-b34b-761e" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -2379,6 +2580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df45-b442-99cd-f533" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -2387,6 +2589,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2403,6 +2606,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="29.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6035-ee29-08a5-6380" name="Beserkers" hidden="false" collective="false" type="model">
@@ -2415,6 +2619,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2422,6 +2627,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0fed-6557-73b9-a431" name="Barbarian Chariot [91 pts]" hidden="false" collective="false" type="unit">
@@ -2452,6 +2658,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2468,6 +2675,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9c53-f7e6-d332-a280" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2476,6 +2684,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b8d2-6b78-9686-1e98" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2484,6 +2693,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2506,6 +2716,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2522,6 +2733,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10b1-1939-b30e-9a72" name="Warhorses" hidden="false" collective="false" type="upgrade">
@@ -2530,6 +2742,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2545,6 +2758,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2561,6 +2775,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2577,6 +2792,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2584,11 +2800,12 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9642-c436-bb1f-d4e4" name="Warhounds [70 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="1d06-85f9-4cde-b90e" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+        <infoLink id="1d06-85f9-4cde-b90e" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
         <infoLink id="9e14-8b49-b40e-b889" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
@@ -2608,6 +2825,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="26.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fd70-9a86-e74e-a3be" name="Pack Master in Medium Armour" hidden="false" collective="false" type="model">
@@ -2616,6 +2834,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2633,6 +2852,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="11.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2649,6 +2869,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="21d8-9b73-16a9-9a8a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2657,6 +2878,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e0bd-f900-c300-5ec3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2665,6 +2887,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2672,6 +2895,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1776-7920-1dd9-1241" name="Barbarian Brats [37 pts]" hidden="false" collective="false" type="unit">
@@ -2692,6 +2916,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd60-35ff-56b4-2c04" name="Barbarian Brats" hidden="false" collective="false" type="model">
@@ -2704,6 +2929,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2721,6 +2947,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db39-dbc4-fa3c-2ee3" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -2733,6 +2960,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c39-14e6-7de4-d12e" name="Javelins" hidden="false" collective="false" type="upgrade">
@@ -2748,6 +2976,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2763,6 +2992,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2785,6 +3015,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2792,6 +3023,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9fa1-66cc-750b-015d" name="Mammoth [156 pts]" hidden="false" collective="false" type="unit">
@@ -2812,6 +3044,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="136.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2828,6 +3061,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2852,6 +3086,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b47c-1043-c3c1-ebc2" name="Javelins" hidden="false" collective="false" type="upgrade">
@@ -2867,6 +3102,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="165b-1dda-286d-c372" name="Bows" hidden="false" collective="false" type="upgrade">
@@ -2882,6 +3118,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7ebe-0305-976b-38b2" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2890,6 +3127,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2897,6 +3135,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3dee-6086-f5fc-e1f3" name="Barbarian Stone Thrower [81 pts]" hidden="false" collective="false" type="unit">
@@ -2916,6 +3155,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7071-a039-62bd-8a03" name="Large stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -2924,6 +3164,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2941,6 +3182,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2964,6 +3206,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="565f-0c3a-3140-bd44" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2979,6 +3222,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9649-390c-3dd1-34ef" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -2987,6 +3231,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3011,6 +3256,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3018,6 +3264,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="175c-effd-2f61-25f1" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -3034,6 +3281,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3041,6 +3289,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3048,6 +3297,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Barbarians.cat
+++ b/Barbarians.cat
@@ -217,77 +217,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="fe1d-773a-b391-df07" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d59d-ceb4-b9a8-e9a7" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="d89d-825d-c098-9532" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b95c-d31d-631e-3aee" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f754-8aa7-5ea5-2641" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ac7a-77f6-de02-915d" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6e55-900e-ddf6-8a79" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4084-8443-69ae-7e7f" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="53ca-b9ea-3ba9-800d" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bce8-1588-4d3e-8a42" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e2cc-4966-954c-5448" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4f35-0b52-94d4-bd02" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="08cc-3338-e7b8-2c18" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="25be-b2de-5777-5716" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="da5a-3213-7f61-d47a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="acae-f0dc-ebc8-8bec" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d5d7-2232-e3ce-ca26" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -532,77 +465,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4723-c6da-8f29-9aa5" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e944-cdc7-7639-8a0c" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="8890-b0d7-5d5e-bef6" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8213-f9b0-d195-d597" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0ab6-051c-4b04-1fd3" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a316-304a-a32f-7be4" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5da5-5651-3916-ca7c" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a897-d879-4a18-e8d0" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a176-0509-e7a0-b39f" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d591-3891-2d45-2893" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8a92-7c94-b9b2-24a1" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7acc-818c-1eca-0ee9" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5cfd-e18b-6590-54e1" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1ce4-9843-f144-a969" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b3cb-4411-a174-f3e6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5324-a4d0-1b5c-9787" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4838-a190-e48a-01ef" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -820,83 +686,19 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c91e-c48b-533e-4253" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c314-6680-36ba-cd5a" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="44ca-cbd8-0c53-3e44" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="3898-98f3-ac35-a5dd" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="dc39-d931-f98d-ff4b" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="620b-4e3d-fa21-96f3" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a121-a529-37a3-be6a" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="cd5f-6b79-897e-95c5" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="30ed-3ec9-0f0a-af32" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e930-2571-0bba-90c7" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="032f-893c-a2e4-af50" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8a8f-25d3-2601-9502" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="42c7-ce0c-f04f-fd15" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a8bc-15b8-3497-d34d" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5b36-4340-dedf-212c" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="3f6d-f54a-d327-fb38" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="cbbb-1cf0-9823-1b31" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f4f0-85af-cb96-c03e" name="Barbarian Shaman [57 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="b499-c569-2a3a-cef1" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="056d-cbae-6216-fa14" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="18fd-cb48-fc9a-4765" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
@@ -1378,105 +1180,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5b88-cc0c-0b55-33d3" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="acbb-b9f1-21d1-4804">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9af3-f2e0-8301-324d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="becd-56ba-f4e8-88be" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="acbb-b9f1-21d1-4804" name="Sword" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d303-082e-1dd3-5257" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="bf2a-7552-136f-28e8" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c284-c9d1-00c5-66b9" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="fbba-516f-f301-65ef" name="Magic Weapon " hidden="false" collective="false">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f08-c207-c4d0-a8d6" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="bf8a-f7dc-288c-adb4" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-                  <infoLinks>
-                    <infoLink id="548d-bb59-6f1c-b093" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="10.0"/>
-                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="c6f2-ddc7-77bc-fd0a" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-                  <infoLinks>
-                    <infoLink id="7a5c-6010-9d63-c766" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="20.0"/>
-                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="1200-3c7c-f444-1943" name="War Bringer" hidden="false" collective="false" type="upgrade">
-                  <infoLinks>
-                    <infoLink id="0d99-b69b-5809-45ca" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="10.0"/>
-                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="526d-156c-578c-9772" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-                  <infoLinks>
-                    <infoLink id="b215-0fb4-f11a-44f3" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
-                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="64bd-b461-8c78-8226" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-                  <infoLinks>
-                    <infoLink id="7bc0-687f-4ca5-9561" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="20.0"/>
-                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="f337-9461-f4a1-ef39" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-                  <infoLinks>
-                    <infoLink id="ea9a-a1c6-56a3-2355" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="10.0"/>
-                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="dd0a-0820-e6b3-69c3" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-                  <infoLinks>
-                    <infoLink id="6696-d204-3e1c-b2e9" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="15.0"/>
-                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d822-1a1e-b1b3-73af" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -1735,6 +1442,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6a4f-66a3-4efd-1526" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -1752,6 +1462,21 @@
         <categoryLink id="a509-f11a-fa85-c2a7" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
         <categoryLink id="692d-7367-656e-7a1b" name="Hero Unit" hidden="false" targetId="hero unit" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7ef1-8dc9-0e4c-2b3a" name="Chariot" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0b7-5a39-ed2f-3d0e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c9e-a678-56ac-1d61" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="cf4f-05fe-45a4-770e" name="Barbarian Chariot with Hero and Crew Pulled by Two Horses" hidden="false" targetId="1c75-f594-7a99-da4e" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="81.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="c427-8f05-fa8e-20f7" name="Chariot Scythes" hidden="false" collective="false">
           <constraints>
@@ -1896,94 +1621,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="165d-ca17-5b33-04be" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dc8-f74c-31dd-5ac0" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="7150-9f84-e548-2326" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="18a9-3264-f2f9-4a86" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e8b8-7b86-ce62-d8a6" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bd7a-ea25-4211-d5e3" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9915-d889-b926-ba5c" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="cb91-6733-c0b8-d8bd" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3233-e5c5-d1a7-34c0" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="f9d1-d4ed-6c4d-0dcd" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="04e9-0cb4-6333-aec0" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e0a4-38ab-669d-7526" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a459-9289-2252-7a33" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="80c2-eba2-9857-66ff" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8040-c0df-87d9-29d5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a36d-4b51-3669-f4a5" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="1820-3a22-8b7d-3041" name="Chariot" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="7990-ecd4-b86f-89d7" name="Chariot" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e08-5201-75d8-521e" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="021c-9cf6-e67a-64ed" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="6aad-0da2-1eb1-6104" name="Barbarian Chariot with Hero and Crew Pulled by Two Horses" hidden="false" targetId="1c75-f594-7a99-da4e" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="455b-907e-8cb5-0c79" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -3202,6 +2843,7 @@
               <infoLinks>
                 <infoLink id="34f8-39b6-63d2-e0b0" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
                 <infoLink id="d1ea-7415-1dfa-84f2" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+                <infoLink id="fdb0-aaff-2699-ca89" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>

--- a/Barbarians.cat
+++ b/Barbarians.cat
@@ -2165,7 +2165,7 @@
     </selectionEntry>
     <selectionEntry id="35b0-f975-d3b5-955f" name="Barbarian Archers [72 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="8839-ebca-bfd9-7ac5" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="8839-ebca-bfd9-7ac5" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="25ab-47d8-7b6b-a68a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>

--- a/Barbarians.cat
+++ b/Barbarians.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ffc5-6ea8-b36a-e2b6" name="Barbarians" revision="2" battleScribeVersion="2.02" authorName="the3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ffc5-6ea8-b36a-e2b6" name="Barbarians" revision="3" battleScribeVersion="2.02" authorName="the3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="090d-26e8-01c2-073e" name="Barbarian Chieftain" hidden="false" collective="false" targetId="8cff-0404-da51-b2e6" type="selectionEntry"/>
     <entryLink id="5c9d-4182-2a3c-956a" name="Mounted Barbarian Chieftain [122 pts]" hidden="false" collective="false" targetId="1e97-78f9-80b5-65b0" type="selectionEntry"/>
@@ -19,60 +19,24 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="8cff-0404-da51-b2e6" name="Barbarian Chieftain [96 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="b82f-fa0b-77f5-3047" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+        <infoLink id="3bfa-84cd-4c8d-e1a7" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7b0f-813a-5065-bc71" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="50fd-faea-5002-7588" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5875-ed7b-6b00-a01c" name="Models" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="3c3a-52de-2ef0-3044" name="Barbarian Chieftain" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2334-ddcf-ce89-7165" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc1c-9663-7ab8-2b05" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="9c92-4dd7-90a8-1964" name="Barbarian Chieftain" hidden="false" targetId="09e6-4341-0bbf-ed92" type="profile"/>
-                <infoLink id="786a-c264-4b67-0d7e" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="72.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="448e-61aa-1e28-6534" name="Barbarian Bodyguard" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c951-3427-abea-7212" type="min"/>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c87b-5bb9-2fd5-d7f3" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="a12f-ed19-3bcd-9670" name="Barbarian Bodyguard" hidden="false" targetId="8ecb-b9ee-880d-0f2f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
         <selectionEntryGroup id="2a99-0aa8-b38f-4829" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="5930-c487-4deb-37dc">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d88d-48f1-9e0f-33a6" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b5c-7947-65b3-2191" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="5930-c487-4deb-37dc" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5930-c487-4deb-37dc" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="e22a-4c9e-66e6-75d5" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="03ad-0449-908c-e4b2" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5587-3075-f646-9c72" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -99,7 +63,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="93de-0ec1-bafe-5d15" name="Chieftain Wounds upgrade" hidden="false" collective="false" defaultSelectionEntryId="02aa-a9ee-7eb3-39d6">
+        <selectionEntryGroup id="93de-0ec1-bafe-5d15" name="Chieftain Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="02aa-a9ee-7eb3-39d6">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6565-1e3f-32b0-3f68" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce0c-9842-8b1b-9fce" type="min"/>
@@ -158,9 +122,9 @@
           <selectionEntries>
             <selectionEntry id="acb5-2340-6913-054c" name="Savage" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="8cff-0404-da51-b2e6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="8cff-0404-da51-b2e6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
               </modifiers>
@@ -174,9 +138,9 @@
             </selectionEntry>
             <selectionEntry id="fdfe-2150-523d-1b99" name="Berserk" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="5">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="8cff-0404-da51-b2e6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
               </modifiers>
@@ -196,20 +160,73 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a70-c81d-75e0-935e" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4c9e-5051-6bfa-8742" name="Light Armour  RES 5(6)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4c9e-5051-6bfa-8742" name="Light Armour" hidden="false" collective="false" type="unit">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="3d4c-d261-65af-44a4" name="Choose 2 to 4" hidden="false" collective="false">
+                  <selectionEntries>
+                    <selectionEntry id="e81b-fac8-fe6b-fcfc" name="Barbarian Bodyguard in Light Armour" hidden="false" collective="false" type="model">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a069-20bb-25e1-3eef" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1769-b7d2-0488-9337" type="min"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="2b42-5b5c-75a0-b6c4" name="Barbarian Bodyguard in Light Armour" hidden="false" targetId="8ecb-b9ee-880d-0f2f" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="12.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="a731-445f-855d-1e4f" name="Barbarian Chieftain in Light Armour" hidden="false" collective="false" type="model">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7475-636f-9a17-1ae7" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4808-8679-f093-2b8c" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="8b48-e52a-f005-d3b2" name="Barbarian Chieftain" hidden="false" targetId="09e6-4341-0bbf-ed92" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="72.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0144-1450-ec97-ad00" name="Medium Armour RES 5(7)" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="2">
-                  <repeats>
-                    <repeat field="selections" scope="8cff-0404-da51-b2e6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
+            <selectionEntry id="0144-1450-ec97-ad00" name="Medium Armour" hidden="false" collective="false" type="unit">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="8316-ded6-376a-2743" name="Choose 2 to 4" hidden="false" collective="false">
+                  <selectionEntries>
+                    <selectionEntry id="79c5-dac7-541e-b332" name="Barbarian Chieftain in Medium Armour" hidden="false" collective="false" type="model">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49ee-ffb6-22d9-fe59" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e3c-d3c2-8e5d-fc56" type="min"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="ee2b-a99c-6f04-6a65" name="Barbarian Chieftain in Medium Armour" hidden="false" targetId="da2e-5091-7006-ab4d" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="74.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="bcd5-f054-1b5f-7ddf" name="Barbarian Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67fb-97f9-eaef-3821" type="min"/>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="178c-5e32-6576-5441" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="8bd2-f26c-b441-8acc" name="Barbarian Bodyguard in Medium Armour" hidden="false" targetId="2086-8df9-ac56-088b" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="14.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
@@ -227,6 +244,10 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="1e97-78f9-80b5-65b0" name="Mounted Barbarian Chieftain [122 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="ec01-f8ca-0c81-bb28" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+        <infoLink id="8056-f89e-d82c-fc2e" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="40a5-f105-e062-25cb" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="f14d-d724-d744-b409" name="Mounted Unit" hidden="false" targetId="mounted unit" primary="false"/>
@@ -238,18 +259,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5eb-6090-4c91-9996" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="eaee-deed-60ec-ab8a" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="eaee-deed-60ec-ab8a" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="f2b5-96a1-fbca-6713" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2192-e0af-7b14-a694" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="fec8-0e30-76f9-14a4" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -285,7 +297,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="94ab-c6cf-2b3e-3f16" name="Chieftain Wounds upgrade" hidden="false" collective="false" defaultSelectionEntryId="4fd3-7615-9458-b110">
+        <selectionEntryGroup id="94ab-c6cf-2b3e-3f16" name="Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="4fd3-7615-9458-b110">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4ef-7fb6-5bcf-cdd9" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="185e-e163-f0bc-ade9" type="min"/>
@@ -311,7 +323,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d973-6dee-62a6-4608" name="Chieftain Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="1a49-2b50-6bb4-6b53">
+        <selectionEntryGroup id="d973-6dee-62a6-4608" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="1a49-2b50-6bb4-6b53">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ea5-dd70-0052-943b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e02b-649c-12e9-92a5" type="min"/>
@@ -337,7 +349,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d6e7-372a-1b83-66f4" name="Savage or Berserk rule" hidden="false" collective="false">
+        <selectionEntryGroup id="d6e7-372a-1b83-66f4" name="Savage or Berserk" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d817-8784-0416-778e" type="max"/>
           </constraints>
@@ -382,60 +394,81 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f3d-6a11-fefb-b892" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="eeee-a520-48d3-8083" name="Light Armour  RES 6(7)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="eeee-a520-48d3-8083" name="Light Armour" hidden="false" collective="false" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="4e5e-8753-edcf-b511" name="Choose 2 to 4" hidden="false" collective="false">
+                  <selectionEntries>
+                    <selectionEntry id="e125-d320-9a26-bd52" name="Mounted Barbarian Bodyguard in Light Armour" hidden="false" collective="false" type="model">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9a5-7004-d13f-f991" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae03-aa84-dbd4-4916" type="min"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="c2bb-a760-9fa3-f05d" name="Mounted Barbarian Bodyguard in Light Armour" hidden="false" targetId="b35a-92fd-29cb-a9d9" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="20.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="de0b-28b1-cc39-417e" name="Mounted Barbarian Chieftain in Light Armour" hidden="false" collective="false" type="model">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afaa-9f11-29fa-2137" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29c5-7b82-a0bb-000b" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="7571-2b4f-3b32-b6c1" name="Mounted Barbarian Chieftain in Light Armour" hidden="false" targetId="e404-635b-5f36-dc01" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="82.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6e05-b856-da6c-cc21" name="Medium Armour RES 6(8)" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="2">
-                  <repeats>
-                    <repeat field="selections" scope="1e97-78f9-80b5-65b0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
+            <selectionEntry id="6e05-b856-da6c-cc21" name="Medium Armour" hidden="false" collective="false" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="dc5e-67d4-5530-40cc" name="Choose 2 to 4" hidden="false" collective="false">
+                  <selectionEntries>
+                    <selectionEntry id="347f-8f49-6fdd-7ca5" name="Mounted Barbarian Chieftain in Medium Armour" hidden="false" collective="false" type="model">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52af-2b70-f7db-5773" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d3c-8897-d395-7c23" type="min"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="6325-b257-d962-c784" name="Mounted Barbarian Chieftain in Medium Armour" hidden="false" targetId="ccce-69e6-06c8-7173" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="84.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="5f6c-570e-320d-7e2d" name="Mounted Barbarian Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d84-9ec0-1ab1-9427" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5742-0204-ac22-9dba" type="min"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="0474-f9fe-88c8-a46d" name="Mounted Barbarian Bodyguard in Medium Armour" hidden="false" targetId="0f15-4744-eeef-0883" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="22.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name="pts" typeId="points" value="10.0"/>
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c070-b8ef-3535-1f6d" name="Models" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="c213-b57f-854f-d437" name="Mounted Barbarian Chieftain" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="129c-f5f6-e9f1-1d11" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdf5-29d6-629b-039e" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="cf54-78da-f89c-1bd3" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                <infoLink id="14ae-3bbc-726f-c6ea" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
-                <infoLink id="9d58-2c20-2bbe-603d" name="Mounted Barbarian Chieftain" hidden="false" targetId="e404-635b-5f36-dc01" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="82.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6b71-900e-77b7-4c85" name="Mounted Barbarian Bodyguard" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e055-de29-1b03-693e" type="min"/>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1c3-d1fc-c5d9-5fc3" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="dbb8-d8de-2763-3179" name="Mounted Barbarian Bodyguard" hidden="false" targetId="b35a-92fd-29cb-a9d9" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="5423-f445-0e8d-b72c" name="Horses" hidden="false" collective="false" defaultSelectionEntryId="da75-4238-0b55-f7a1">
+        <selectionEntryGroup id="5423-f445-0e8d-b72c" name="Warhorse Upgrade" hidden="false" collective="false" defaultSelectionEntryId="da75-4238-0b55-f7a1">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8167-9d39-a69f-2462" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe88-b4d4-68d5-985f" type="max"/>
@@ -481,6 +514,8 @@
         <infoLink id="824d-79d1-7fdd-b06e" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="b530-1892-1be5-447d" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
         <infoLink id="5820-2515-70e2-0f27" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+        <infoLink id="00e4-b83e-fb50-597c" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+        <infoLink id="0774-0a09-fba1-190a" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="d661-41de-745f-c906" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
@@ -495,20 +530,16 @@
           <selectionEntries>
             <selectionEntry id="9aad-1770-195f-f650" name="Barbarian Chieftain with Light Armour" hidden="false" collective="false" type="model">
               <infoLinks>
-                <infoLink id="8808-0b44-fc01-e881" name="Barbarian Chieftain, Light armour, (chariot - on foot)" hidden="false" targetId="d9ad-0e48-0e5a-8b79" type="profile"/>
-                <infoLink id="648a-cf12-3b99-69d2" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                <infoLink id="59d7-a02b-a12b-0b50" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
+                <infoLink id="8808-0b44-fc01-e881" name="Barbarian Chieftain in Light Armour in Chariot" hidden="false" targetId="d9ad-0e48-0e5a-8b79" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="147.0"/>
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="aa69-8aa1-01c0-8832" name="Barbarian Chieftain, Medium Armour" hidden="false" collective="false" type="model">
+            <selectionEntry id="aa69-8aa1-01c0-8832" name="Barbarian Chieftain in Medium Armour" hidden="false" collective="false" type="model">
               <infoLinks>
-                <infoLink id="5f76-c1ef-2f3b-1656" name="Barbarian Chieftain, Medium Armour, (chariot - on foot)" hidden="false" targetId="cc65-1b12-5415-6b7d" type="profile"/>
-                <infoLink id="bdf0-cf2a-c65d-0963" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                <infoLink id="47f7-e2f8-8ebf-dbaf" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
+                <infoLink id="5f76-c1ef-2f3b-1656" name="Barbarian Chieftain in Medium Armour in Chariot" hidden="false" targetId="cc65-1b12-5415-6b7d" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="147.0"/>
@@ -517,7 +548,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a97c-b3ca-13bb-9ed2" name="warhorse upgrade" hidden="false" collective="false" defaultSelectionEntryId="0854-f47a-c05a-4f68">
+        <selectionEntryGroup id="a97c-b3ca-13bb-9ed2" name="Warhorse Upgrade" hidden="false" collective="false" defaultSelectionEntryId="0854-f47a-c05a-4f68">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9339-2f75-f148-9cbf" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4e4-3c2e-88be-07f5" type="max"/>
@@ -559,7 +590,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="06e9-6140-7ba0-d1a8" name="Chief Wound [on foot] Upgrade" hidden="false" collective="false" defaultSelectionEntryId="add3-4f70-191f-a4fb">
+        <selectionEntryGroup id="06e9-6140-7ba0-d1a8" name=" Wound Upgrade [on foot]" hidden="false" collective="false" defaultSelectionEntryId="add3-4f70-191f-a4fb">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c316-56a0-748f-35a1" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a34-2a68-ba6b-756c" type="max"/>
@@ -585,7 +616,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ab6e-2c51-2bda-9bec" name="Hero Tough [on foot] Upgrade" hidden="false" collective="false" defaultSelectionEntryId="322e-1a48-e326-c241">
+        <selectionEntryGroup id="ab6e-2c51-2bda-9bec" name="Hero Tough Upgrade [on foot]" hidden="false" collective="false" defaultSelectionEntryId="322e-1a48-e326-c241">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b73d-7c32-b4a3-2260" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a1e-0e2b-756e-3057" type="max"/>
@@ -640,18 +671,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="154a-1b30-35e7-eba9" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f022-6671-34c4-a5a1" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f022-6671-34c4-a5a1" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="b6de-d20f-57a9-6b26" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="efb5-b1aa-fb9c-282b" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="6d2f-a22b-489f-036a" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -669,7 +691,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c416-265d-99a5-88ba" name="Crew" hidden="false" collective="false">
+        <selectionEntryGroup id="c416-265d-99a5-88ba" name="Choose 1 to 3" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="69f5-dc45-04df-ad90" name="Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -697,12 +719,28 @@
     </selectionEntry>
     <selectionEntry id="f4f0-85af-cb96-c03e" name="Barbarian Shaman [57 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="b499-c569-2a3a-cef1" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="3929-e827-2e24-3265" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="056d-cbae-6216-fa14" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="18fd-cb48-fc9a-4765" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="35c7-7c50-afbb-9fc0" name="Shaman" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f99e-58de-bbd8-72fa" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df4e-1d93-deab-964d" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="9d91-47bb-02c4-68b3" name="Barbarian Shaman" hidden="false" targetId="6f7a-1e71-1b91-a7b3" type="profile"/>
+            <infoLink id="5292-b21b-120f-9a9a" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="57.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="c678-ded4-01e0-4a3a" name="Magic Level" hidden="false" collective="false" defaultSelectionEntryId="3a93-4b32-a370-fb4d">
           <constraints>
@@ -796,14 +834,14 @@
           <selectionEntries>
             <selectionEntry id="0814-c8fd-f14d-5936" name="Barbarian Bodyguard" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="e6ed-4ee9-b029-0667" name="Bodyguards" hidden="false" collective="false" defaultSelectionEntryId="4729-03c9-0c5c-b3cb">
+                <selectionEntryGroup id="e6ed-4ee9-b029-0667" name="Choose up to 4" hidden="false" collective="false" defaultSelectionEntryId="4729-03c9-0c5c-b3cb">
                   <selectionEntries>
                     <selectionEntry id="4729-03c9-0c5c-b3cb" name="Barbarian Bodyguards" hidden="false" collective="false" type="model">
                       <constraints>
                         <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2ae-5223-3b54-ad8e" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="6bfa-6982-d591-3386" name="Barbarian Bodyguard (no armour)" hidden="false" targetId="1cda-18b8-4a29-832f" type="profile"/>
+                        <infoLink id="6bfa-6982-d591-3386" name="Barbarian Bodyguard" hidden="false" targetId="1cda-18b8-4a29-832f" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
@@ -832,7 +870,7 @@
             </selectionEntry>
             <selectionEntry id="5ca4-a642-4d45-001b" name="Elemental Spirits" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="9a26-25ce-ae11-73b1" name="Elemental Spirits" hidden="false" collective="false">
+                <selectionEntryGroup id="9a26-25ce-ae11-73b1" name="Choose up to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="7d05-eb25-f8ea-173e" name="Elemental Spirits" hidden="false" collective="false" type="model">
                       <constraints>
@@ -851,24 +889,6 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="4f0c-835d-a567-b31e" name="Shaman" hidden="false" collective="false" defaultSelectionEntryId="a315-57a3-a250-c419">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ef5-9a94-2725-b7d5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bedc-1dec-6116-9ee0" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="a315-57a3-a250-c419" name="Shaman" hidden="false" collective="false" type="model">
-              <infoLinks>
-                <infoLink id="c4dd-dc4b-17d0-b2d6" name="Barbarian Shaman" hidden="false" targetId="6f7a-1e71-1b91-a7b3" type="profile"/>
-                <infoLink id="2734-77e1-ca9f-4910" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="57.0"/>
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -1224,7 +1244,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="411f-a353-b35c-86c4" name="Hero Wounds upgrade" hidden="false" collective="false" defaultSelectionEntryId="0fcf-ea75-2ef0-6b84">
+        <selectionEntryGroup id="411f-a353-b35c-86c4" name="Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="0fcf-ea75-2ef0-6b84">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8331-4004-2f4a-c9ec" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8f1-6c7a-45f2-934d" type="min"/>
@@ -1248,7 +1268,7 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="09b8-7215-3525-09cb" name="Wounds 3" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="09b8-7215-3525-09cb" name="Wound 3" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="8280-7366-1e4c-e5d8" name="Wound 3" hidden="false" targetId="2724-2057-e745-23a3" type="rule"/>
               </infoLinks>
@@ -1259,7 +1279,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="7982-336b-8e29-0714" name="Hero Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="d4fe-b3df-629a-edd3">
+        <selectionEntryGroup id="7982-336b-8e29-0714" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="d4fe-b3df-629a-edd3">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bda8-87b5-d41b-0ac8" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4669-c991-c82c-4d01" type="min"/>
@@ -1285,7 +1305,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="db41-bfe0-c753-6d41" name="Savage or Berserk rule" hidden="false" collective="false">
+        <selectionEntryGroup id="db41-bfe0-c753-6d41" name="Savage or Berserk" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4a4-1f3b-f80b-8554" type="max"/>
           </constraints>
@@ -1316,18 +1336,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="295e-2566-4a2f-c334" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ec87-06ea-5e6f-852d" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ec87-06ea-5e6f-852d" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="0c3c-8fae-09f7-378e" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4b4e-55d9-ecfd-a4c6" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ab74-43bb-4139-2db0" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1494,7 +1505,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ccb6-5b62-ac33-63a3" name="Warhorse upgrade" hidden="false" collective="false" defaultSelectionEntryId="044f-0167-5a04-208c">
+        <selectionEntryGroup id="ccb6-5b62-ac33-63a3" name="Warhorse Upgrade" hidden="false" collective="false" defaultSelectionEntryId="044f-0167-5a04-208c">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9e6-1db9-155d-0f88" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b13f-459a-8ded-dc74" type="max"/>
@@ -1543,7 +1554,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="7922-2147-f691-2b58" name="Crew" hidden="false" collective="false">
+        <selectionEntryGroup id="7922-2147-f691-2b58" name="Choose 1 to 3" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="c4cb-58db-0735-41c0" name="Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -1566,7 +1577,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74ff-c5d2-4b5f-5be6" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="0b05-7539-9fef-4521" name="Hero with Light Armour" hidden="false" collective="false" type="model">
+            <selectionEntry id="0b05-7539-9fef-4521" name="Hero in Light Armour" hidden="false" collective="false" type="model">
               <infoLinks>
                 <infoLink id="b520-1123-4e8b-17e2" name="Barbarian Hero in light armour (Chariot - on foot)" hidden="false" targetId="35d6-2cfb-7c39-3597" type="profile"/>
               </infoLinks>
@@ -1575,7 +1586,7 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d180-1388-e274-0a57" name="Hero with Medium Armour" hidden="false" collective="false" type="model">
+            <selectionEntry id="d180-1388-e274-0a57" name="Hero in Medium Armour" hidden="false" collective="false" type="model">
               <infoLinks>
                 <infoLink id="8258-fd5b-3ffd-5392" name="Barbarian Hero in Medium armour (Chariot - on foot)" hidden="false" targetId="05fe-959b-50af-fec2" type="profile"/>
               </infoLinks>
@@ -1592,18 +1603,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a156-02e2-c135-8210" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4a9f-1cf3-dab7-56e4" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4a9f-1cf3-dab7-56e4" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="68f3-d843-ac79-4428" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5ae1-a596-acf1-5588" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9ff9-818a-c287-841c" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1644,18 +1646,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7265-24fe-d891-f4e8" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="31bb-3d79-0e8f-168a" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="31bb-3d79-0e8f-168a" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="31e3-19b2-4bd1-cdbb" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2e18-9a8c-a538-6a38" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b5c0-f85a-d61e-1823" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1698,7 +1691,7 @@
           <selectionEntries>
             <selectionEntry id="9d2d-d21e-2f72-e815" name="Savage" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="2ca7-6f0b-7006-5d2c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -1714,7 +1707,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="7da3-f228-50c3-cf0b" name="Models" hidden="false" collective="false" defaultSelectionEntryId="06fb-bf64-b884-3546">
+        <selectionEntryGroup id="7da3-f228-50c3-cf0b" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="06fb-bf64-b884-3546">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="288f-5dff-b74d-1b7f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad35-3ff8-d3eb-070f" type="min"/>
@@ -1722,7 +1715,7 @@
           <selectionEntries>
             <selectionEntry id="06fb-bf64-b884-3546" name="Warriors in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="0a95-17a7-3dc6-5528" name="models" hidden="false" collective="false">
+                <selectionEntryGroup id="0a95-17a7-3dc6-5528" name="Choose 5 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="fe9c-5d27-f705-9ea7" name="Warrior Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1760,7 +1753,7 @@
             </selectionEntry>
             <selectionEntry id="cf71-76a9-b881-ec20" name="Warriors in Medium Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="b9fc-0608-7d4f-90ce" name="models" hidden="false" collective="false">
+                <selectionEntryGroup id="b9fc-0608-7d4f-90ce" name="Choose 5 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="8795-a27a-14e1-1db2" name="Warrior Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1807,37 +1800,13 @@
     <selectionEntry id="35b0-f975-d3b5-955f" name="Barbarian Archers [72 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="8839-ebca-bfd9-7ac5" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="84a1-3fd0-d6f3-6bf7" name="Bow" hidden="false" targetId="95e1-d9f2-8182-5835" type="profile"/>
+        <infoLink id="9f48-0f93-769c-4a8e" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="25ab-47d8-7b6b-a68a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="fdf2-ae98-7a66-8a4d" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="8fae-5352-0401-312b">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9455-a2be-86e3-26ac" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="753d-1e12-6ff9-5aa5" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="8fae-5352-0401-312b" name="Sword" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="753b-1cd9-da61-f257" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0b78-c9ce-3169-fc1c" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="aefa-f959-b70c-355a" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
         <selectionEntryGroup id="5d7c-ad89-2b50-c2b0" name="Savage Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="710e-f164-7dad-1f3d" type="max"/>
@@ -1861,7 +1830,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a36d-5bc8-1816-894f" name="Models" hidden="false" collective="false" defaultSelectionEntryId="3537-d976-7a36-dc8a">
+        <selectionEntryGroup id="a36d-5bc8-1816-894f" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="3537-d976-7a36-dc8a">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf07-0d1f-c1de-eb7d" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7051-508e-0b84-772c" type="min"/>
@@ -1869,7 +1838,7 @@
           <selectionEntries>
             <selectionEntry id="3537-d976-7a36-dc8a" name="Archers" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="b375-a1e2-93c0-c0e7" name="models" hidden="false" collective="false">
+                <selectionEntryGroup id="b375-a1e2-93c0-c0e7" name="Choose 5 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="7559-6407-7155-7195" name="Archer Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1907,7 +1876,7 @@
             </selectionEntry>
             <selectionEntry id="946c-598e-41a4-4a02" name="Archers in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="8ad6-32df-1b1e-432d" name="models" hidden="false" collective="false">
+                <selectionEntryGroup id="8ad6-32df-1b1e-432d" name="Choose 5 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="d892-b4a1-d23b-f64c" name="Archer Leader in Light Armour" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1945,23 +1914,6 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="53a1-5fd0-3bdf-3a90" name="Bows" hidden="false" collective="false" defaultSelectionEntryId="46c2-88d3-9077-a669">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80d7-e6b4-b6bc-a5af" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1489-8f08-a27b-d9dc" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="46c2-88d3-9077-a669" name="Bow" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8552-3b57-c7b4-13fb" name="Bow" hidden="false" targetId="95e1-d9f2-8182-5835" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -1977,7 +1929,7 @@
         <categoryLink id="e0cf-17ae-207f-11b1" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d39c-c7db-d339-a789" name="Horses" hidden="false" collective="false" defaultSelectionEntryId="845a-60e8-e4f7-f3fa">
+        <selectionEntryGroup id="d39c-c7db-d339-a789" name="Warhorse Upgrade" hidden="false" collective="false" defaultSelectionEntryId="845a-60e8-e4f7-f3fa">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2412-b8ce-ed3e-2463" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10bd-3a2b-2b47-5d21" type="max"/>
@@ -2036,18 +1988,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2539-d7d5-575a-fb52" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="0574-2261-9b20-18d2" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0574-2261-9b20-18d2" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="2dfc-34eb-75d2-9f6b" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e82d-4513-61d6-0f0f" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9f93-2486-8519-257e" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2088,7 +2031,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0457-4648-20bb-eae6" name="Models" hidden="false" collective="false" defaultSelectionEntryId="da44-2eff-89f1-03b0">
+        <selectionEntryGroup id="0457-4648-20bb-eae6" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="da44-2eff-89f1-03b0">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8615-a7ae-5904-0d37" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c29b-106f-3e20-44dc" type="min"/>
@@ -2096,9 +2039,9 @@
           <selectionEntries>
             <selectionEntry id="da44-2eff-89f1-03b0" name="Horsemen in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="8e77-7760-789c-7782" name="models" hidden="false" collective="false">
+                <selectionEntryGroup id="8e77-7760-789c-7782" name="Choose 2 to 4" hidden="false" collective="false">
                   <selectionEntries>
-                    <selectionEntry id="74e5-d364-62f7-4524" name="Horsemen Leader" hidden="false" collective="false" type="model">
+                    <selectionEntry id="74e5-d364-62f7-4524" name="Horsemen Leader in Light Armour" hidden="false" collective="false" type="model">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a70-8d2c-53e9-b309" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e00-8882-20d9-d7a3" type="min"/>
@@ -2111,7 +2054,7 @@
                         <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
-                    <selectionEntry id="a2f3-61ab-e31b-168e" name="Horsemen" hidden="false" collective="false" type="model">
+                    <selectionEntry id="a2f3-61ab-e31b-168e" name="Horsemen in Light Armour" hidden="false" collective="false" type="model">
                       <constraints>
                         <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e1d-5e49-4770-abef" type="max"/>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30bc-e72b-9885-41c7" type="min"/>
@@ -2134,9 +2077,9 @@
             </selectionEntry>
             <selectionEntry id="6157-a47c-ed44-ca25" name="Horsemen in Medium Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="2fb6-fd7f-2ce2-718b" name="models" hidden="false" collective="false">
+                <selectionEntryGroup id="2fb6-fd7f-2ce2-718b" name="Choose 2 to 4" hidden="false" collective="false">
                   <selectionEntries>
-                    <selectionEntry id="4869-8b3a-d0f6-e7b0" name="Horsemen Leader" hidden="false" collective="false" type="model">
+                    <selectionEntry id="4869-8b3a-d0f6-e7b0" name="Horsemen Leader in Medium Armour" hidden="false" collective="false" type="model">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd52-21a5-7012-f63a" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8658-601c-fd11-8647" type="min"/>
@@ -2149,7 +2092,7 @@
                         <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
-                    <selectionEntry id="604e-4e04-7052-b03d" name="Horsemen" hidden="false" collective="false" type="model">
+                    <selectionEntry id="604e-4e04-7052-b03d" name="Horsemen in Medium Armour" hidden="false" collective="false" type="model">
                       <constraints>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5538-5b4e-020c-fcfa" type="min"/>
                         <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1042-9888-5060-7c32" type="max"/>
@@ -2181,7 +2124,7 @@
     <selectionEntry id="2bad-a623-9159-2ff5" name="Barbarian Berserkers [97 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="4e08-7b0f-6a8a-74ad" name="Berserk" hidden="false" targetId="0b0f-1de6-7017-9097" type="rule"/>
-        <infoLink id="1c57-79a1-e038-f61d" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="1c57-79a1-e038-f61d" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="6810-09b0-c563-1836" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -2216,18 +2159,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbb8-0525-f336-1437" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ceb9-4646-7b01-7542" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ceb9-4646-7b01-7542" name="Sword or Axe" publicationId="cffa-cd51-pubN65537" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="0182-46e5-5554-90e3" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4e39-4b92-5418-2f60" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bdec-848d-06cd-b9d5" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="0182-46e5-5554-90e3" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2254,7 +2188,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ce3b-b770-7fbc-22e5" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="ce3b-b770-7fbc-22e5" name="Choose 4 to 9" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="74dd-7d70-75ca-1830" name="Berserker Leader" hidden="false" collective="false" type="model">
               <constraints>
@@ -2299,6 +2233,21 @@
       <categoryLinks>
         <categoryLink id="3b1d-483c-ff30-e065" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="163c-0445-2234-30cf" name="Chariot" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5a1-4b8b-5344-12ae" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ddb-7dcd-2af4-0fd4" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6b20-84e5-bc7e-fe6a" name="Barbarian Chariot and Crew Pulled by Two Horses" hidden="false" targetId="fd0a-fee6-1a73-f22e" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="81.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="7e66-a096-9c24-62a8" name="Bows" hidden="false" collective="false">
           <constraints>
@@ -2307,7 +2256,7 @@
           <selectionEntries>
             <selectionEntry id="a6d7-409f-53a0-09a0" name="Bow" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="2">
+                <modifier type="increment" field="points" value="2.0">
                   <repeats>
                     <repeat field="selections" scope="0fed-6557-73b9-a431" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -2332,15 +2281,6 @@
             <selectionEntry id="9f7a-0169-4b21-75e3" name="Sword" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="787c-6527-41e0-5d3d" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9c53-f7e6-d332-a280" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b8fa-e59b-182c-4ded" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2381,7 +2321,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c00c-430d-ec24-9741" name="warhorse upgrade" hidden="false" collective="false" defaultSelectionEntryId="69b7-0b3d-dff7-af96">
+        <selectionEntryGroup id="c00c-430d-ec24-9741" name="Warhorse upgrade" hidden="false" collective="false" defaultSelectionEntryId="69b7-0b3d-dff7-af96">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5ca-17e2-bdc6-158e" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f8c-910d-2498-416e" type="max"/>
@@ -2423,7 +2363,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="2164-2e89-f9ed-c5eb" name="Crew" hidden="false" collective="false">
+        <selectionEntryGroup id="2164-2e89-f9ed-c5eb" name="Choose 2 to 4" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="9bfa-bb2f-4408-e654" name="Barbarian Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -2431,27 +2371,10 @@
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6bf-5dda-5017-c4a6" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="993f-134b-9554-4248" name="Barbarian Chariot Crew" hidden="false" targetId="bc5b-5be5-e52e-76a3" type="profile"/>
+                <infoLink id="993f-134b-9554-4248" name="Barbarian Chariot Crew with Sword or Axe" hidden="false" targetId="bc5b-5be5-e52e-76a3" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="4868-71d0-79de-0177" name="Chariot" hidden="false" collective="false" defaultSelectionEntryId="d748-18f0-61a3-7444">
-          <selectionEntries>
-            <selectionEntry id="d748-18f0-61a3-7444" name="Chariot" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a3d-f093-4187-235c" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5b8-9e6f-fd6e-7fa8" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="f9d4-2dd4-caf0-140c" name="Barbarian Chariot and Crew Pulled by Two Horses" hidden="false" targetId="fd0a-fee6-1a73-f22e" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="81.0"/>
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -2467,13 +2390,14 @@
       <infoLinks>
         <infoLink id="1d06-85f9-4cde-b90e" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
         <infoLink id="9e14-8b49-b40e-b889" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="5c15-fa69-6599-a639" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4c5f-6965-a017-e993" name="Beast Unit" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="false"/>
         <categoryLink id="7e68-3dcf-359f-4c34" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="82be-4422-6780-c432" name="Pack master" hidden="false" collective="false" defaultSelectionEntryId="5533-4f6c-4378-21e7">
+        <selectionEntryGroup id="82be-4422-6780-c432" name="Pack Master" hidden="false" collective="false" defaultSelectionEntryId="5533-4f6c-4378-21e7">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dba-231b-3a8b-da99" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eeaf-b1f3-c657-0ffe" type="min"/>
@@ -2499,7 +2423,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="80d8-5884-d1b1-720f" name="warhounds" hidden="false" collective="false">
+        <selectionEntryGroup id="80d8-5884-d1b1-720f" name="Choose 4 to 9" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="4fcb-b447-53d2-ceb6" name="Warhound" hidden="false" collective="false" type="model">
               <constraints>
@@ -2508,7 +2432,6 @@
               </constraints>
               <infoLinks>
                 <infoLink id="0d2c-c2ea-4a06-de61" name="Warhounds" hidden="false" targetId="907a-ff0d-2f5b-6fd4" type="profile"/>
-                <infoLink id="2bbb-893e-9b0a-6eea" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="11.0"/>
@@ -2523,18 +2446,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17e4-f85d-0c00-2b47" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3262-4277-0c72-f2ac" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3262-4277-0c72-f2ac" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="42c4-8aaa-3fbb-e665" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="21d8-9b73-16a9-9a8a" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="2f8b-7979-0747-5485" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2563,7 +2477,7 @@
         <categoryLink id="f0d0-a9e4-9b58-4b24" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="9cd7-113a-41b8-2cfa" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="9cd7-113a-41b8-2cfa" name="Choose 4 to 9" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="5de0-3428-64ad-5210" name="Barbarian Brat Leader" hidden="false" collective="false" type="model">
               <constraints>
@@ -2644,12 +2558,12 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="dadc-3fcf-56d3-9287" name="Dead Eye Shot Upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="dadc-3fcf-56d3-9287" name="Deadeye Shot Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14c2-9fad-3f70-68a9" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="39ff-31fd-3a0c-5657" name="Dead Eye Shot" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="39ff-31fd-3a0c-5657" name="Deadeye Shot" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="d198-c533-25c9-2964" name="Deadeye Shot" hidden="false" targetId="d055-98ce-6f28-1600" type="rule"/>
               </infoLinks>
@@ -2721,7 +2635,7 @@
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3479-bc71-4875-5f11" type="min"/>
               </constraints>
               <infoLinks>
-                <infoLink id="13a4-6de7-2f2f-e346" name="Barbarian Crew (mammoth)" hidden="false" targetId="cb76-bdb8-704e-2bc5" type="profile"/>
+                <infoLink id="13a4-6de7-2f2f-e346" name="Barbarian Mammoth Crew" hidden="false" targetId="cb76-bdb8-704e-2bc5" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -2803,6 +2717,12 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="3dee-6086-f5fc-e1f3" name="Barbarian Stone Thrower [81 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="035c-6222-d008-e79b" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+        <infoLink id="dc69-dc17-59db-e957" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="5820-6897-3646-2249" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="f53c-be9d-be2a-1d6f" name="Overhead" hidden="false" targetId="7751-622a-b896-4874" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="a9b7-22e6-43d7-8241" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2833,32 +2753,13 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5938-293c-3fcd-b8d0" name="Stone Thrower" hidden="false" collective="false" defaultSelectionEntryId="9df3-0809-49a2-3ab4">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75a5-f333-26cb-36a6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26fc-fde5-be23-431a" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="9df3-0809-49a2-3ab4" name="Stone Thrower" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="34f8-39b6-63d2-e0b0" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="d1ea-7415-1dfa-84f2" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
-                <infoLink id="fdb0-aaff-2699-ca89" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
         <selectionEntryGroup id="041d-1ac3-60c8-3c75" name="Crew Weapons" hidden="false" collective="false" defaultSelectionEntryId="9649-390c-3dd1-34ef">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed74-904a-ab08-abb9" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f705-bf83-0966-b2a2" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="368e-1640-d28b-0f66" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="368e-1640-d28b-0f66" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
@@ -2868,22 +2769,6 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="5a39-ee81-a892-3439" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="565f-0c3a-3140-bd44" name="Axe" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="1">
-                  <repeats>
-                    <repeat field="selections" scope="3dee-6086-f5fc-e1f3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="7ee5-9c42-134c-6687" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2901,15 +2786,15 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="59ec-fe55-4ece-6e22" name="Models" hidden="false" collective="false" defaultSelectionEntryId="39bb-54e1-27cb-8164">
+        <selectionEntryGroup id="59ec-fe55-4ece-6e22" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="39bb-54e1-27cb-8164">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="104d-df1d-6768-f009" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74b2-6c72-6621-779f" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="39bb-54e1-27cb-8164" name="Crew" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="39bb-54e1-27cb-8164" name="Crew (no armour)" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="08f1-baab-fac1-b498" name="models" hidden="false" collective="false">
+                <selectionEntryGroup id="08f1-baab-fac1-b498" name="Choose 3 to 5" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="a564-b55e-46b2-ee82" name="Crew" hidden="false" collective="false" type="model">
                       <constraints>
@@ -2934,7 +2819,7 @@
             </selectionEntry>
             <selectionEntry id="175c-effd-2f61-25f1" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="35ac-5d94-a7d2-36d8" name="models" hidden="false" collective="false">
+                <selectionEntryGroup id="35ac-5d94-a7d2-36d8" name="Choose 3 to 5" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="addf-5a7b-7b8e-9698" name="Crew in Light Armour" hidden="false" collective="false" type="model">
                       <constraints>
@@ -2967,7 +2852,7 @@
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedProfiles>
-    <profile id="09e6-4341-0bbf-ed92" name="Barbarian Chieftain" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="09e6-4341-0bbf-ed92" name="Barbarian Chieftain in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -2989,7 +2874,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="e404-635b-5f36-dc01" name="Mounted Barbarian Chieftain" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="e404-635b-5f36-dc01" name="Mounted Barbarian Chieftain in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3000,7 +2885,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, Fast 8, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
-    <profile id="b35a-92fd-29cb-a9d9" name="Mounted Barbarian Bodyguard" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="b35a-92fd-29cb-a9d9" name="Mounted Barbarian Bodyguard in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3385,7 +3270,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="2663-6fd2-7757-a40a" name="Rock (thrown)" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="2663-6fd2-7757-a40a" name="Rock (thrown)" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -3447,6 +3332,50 @@
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough 2, Fast 8, Irresistable Charge</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="da2e-5091-7006-ab4d" name="Barbarian Chieftain in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+      <characteristics>
+        <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
+        <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
+        <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61">5</characteristic>
+        <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
+        <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
+        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 3xHtH, Wound X</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="2086-8df9-ac56-088b" name="Barbarian Bodyguard in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+      <characteristics>
+        <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
+        <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
+        <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61">5</characteristic>
+        <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
+        <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
+        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0f15-4744-eeef-0883" name="Mounted Barbarian Bodyguard in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+      <characteristics>
+        <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
+        <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
+        <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61">5</characteristic>
+        <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
+        <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
+        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 8</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ccce-69e6-06c8-7173" name="Mounted Barbarian Chieftain in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+      <characteristics>
+        <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
+        <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
+        <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61">5</characteristic>
+        <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
+        <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
+        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, Fast 8, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Barbarians.cat
+++ b/Barbarians.cat
@@ -37,7 +37,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="72.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="448e-61aa-1e28-6534" name="Barbarian Bodyguard" hidden="false" collective="false" type="model">
@@ -50,7 +50,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -67,7 +67,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="03ad-0449-908c-e4b2" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -76,7 +76,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99c9-a2c3-4b56-ae46" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -85,7 +85,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27bc-085f-badb-3f7c" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -94,7 +94,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -111,7 +111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4658-2d35-b252-8ebd" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -120,7 +120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -137,7 +137,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9c55-4d4a-594a-d2ed" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -146,7 +146,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -169,7 +169,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fdfe-2150-523d-1b99" name="Berserk" hidden="false" collective="false" type="upgrade">
@@ -185,7 +185,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -199,7 +199,7 @@
             <selectionEntry id="4c9e-5051-6bfa-8742" name="Light Armour  RES 5(6)" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0144-1450-ec97-ad00" name="Medium Armour RES 5(7)" hidden="false" collective="false" type="upgrade">
@@ -212,7 +212,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -228,7 +228,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f754-8aa7-5ea5-2641" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -237,7 +237,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e55-900e-ddf6-8a79" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -246,7 +246,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53ca-b9ea-3ba9-800d" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -255,7 +255,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e2cc-4966-954c-5448" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -264,7 +264,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="08cc-3338-e7b8-2c18" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -273,7 +273,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da5a-3213-7f61-d47a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -282,7 +282,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -290,7 +290,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1e97-78f9-80b5-65b0" name="Mounted Barbarian Chieftain [122 pts]" hidden="false" collective="false" type="unit">
@@ -311,7 +311,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2192-e0af-7b14-a694" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -320,7 +320,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fbe7-bc68-76a9-bedf" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -329,7 +329,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c252-baf8-83ac-2b82" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -338,7 +338,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8223-025c-7df6-e2ce" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -347,7 +347,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -364,7 +364,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73ad-6c90-c850-31cb" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -373,7 +373,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -390,7 +390,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f22f-4ef4-5c4b-7676" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -399,7 +399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -422,7 +422,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fab6-c2b3-0337-f201" name="Berserk" hidden="false" collective="false" type="upgrade">
@@ -438,7 +438,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -452,7 +452,7 @@
             <selectionEntry id="eeee-a520-48d3-8083" name="Light Armour  RES 6(7)" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e05-b856-da6c-cc21" name="Medium Armour RES 6(8)" hidden="false" collective="false" type="upgrade">
@@ -465,7 +465,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -484,7 +484,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="82.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6b71-900e-77b7-4c85" name="Mounted Barbarian Bodyguard" hidden="false" collective="false" type="model">
@@ -497,7 +497,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -511,7 +511,7 @@
             <selectionEntry id="da75-4238-0b55-f7a1" name="Horses" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e25d-99eb-2532-2fa6" name="Warhorses" hidden="false" collective="false" type="upgrade">
@@ -523,11 +523,11 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="e509-5669-f27a-fb6b" name="Warhorses" hidden="false" targetId="2198-843f-898a-d563" type="profile"/>
+                <infoLink id="e509-5669-f27a-fb6b" name="Warhorses" hidden="false" targetId="7ec0-8eda-2a2b-bd7b" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -543,7 +543,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ab6-051c-4b04-1fd3" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -552,7 +552,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5da5-5651-3916-ca7c" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -561,7 +561,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a176-0509-e7a0-b39f" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -570,7 +570,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8a92-7c94-b9b2-24a1" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -579,7 +579,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5cfd-e18b-6590-54e1" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -588,7 +588,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b3cb-4411-a174-f3e6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -597,7 +597,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -605,7 +605,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8b28-5f08-d158-e945" name="Barbarian Chieftain in Chariot [152 pts]" hidden="false" collective="false" type="unit">
@@ -613,8 +613,8 @@
         <infoLink id="6a35-d007-9b86-f033" name="Chariot with Chieftain and crew, pulled by horses" hidden="false" targetId="e721-b469-749b-663d" type="profile"/>
         <infoLink id="78ce-b858-5837-04ab" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="824d-79d1-7fdd-b06e" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-        <infoLink id="5f2b-08ef-7e20-bc70" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
         <infoLink id="b530-1892-1be5-447d" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+        <infoLink id="5820-2515-70e2-0f27" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="d661-41de-745f-c906" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
@@ -635,7 +635,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="147.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa69-8aa1-01c0-8832" name="Barbarian Chieftain, Medium Armour" hidden="false" collective="false" type="model">
@@ -646,7 +646,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="147.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -663,16 +663,16 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3078-4805-bc20-2ca9" name="Warhorses" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="cddb-d127-b30e-f8a1" name="Warhorses" hidden="false" targetId="2198-843f-898a-d563" type="profile"/>
+                <infoLink id="cddb-d127-b30e-f8a1" name="Warhorses" hidden="false" targetId="7ec0-8eda-2a2b-bd7b" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -688,7 +688,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -705,7 +705,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51df-f0f9-fbe6-14b2" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -714,7 +714,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -731,7 +731,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="322e-1a48-e326-c241" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -740,7 +740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -763,7 +763,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -780,7 +780,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="efb5-b1aa-fb9c-282b" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -789,7 +789,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fd2d-306d-910b-c82e" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -798,7 +798,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -811,11 +811,11 @@
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05b1-f179-6be7-22be" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="e827-c2aa-33b6-a3c5" name="Barbarian Crew (for chariot)" hidden="false" targetId="a232-f517-cf84-e38e" type="profile"/>
+                <infoLink id="e827-c2aa-33b6-a3c5" name="Barbarian Chariot Crew" hidden="false" targetId="bc5b-5be5-e52e-76a3" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -831,7 +831,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dc39-d931-f98d-ff4b" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -840,7 +840,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a121-a529-37a3-be6a" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -849,7 +849,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30ed-3ec9-0f0a-af32" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -858,7 +858,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="032f-893c-a2e4-af50" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -867,7 +867,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="42c7-ce0c-f04f-fd15" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -876,7 +876,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5b36-4340-dedf-212c" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -885,7 +885,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -893,7 +893,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f4f0-85af-cb96-c03e" name="Barbarian Shaman [57 pts]" hidden="false" collective="false" type="unit">
@@ -914,7 +914,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1d88-fb7d-f333-3340" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -923,7 +923,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e099-d1ef-e4ab-d838" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -932,7 +932,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -949,7 +949,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="870d-d7ee-ee71-4088" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -958,7 +958,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -981,7 +981,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1005,7 +1005,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="636f-ffc3-e138-be00" name="Barbarian Bodyguards in Light Armour" hidden="false" collective="false" type="model">
@@ -1017,7 +1017,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1025,7 +1025,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ca4-a642-4d45-001b" name="Elemental Spirits" hidden="false" collective="false" type="upgrade">
@@ -1041,7 +1041,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1049,7 +1049,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1067,7 +1067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="57.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1084,7 +1084,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="65ea-20aa-3624-2bf2" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1093,7 +1093,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dc70-bc37-58ad-e234" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1102,7 +1102,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ea8-4499-acc1-80bb" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1111,7 +1111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3dfc-cecf-efcc-8c6b" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1120,7 +1120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9202-3bbe-c958-0a2c" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1129,7 +1129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fe7a-8d15-cc91-71b9" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1138,7 +1138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2452-d7a3-9d6f-33b8" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1147,7 +1147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="779e-6b1a-f1c6-933f" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1156,7 +1156,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0a9-fe89-2cc5-bc13" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1165,7 +1165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62ae-9021-e19a-1040" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1174,7 +1174,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ec6-2e06-a04e-a0ea" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1183,7 +1183,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e1f-0d38-0e08-a762" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1192,7 +1192,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3a95-2ae1-704f-9cea" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1201,7 +1201,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1217,7 +1217,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8699-5f6c-ecc5-5db2" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1229,7 +1229,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f20a-5ca4-2a65-e34a" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1241,7 +1241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d1ce-df6a-846b-a537" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1253,7 +1253,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5814-d44b-856c-e1b6" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1265,7 +1265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ab30-e561-d43a-799a" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1277,7 +1277,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b4b1-9320-ee31-5cfa" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1289,7 +1289,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aebe-67f6-13ad-e045" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1301,7 +1301,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bfea-0896-d95a-3613" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1313,7 +1313,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4a8e-b3d9-86fb-0189" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1325,7 +1325,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd0a-a534-5475-9130" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1337,7 +1337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa2a-5dca-d862-761c" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1349,7 +1349,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f671-f6c1-4cc8-16ac" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1361,7 +1361,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ee8-a565-2e9e-a9e7" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1373,7 +1373,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1390,7 +1390,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bf2a-7552-136f-28e8" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1399,7 +1399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1415,7 +1415,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="c6f2-ddc7-77bc-fd0a" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1424,7 +1424,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="20.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1200-3c7c-f444-1943" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1433,7 +1433,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="526d-156c-578c-9772" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1442,7 +1442,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="5.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="64bd-b461-8c78-8226" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1451,7 +1451,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="20.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="f337-9461-f4a1-ef39" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1460,7 +1460,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="10.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="dd0a-0820-e6b3-69c3" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1469,7 +1469,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="15.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -1479,7 +1479,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4d21-f575-3538-c572" name="Barbarian Hero [81 pts]" hidden="false" collective="false" type="unit">
@@ -1487,7 +1487,8 @@
         <infoLink id="3e23-e8ad-a38e-7681" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="5c7f-199e-cb05-19de" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
+        <categoryLink id="5c7f-199e-cb05-19de" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
+        <categoryLink id="067a-6f18-c8d7-73d6" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="bbc1-017e-7aa2-d998" name="Barbarian Hero" hidden="false" collective="false" defaultSelectionEntryId="56a9-6fde-8f5b-b360">
@@ -1502,7 +1503,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7ff5-1641-bac9-f3cc" name="Barbarian Hero in Medium Armour" hidden="false" collective="false" type="model">
@@ -1511,7 +1512,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="91.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1528,7 +1529,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac10-8e66-0b07-3d5d" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1537,7 +1538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="09b8-7215-3525-09cb" name="Wounds 3" hidden="false" collective="false" type="upgrade">
@@ -1546,7 +1547,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1563,7 +1564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d4fe-b3df-629a-edd3" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1572,7 +1573,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1588,7 +1589,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d2c6-b125-c60d-92fe" name="Berserk" hidden="false" collective="false" type="upgrade">
@@ -1597,7 +1598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1614,7 +1615,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4b4e-55d9-ecfd-a4c6" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1623,7 +1624,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e0c6-f503-34b2-e3a9" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1632,7 +1633,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="470a-1f59-6b0d-abf9" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -1641,7 +1642,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="33d4-409d-966e-fdb1" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1650,7 +1651,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="26e9-a974-9203-5236" name="Magic Weapon" hidden="false" collective="false" type="upgrade">
@@ -1666,7 +1667,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b4e9-cc99-8c07-10ac" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1675,7 +1676,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4d4c-ef22-fa86-888e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1684,7 +1685,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="26a5-8c78-cbc8-a1bb" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1693,7 +1694,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="cf65-d34a-e630-00fd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1702,7 +1703,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="51e6-8117-f30a-3319" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1711,7 +1712,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0e02-ec58-300f-1d6a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1720,7 +1721,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1728,7 +1729,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1736,19 +1737,20 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="49e7-fbb8-9ff8-91d7" name="Barbarian Hero in Chariot [158 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="628e-5bad-56c5-9913" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
-        <infoLink id="b500-ad8c-db5e-5741" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
         <infoLink id="3943-7c3d-d3c2-9824" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5af0-f664-6213-afca" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+        <infoLink id="e64c-e072-a377-f9e8" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+        <infoLink id="a352-a939-0702-de54" name="Tough 2" hidden="false" targetId="487f-dc82-bce1-c0f6" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a509-f11a-fa85-c2a7" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
-        <categoryLink id="692d-7367-656e-7a1b" name="Hero Unit" hidden="false" targetId="hero unit" primary="false"/>
+        <categoryLink id="a509-f11a-fa85-c2a7" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
+        <categoryLink id="692d-7367-656e-7a1b" name="Hero Unit" hidden="false" targetId="hero unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="c427-8f05-fa8e-20f7" name="Chariot Scythes" hidden="false" collective="false">
@@ -1762,12 +1764,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ccb6-5b62-ac33-63a3" name="warhorse upgrade" hidden="false" collective="false" defaultSelectionEntryId="044f-0167-5a04-208c">
+        <selectionEntryGroup id="ccb6-5b62-ac33-63a3" name="Warhorse upgrade" hidden="false" collective="false" defaultSelectionEntryId="044f-0167-5a04-208c">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9e6-1db9-155d-0f88" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b13f-459a-8ded-dc74" type="max"/>
@@ -1779,16 +1781,16 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0076-c227-f443-6ab1" name="Warhorses" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="d4d5-c002-714b-e689" name="Warhorses" hidden="false" targetId="2198-843f-898a-d563" type="profile"/>
+                <infoLink id="d4d5-c002-714b-e689" name="Warhorses" hidden="false" targetId="7ec0-8eda-2a2b-bd7b" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1811,7 +1813,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1824,11 +1826,11 @@
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83ab-c064-7fd7-da12" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="2ecd-c3eb-282d-b6a3" name="Barbarian Crew (for chariot)" hidden="false" targetId="a232-f517-cf84-e38e" type="profile"/>
+                <infoLink id="2ecd-c3eb-282d-b6a3" name="Barbarian Chariot Crew with Sword or Axe" hidden="false" targetId="bc5b-5be5-e52e-76a3" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1845,7 +1847,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="153.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d180-1388-e274-0a57" name="Hero with Medium Armour" hidden="false" collective="false" type="model">
@@ -1854,7 +1856,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="163.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1871,7 +1873,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ae1-a596-acf1-5588" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1880,7 +1882,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c9d-d8f6-c75a-2ad3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1889,7 +1891,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1905,7 +1907,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e8b8-7b86-ce62-d8a6" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1914,7 +1916,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9915-d889-b926-ba5c" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1923,7 +1925,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3233-e5c5-d1a7-34c0" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1932,7 +1934,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04e9-0cb4-6333-aec0" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1941,7 +1943,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a459-9289-2252-7a33" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1950,7 +1952,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8040-c0df-87d9-29d5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1959,7 +1961,24 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1820-3a22-8b7d-3041" name="Chariot" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="7990-ecd4-b86f-89d7" name="Chariot" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e08-5201-75d8-521e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="021c-9cf6-e67a-64ed" type="min"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6aad-0da2-1eb1-6104" name="Barbarian Chariot with Hero and Crew Pulled by Two Horses" hidden="false" targetId="1c75-f594-7a99-da4e" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1967,7 +1986,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2ca7-6f0b-7006-5d2c" name="Barbarian Warriors [72 pts]" hidden="false" collective="false" type="unit">
@@ -1990,7 +2009,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2e18-9a8c-a538-6a38" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1999,7 +2018,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5324-95ce-d159-b21e" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2008,7 +2027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9523-d203-22be-1d6b" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -2017,7 +2036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7768-8b64-f829-a837" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -2026,7 +2045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2049,7 +2068,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2074,7 +2093,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="36cf-6696-6b1e-760e" name="Warrior" hidden="false" collective="false" type="model">
@@ -2087,7 +2106,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2095,7 +2114,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf71-76a9-b881-ec20" name="Warriors in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2112,7 +2131,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f8c9-ea20-c0dd-c839" name="Warriors" hidden="false" collective="false" type="model">
@@ -2125,7 +2144,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2133,7 +2152,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2141,7 +2160,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="35b0-f975-d3b5-955f" name="Barbarian Archers [72 pts]" hidden="false" collective="false" type="unit">
@@ -2164,7 +2183,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b78-c9ce-3169-fc1c" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2173,7 +2192,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2196,7 +2215,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2221,7 +2240,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d800-da74-6f53-3f8d" name="Archer" hidden="false" collective="false" type="model">
@@ -2234,7 +2253,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2242,7 +2261,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="946c-598e-41a4-4a02" name="Archers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2259,7 +2278,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c5e3-942f-0852-3c62" name="Archers in Light Armour" hidden="false" collective="false" type="model">
@@ -2272,7 +2291,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2280,7 +2299,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2297,7 +2316,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2305,7 +2324,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="eec3-cdab-e67f-de60" name="Barbarian Horsemen [72 pts]" hidden="false" collective="false" type="unit">
@@ -2326,7 +2345,7 @@
             <selectionEntry id="845a-60e8-e4f7-f3fa" name="Horses" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91b8-7038-0e4c-9c7e" name="Warhorses" hidden="false" collective="false" type="upgrade">
@@ -2338,11 +2357,11 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="91b2-c770-1978-b65a" name="Warhorses" hidden="false" targetId="2198-843f-898a-d563" type="profile"/>
+                <infoLink id="91b2-c770-1978-b65a" name="Warhorses" hidden="false" targetId="7ec0-8eda-2a2b-bd7b" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2365,7 +2384,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2382,7 +2401,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e82d-4513-61d6-0f0f" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2391,7 +2410,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9d96-dba6-c6d7-51e5" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2400,7 +2419,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2423,7 +2442,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2448,7 +2467,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a2f3-61ab-e31b-168e" name="Horsemen" hidden="false" collective="false" type="model">
@@ -2461,7 +2480,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2469,7 +2488,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6157-a47c-ed44-ca25" name="Horsemen in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2486,7 +2505,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="604e-4e04-7052-b03d" name="Horsemen" hidden="false" collective="false" type="model">
@@ -2499,7 +2518,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2507,7 +2526,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2515,7 +2534,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2bad-a623-9159-2ff5" name="Barbarian Berserkers [97 pts]" hidden="false" collective="false" type="unit">
@@ -2545,7 +2564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2562,7 +2581,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4e39-4b92-5418-2f60" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2571,7 +2590,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b264-460b-b34b-761e" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -2580,7 +2599,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df45-b442-99cd-f533" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -2589,7 +2608,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2606,7 +2625,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="29.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6035-ee29-08a5-6380" name="Beserkers" hidden="false" collective="false" type="model">
@@ -2619,7 +2638,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2627,14 +2646,14 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0fed-6557-73b9-a431" name="Barbarian Chariot [91 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="494d-abbc-c32b-d4f5" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="8ba0-104f-7dca-e7fd" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-        <infoLink id="b66a-5182-3a50-832a" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+        <infoLink id="2fa9-25c6-7050-25fd" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+        <infoLink id="eea9-1c36-e80c-cdd5" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+        <infoLink id="95b6-4e41-8b7e-ddab" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="3b1d-483c-ff30-e065" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
@@ -2658,7 +2677,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2675,7 +2694,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9c53-f7e6-d332-a280" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2684,7 +2703,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b8d2-6b78-9686-1e98" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2693,7 +2712,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2716,7 +2735,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2733,16 +2752,16 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10b1-1939-b30e-9a72" name="Warhorses" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="2161-6e85-4dda-f26f" name="Warhorses" hidden="false" targetId="2198-843f-898a-d563" type="profile"/>
+                <infoLink id="2161-6e85-4dda-f26f" name="Warhorses" hidden="false" targetId="7ec0-8eda-2a2b-bd7b" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2758,7 +2777,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2771,11 +2790,11 @@
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6bf-5dda-5017-c4a6" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="993f-134b-9554-4248" name="Barbarian Crew (for chariot)" hidden="false" targetId="a232-f517-cf84-e38e" type="profile"/>
+                <infoLink id="993f-134b-9554-4248" name="Barbarian Chariot Crew" hidden="false" targetId="bc5b-5be5-e52e-76a3" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2788,11 +2807,11 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5b8-9e6f-fd6e-7fa8" type="min"/>
               </constraints>
               <infoLinks>
-                <infoLink id="dd03-1734-d20b-0a42" name="Barbarian Chariot, Crew, pulled by two horses" hidden="false" targetId="fd0a-fee6-1a73-f22e" type="profile"/>
+                <infoLink id="f9d4-2dd4-caf0-140c" name="Barbarian Chariot and Crew Pulled by Two Horses" hidden="false" targetId="fd0a-fee6-1a73-f22e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2800,7 +2819,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9642-c436-bb1f-d4e4" name="Warhounds [70 pts]" hidden="false" collective="false" type="unit">
@@ -2825,7 +2844,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="26.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fd70-9a86-e74e-a3be" name="Pack Master in Medium Armour" hidden="false" collective="false" type="model">
@@ -2834,7 +2853,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2852,7 +2871,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="11.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2869,7 +2888,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="21d8-9b73-16a9-9a8a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2878,7 +2897,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e0bd-f900-c300-5ec3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2887,7 +2906,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2895,7 +2914,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1776-7920-1dd9-1241" name="Barbarian Brats [37 pts]" hidden="false" collective="false" type="unit">
@@ -2916,7 +2935,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd60-35ff-56b4-2c04" name="Barbarian Brats" hidden="false" collective="false" type="model">
@@ -2929,7 +2948,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2942,25 +2961,28 @@
           <selectionEntries>
             <selectionEntry id="3bab-534c-66dc-ea19" name="Rock" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="db98-9d68-6b9f-595a" name="Rocks (HTH)" hidden="false" targetId="88d0-6821-ceff-0382" type="profile"/>
+                <infoLink id="db98-9d68-6b9f-595a" name="Rocks (HtH)" hidden="false" targetId="88d0-6821-ceff-0382" type="profile"/>
                 <infoLink id="c99f-bcaa-fcd4-db42" name="Rock (thrown)" hidden="false" targetId="2663-6fd2-7757-a40a" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db39-dbc4-fa3c-2ee3" name="Slings" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="3">
+                <modifier type="increment" field="points" value="3.0">
                   <repeats>
                     <repeat field="selections" scope="1776-7920-1dd9-1241" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
               </modifiers>
+              <infoLinks>
+                <infoLink id="de54-3fb9-f3ca-a5db" name="Sling" hidden="false" targetId="aae2-6321-3b33-079d" type="profile"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c39-14e6-7de4-d12e" name="Javelins" hidden="false" collective="false" type="upgrade">
@@ -2976,7 +2998,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2992,7 +3014,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3015,7 +3037,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3023,7 +3045,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9fa1-66cc-750b-015d" name="Mammoth [156 pts]" hidden="false" collective="false" type="unit">
@@ -3041,10 +3063,11 @@
             <infoLink id="f0b6-cc0c-a493-f088" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
             <infoLink id="e64b-e17d-52c9-5733" name="Surly" hidden="false" targetId="8a4d-4dea-f005-ddc5" type="rule"/>
             <infoLink id="1b1b-5bfb-b7a1-9530" name="Stampede" hidden="false" targetId="45b3-c028-8c8c-43ae" type="rule"/>
+            <infoLink id="a562-72d6-4260-e6bd" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="136.0"/>
-            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -3061,7 +3084,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3081,12 +3104,12 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="bf6e-51b0-f9c5-19d7" name="Rocks (HTH)" hidden="false" targetId="88d0-6821-ceff-0382" type="profile"/>
+                <infoLink id="bf6e-51b0-f9c5-19d7" name="Rocks (HtH)" hidden="false" targetId="88d0-6821-ceff-0382" type="profile"/>
                 <infoLink id="fc07-43aa-2bfd-6ab9" name="Rock (thrown)" hidden="false" targetId="2663-6fd2-7757-a40a" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b47c-1043-c3c1-ebc2" name="Javelins" hidden="false" collective="false" type="upgrade">
@@ -3102,7 +3125,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="165b-1dda-286d-c372" name="Bows" hidden="false" collective="false" type="upgrade">
@@ -3118,7 +3141,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7ebe-0305-976b-38b2" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -3127,7 +3150,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3135,7 +3158,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3dee-6086-f5fc-e1f3" name="Barbarian Stone Thrower [81 pts]" hidden="false" collective="false" type="unit">
@@ -3155,7 +3178,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7071-a039-62bd-8a03" name="Large stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -3164,7 +3187,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3177,12 +3200,12 @@
           <selectionEntries>
             <selectionEntry id="9df3-0809-49a2-3ab4" name="Stone Thrower" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="795c-517f-dc51-4645" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
                 <infoLink id="34f8-39b6-63d2-e0b0" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+                <infoLink id="d1ea-7415-1dfa-84f2" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3206,7 +3229,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="565f-0c3a-3140-bd44" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -3222,7 +3245,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9649-390c-3dd1-34ef" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -3231,7 +3254,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3256,7 +3279,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3264,7 +3287,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="175c-effd-2f61-25f1" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -3281,7 +3304,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3289,7 +3312,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3297,7 +3320,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -3310,10 +3333,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Command, 3xHTH, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
-    <profile id="8ecb-b9ee-880d-0f2f" name="Barbarian Bodyguard (light armour)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="8ecb-b9ee-880d-0f2f" name="Barbarian Bodyguard in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3332,7 +3355,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Command, Follow, Fast 8, 3xHTH, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, Fast 8, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="b35a-92fd-29cb-a9d9" name="Mounted Barbarian Bodyguard" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3346,18 +3369,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 8</characteristic>
       </characteristics>
     </profile>
-    <profile id="2198-843f-898a-d563" name="Warhorses" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
-      <characteristics>
-        <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">-</characteristic>
-        <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
-        <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61">5</characteristic>
-        <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
-        <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
-        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHTH SV1</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="e721-b469-749b-663d" name="Chariot with Chieftain and crew, pulled by horses" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="e721-b469-749b-663d" name="Chariot with Chieftain and Crew Pulled by Horses" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">3</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -3365,10 +3377,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">10</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough, Fast 8, Irresistible Charge</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough 1, Fast 8, Irresistable Charge</characteristic>
       </characteristics>
     </profile>
-    <profile id="d9ad-0e48-0e5a-8b79" name="Barbarian Chieftain, Light armour, (chariot - on foot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="d9ad-0e48-0e5a-8b79" name="Barbarian Chieftain in Light Armour in Chariot" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">[5]</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3376,18 +3388,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[5(6)]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough], Command, Follow, 3xHTH, [Wound]</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="a232-f517-cf84-e38e" name="Barbarian Crew (for chariot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
-      <characteristics>
-        <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">-</characteristic>
-        <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
-        <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61">5</characteristic>
-        <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
-        <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
-        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, Follow, 3xHtH, [Wound X], [on foot]</characteristic>
       </characteristics>
     </profile>
     <profile id="e89b-4b35-89d1-8142" name="Horses" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3409,10 +3410,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHtH SV1</characteristic>
       </characteristics>
     </profile>
-    <profile id="cc65-1b12-5415-6b7d" name="Barbarian Chieftain, Medium Armour, (chariot - on foot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="cc65-1b12-5415-6b7d" name="Barbarian Chieftain in Medium Armour in Chariot" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">[5]</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3420,7 +3421,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[6(7)]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough], Command, Follow, 3xHTH, [Wound]</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, Follow, 3xHtH, [Wound X], [on foot]</characteristic>
       </characteristics>
     </profile>
     <profile id="6f7a-1e71-1b91-a7b3" name="Barbarian Shaman" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3431,10 +3432,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Wound, Magic Level 1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Wound X, Magic Level 1</characteristic>
       </characteristics>
     </profile>
-    <profile id="1cda-18b8-4a29-832f" name="Barbarian Bodyguard (no armour)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="1cda-18b8-4a29-832f" name="Barbarian Bodyguard" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3453,7 +3454,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">5</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Spirit, 1xHTH SV1, Exchange of Missiles SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Spirit, 1xHtH SV1, Exchange of Missiles SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="8f52-f37a-458b-09bf" name="Barbarian Hero in light armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3464,7 +3465,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">9</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 2, Hero, 3xHTH, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="170d-2cdc-9882-a8e2" name="Barbarian Hero in medium armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3475,10 +3476,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">9</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 2, Hero, 3xHTH, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
-    <profile id="7b27-80ef-e77d-6dda" name="Chariot with Hero, Crew, pulled by horses" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="7b27-80ef-e77d-6dda" name="Chariot with Hero and Crew Pulled by Horses" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">3</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -3486,10 +3487,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">10</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough, Fast 8, Irresistible Charge</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough 2, Fast 8, Irresistable Charge</characteristic>
       </characteristics>
     </profile>
-    <profile id="35d6-2cfb-7c39-3597" name="Barbarian Hero in light armour (Chariot - on foot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="35d6-2cfb-7c39-3597" name="Barbarian Hero in Light Armour in Chariot" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">[5]</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3497,10 +3498,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[6(7)]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">9</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough 2], Hero, 3xHTH, [Wound]</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Hero, 3xHtH, [Wound X], [on foot]</characteristic>
       </characteristics>
     </profile>
-    <profile id="05fe-959b-50af-fec2" name="Barbarian Hero in Medium armour (Chariot - on foot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="05fe-959b-50af-fec2" name="Barbarian Hero in Medium Armour in Chariot" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">[5]</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3508,10 +3509,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[6(8)]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">9</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough 2], Hero, 3xHTH, [Wound]</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Hero, 3xHtH, [Wound X], [on foot]</characteristic>
       </characteristics>
     </profile>
-    <profile id="dcc5-397b-8c60-d9d3" name="Barbarian Warrior Leader in light armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="dcc5-397b-8c60-d9d3" name="Barbarian Warrior Leader in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3519,7 +3520,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="3e80-d24c-545f-44e2" name="Barbarian Warrior in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3533,7 +3534,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="d453-86fd-1e88-3aed" name="Barbarian Warrior in medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="d453-86fd-1e88-3aed" name="Barbarian Warrior in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3544,7 +3545,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="6d36-7268-8673-d362" name="Barbarian Warrior Leader in medium armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="6d36-7268-8673-d362" name="Barbarian Warrior Leader in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3552,10 +3553,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
-    <profile id="827d-0eed-ee14-6839" name="Barbarian Archer Leader (no armor)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="827d-0eed-ee14-6839" name="Barbarian Archer Leader" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3563,10 +3564,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
-    <profile id="ca8e-fbf8-bba0-a440" name="Barbarian Archer Leader, Light armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="ca8e-fbf8-bba0-a440" name="Barbarian Archer Leader in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3574,10 +3575,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
-    <profile id="8874-7f55-cf83-ab10" name="Barbarian Archer (no armour)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="8874-7f55-cf83-ab10" name="Barbarian Archer" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3588,7 +3589,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="2efa-1d81-d4e8-5b71" name="Barbarian Archer, Light armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="2efa-1d81-d4e8-5b71" name="Barbarian Archer in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3607,7 +3608,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 8</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 8</characteristic>
       </characteristics>
     </profile>
     <profile id="b63c-7777-0fb1-2a30" name="Barbarian Horsemen Leader in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3618,7 +3619,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 8</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 8</characteristic>
       </characteristics>
     </profile>
     <profile id="4e28-2cb0-55bc-733a" name="Barbarian Horsemen in Light armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3643,7 +3644,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 8</characteristic>
       </characteristics>
     </profile>
-    <profile id="b583-9199-2b89-b603" name="Barbarian Berserker Leader, in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="b583-9199-2b89-b603" name="Barbarian Berserker Leader in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3651,7 +3652,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Berserk</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Berserk</characteristic>
       </characteristics>
     </profile>
     <profile id="8522-4b42-977d-1edf" name="Barbarian Berserker in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3665,7 +3666,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Berserk</characteristic>
       </characteristics>
     </profile>
-    <profile id="fd0a-fee6-1a73-f22e" name="Barbarian Chariot, Crew, pulled by two horses" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="fd0a-fee6-1a73-f22e" name="Barbarian Chariot and Crew Pulled by Two Horses" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">3</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -3676,7 +3677,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Fast 8, Irresistable Charge</characteristic>
       </characteristics>
     </profile>
-    <profile id="bc5b-5be5-e52e-76a3" name="Barbarian Chariot Crew" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="bc5b-5be5-e52e-76a3" name="Barbarian Chariot Crew with Sword or Axe" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">-</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3687,7 +3688,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="4152-8a94-a319-90db" name="Pack Master with Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="4152-8a94-a319-90db" name="Pack Master in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3695,10 +3696,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Rapid Sprint</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Rapid Sprint</characteristic>
       </characteristics>
     </profile>
-    <profile id="fa05-c7bb-0c13-77e6" name="Pack Master with Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="fa05-c7bb-0c13-77e6" name="Pack Master in  Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3706,7 +3707,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Rapid Sprint</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Rapid Sprint</characteristic>
       </characteristics>
     </profile>
     <profile id="907a-ff0d-2f5b-6fd4" name="Warhounds" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3717,7 +3718,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">5</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Savage, Rapid Sprint, 1xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Savage, Rapid Sprint, 1xHtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="4582-5872-d4ec-5218" name="Barbarian Brat Leader" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3728,7 +3729,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">4</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="7676-3c40-0d7a-3610" name="Barbarian Brat" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3748,7 +3749,7 @@
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
         <characteristic name="Range Extreme" typeId="49d3-642a-08be-5817">-</characteristic>
         <characteristic name="Strike Value" typeId="47c7-dced-6203-6b76">0</characteristic>
-        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Can also be used in HTH</characteristic>
+        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Can also be used in HtH</characteristic>
       </characteristics>
     </profile>
     <profile id="efda-5e2b-7665-7f6a" name="Mammoth with Riders" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3759,10 +3760,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">12</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD 2, 5xHTH SV5, Surly, Stampede</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MoD 2, 5xHtH SV5, Surly, Stampede</characteristic>
       </characteristics>
     </profile>
-    <profile id="cb76-bdb8-704e-2bc5" name="Barbarian Crew (mammoth)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="cb76-bdb8-704e-2bc5" name="Barbarian Mammoth Crew" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">-</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3784,7 +3785,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Slow 3</characteristic>
       </characteristics>
     </profile>
-    <profile id="7288-7594-a76c-9b38" name="Barbarian Crew in Light Armour with Stone throwing engine" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="7288-7594-a76c-9b38" name="Barbarian Crew in Light Armour with Stone Throwing Engine" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3793,6 +3794,17 @@
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Slow 3</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="1c75-f594-7a99-da4e" name="Barbarian Chariot with Hero and Crew Pulled by Two Horses" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+      <characteristics>
+        <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">3</characteristic>
+        <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
+        <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61">-</characteristic>
+        <characteristic name="Res" typeId="d916-9ec8-dd33-7873">10</characteristic>
+        <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
+        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough 2, Fast 8, Irresistable Charge</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Beastmen.cat
+++ b/Beastmen.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="495c-99bf-3793-41ba" name="Beastmen" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="495c-99bf-3793-41ba" name="Beastmen" revision="3" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d341-7808-1528-80dd" name="Centaur Lord" hidden="false" collective="false" targetId="eebd-c5bd-500d-1128" type="selectionEntry"/>
     <entryLink id="5920-ac53-718c-9dba" name="Minotaur Lord" hidden="false" collective="false" targetId="ec37-7732-2e11-9c4a" type="selectionEntry"/>
@@ -19,9 +19,6 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="eebd-c5bd-500d-1128" name="Centaur Lord" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="560e-175e-30ee-8a1d" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -40,7 +37,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -57,7 +54,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8191-ed28-15fe-4939" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -66,7 +63,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6639-f58f-fd9e-7f95" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -75,7 +72,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3ad5-73f4-2cb9-4d5e" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -84,7 +81,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -100,7 +97,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="257e-5776-82de-edaf" name="Ranged Magic Weapons" hidden="false" collective="false" type="upgrade">
@@ -116,7 +113,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="cd2f-2ee1-9c8d-ae90" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -125,7 +122,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8b86-33bb-680c-9377" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -134,7 +131,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -142,7 +139,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -158,7 +155,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -171,7 +168,7 @@
             <selectionEntry id="9c7f-08a9-b243-14e7" name="Savage" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -187,7 +184,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="245c-597b-ebbd-8c79" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -196,7 +193,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d31-1b9e-ac37-0383" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -205,7 +202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5c86-96d7-7226-1844" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -214,7 +211,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c810-20ff-6395-e97a" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -223,7 +220,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8e23-0119-f5d3-cc26" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -232,7 +229,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5170-b6f8-9436-2430" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -241,7 +238,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -249,13 +246,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="52.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ec37-7732-2e11-9c4a" name="Minotaur Lord" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc22-bd2b-b3b7-2331" type="max"/>
       </constraints>
@@ -286,7 +280,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="66.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -294,7 +288,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a85b-bdd1-8049-ff8f" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -314,7 +308,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="76.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -322,7 +316,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -339,7 +333,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5f1-c16f-0aa0-a683" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -348,7 +342,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0900-d64c-d274-edfe" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -357,7 +351,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30f8-d758-a278-36b2" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -366,7 +360,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78a8-4b52-3b32-77fc" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -375,7 +369,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="069e-7f63-a7be-ca08" name="Bloomin Big Axe" hidden="false" collective="false" type="upgrade">
@@ -384,7 +378,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1987-f299-6bb6-28ad" name="Magic Weapon" hidden="false" collective="false" type="upgrade">
@@ -400,7 +394,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b73d-2764-cbef-b258" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -409,7 +403,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c538-7361-eb84-68f9" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -418,7 +412,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3df2-58f8-0243-3aed" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -427,7 +421,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="72d1-d8bf-ac8e-2044" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -436,7 +430,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fc8b-eb76-8231-90b2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -445,7 +439,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="588c-7afc-75d7-459b" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -454,7 +448,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -462,7 +456,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -479,7 +473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b558-c63a-65e4-b13e" name="Irresistible Charge" hidden="false" collective="false" type="upgrade">
@@ -488,7 +482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -504,7 +498,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -512,13 +506,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a878-9926-c79b-52f9" name="Beastman Guard" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="d512-74a1-8db4-8b9d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -543,7 +534,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="91a7-c477-55e2-ca33" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -557,7 +548,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -565,7 +556,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="123c-8f08-a41b-a4d9" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -582,7 +573,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="dc2c-1804-1e25-0ec4" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -596,7 +587,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -604,7 +595,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -621,7 +612,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="426b-f70f-042c-454a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -630,7 +621,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18f3-c91c-b03b-bf0e" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -639,7 +630,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a1f6-3522-9eea-fe6d" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -655,7 +646,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="671b-8e4c-0a6a-f24f" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -664,7 +655,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -687,7 +678,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -695,13 +686,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="09df-5d39-3dd7-ebd4" name="Beastman Warriors" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="079c-502a-44fe-2257" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -726,7 +714,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e340-d92c-e18b-dea6" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -740,7 +728,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -748,7 +736,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4e0a-2fb3-0822-21c8" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -765,7 +753,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8126-4076-bd74-ccab" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -779,7 +767,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -787,7 +775,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -804,7 +792,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="611d-26f9-0216-a406" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -813,7 +801,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5682-4851-d858-93e4" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -822,7 +810,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b1c7-0ba8-9d8d-afc2" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -838,7 +826,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="caf0-ac47-d61c-a87e" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -847,7 +835,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -870,7 +858,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -878,13 +866,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8306-d0be-5ab8-5c90" name="Low Beastman Warriors" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="8cd2-d288-bd09-9bb2" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -909,7 +894,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0ffc-c050-5c94-8614" name="Low Beastman Warrior Leader" hidden="false" collective="false" type="model">
@@ -923,7 +908,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -931,7 +916,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2625-0cb2-db95-f8f5" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -948,7 +933,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1521-d702-cafa-92cd" name="Low Beastman Warrior Leader" hidden="false" collective="false" type="model">
@@ -962,7 +947,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -970,7 +955,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -994,7 +979,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1464-a592-9f11-5c94" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1010,7 +995,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30e3-95ee-424d-463a" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1026,7 +1011,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebd3-7c54-caea-c0f7" name="Clubs" hidden="false" collective="false" type="upgrade">
@@ -1035,7 +1020,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1043,13 +1028,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="48b1-55f2-458e-7da3" name="Low Beastman Archers" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="88b3-9f1e-e217-d3d9" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1064,7 +1046,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1082,7 +1064,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5b7-faa2-99aa-cc48" name="Low Beastman Archer" hidden="false" collective="false" type="model">
@@ -1095,7 +1077,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1119,7 +1101,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="09fa-14dd-6651-f785" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1135,7 +1117,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88ad-2da9-7dab-e3da" name="Clubs" hidden="false" collective="false" type="upgrade">
@@ -1144,7 +1126,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1152,13 +1134,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="229d-a488-92e7-b61c" name="Minotaurs" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="aff1-bead-b023-5d06" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -1176,7 +1155,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88a5-d308-2eed-67dd" name="Minotaur Champion" hidden="false" collective="false" type="model">
@@ -1191,7 +1170,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1208,7 +1187,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89d4-b366-5c21-5532" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1217,7 +1196,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="887a-7031-a813-625f" name="Bloomin Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1233,7 +1212,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1250,7 +1229,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9864-7e05-45d1-df5b" name="Irresistible Charge" hidden="false" collective="false" type="upgrade">
@@ -1266,7 +1245,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1274,13 +1253,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="99f4-211b-3162-038d" name="Beast Hounds" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="fb3f-a4ba-fcc1-9771" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
         <categoryLink id="e7d4-f5c6-295a-47a7" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1300,7 +1276,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1320,7 +1296,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1337,7 +1313,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9883-770c-0e26-69f9" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1346,7 +1322,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1373,7 +1349,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1381,7 +1357,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="43ac-cc6b-b21b-7d80" name="Pack Master in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1400,7 +1376,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1408,7 +1384,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1416,13 +1392,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e6ed-5b98-5c6a-7096" name="Centaurs" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="dd9a-2934-8da9-aade" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -1447,7 +1420,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b2de-1d26-3518-f6f0" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -1461,7 +1434,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="44.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1469,7 +1442,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2064-340b-bfba-e4c0" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1486,7 +1459,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6ffa-4ea8-4436-941e" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -1500,7 +1473,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="46.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1508,7 +1481,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0a42-7c7f-0e0e-ad1c" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1525,7 +1498,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="36.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9dba-b719-22a8-18dc" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -1539,7 +1512,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="48.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1547,7 +1520,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1564,7 +1537,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="21b9-5061-e069-c829" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -1580,7 +1553,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf7e-df25-d805-31dc" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1596,7 +1569,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c94e-d5ef-a2f4-42e3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1612,7 +1585,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4832-7fa7-cf23-be91" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -1628,7 +1601,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1651,7 +1624,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1667,7 +1640,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1675,13 +1648,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="18b6-72e8-624b-489a" name="Harpies" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="4f86-0b14-d18e-3e21" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1700,7 +1670,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1716,7 +1686,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1739,7 +1709,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1747,13 +1717,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="67f5-eb29-60ba-e402" name="Beastman Bolt Thrower" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="ff30-a715-e4df-e017" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -1770,7 +1737,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bbc-ff85-f34f-c7fb" name="Beastman Crew" hidden="false" collective="false" type="model">
@@ -1783,7 +1750,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1800,7 +1767,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e981-6fa8-87ab-99d4" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1809,7 +1776,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1826,7 +1793,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3995-525a-7cc0-9494" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -1835,7 +1802,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1843,13 +1810,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8605-371b-3b15-4600" name="Beastman Chieftain" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="a862-20e7-8392-0907" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="ed2a-3bf2-5e2f-04a8" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1868,7 +1832,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="80.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="994f-b68f-0164-d6a3" name="Beastman Bodyguard" hidden="false" collective="false" type="model">
@@ -1881,7 +1845,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1898,7 +1862,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90d8-bd28-17a1-8ba1" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1907,7 +1871,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="70a9-d90a-0657-cb1e" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -1916,7 +1880,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c77a-5258-0c60-eb7d" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1925,7 +1889,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1942,7 +1906,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3241-012a-1440-e53d" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1951,7 +1915,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b42-ca29-f289-f3b5" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1960,7 +1924,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1977,7 +1941,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a281-bfd7-9d59-ef5d" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1986,7 +1950,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2010,7 +1974,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2026,7 +1990,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7258-496c-012b-4adb" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2035,7 +1999,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0db0-83a8-347d-8543" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2044,7 +2008,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8659-a62f-9569-8fa4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2053,7 +2017,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="24aa-5ea6-22d4-db99" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2062,7 +2026,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cff6-6dea-13bb-acd2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2071,7 +2035,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="20ae-e372-6022-2cfc" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2080,7 +2044,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2088,13 +2052,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0fe7-f569-45ac-b1df" name="Beastman Chieftain in Chariot" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="57b3-a1a2-5336-ecff" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="683f-34ff-b931-046e" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
@@ -2112,7 +2073,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="631f-5c61-c79f-9d93" name="Beastman Chieftain" hidden="false" collective="false" type="model">
@@ -2127,7 +2088,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="166.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d794-06af-fcfc-3fe5" name="Chariot" hidden="false" collective="false" type="upgrade">
@@ -2144,7 +2105,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2161,7 +2122,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff4c-410f-1334-001a" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -2170,7 +2131,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c6aa-12d4-1f9b-239e" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -2179,7 +2140,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7fb5-7476-d2df-8b81" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -2188,7 +2149,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2205,7 +2166,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8a43-3db2-f216-b65c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2214,7 +2175,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d0f-b441-03e5-b9cb" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -2223,7 +2184,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2239,7 +2200,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2256,7 +2217,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29ef-7b9c-9f4b-53f6" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2265,7 +2226,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2289,7 +2250,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2305,7 +2266,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f859-065a-1b0d-36d1" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2314,7 +2275,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6866-8134-56e2-9b4f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2323,7 +2284,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02ff-462c-7bd4-dda9" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2332,7 +2293,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="60f7-3d48-d995-aaad" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2341,7 +2302,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6bf-a7f6-ab86-954e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2350,7 +2311,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7632-c3c1-d859-b9fa" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2359,7 +2320,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2367,13 +2328,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f4ae-d5fd-7d7d-7001" name="Beastman Shaman" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="9d24-e284-748b-6b9a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="8dc7-00dc-1b07-78e1" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
@@ -2393,7 +2351,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2407,19 +2365,19 @@
             <selectionEntry id="0a1a-8204-4493-83f9" name="Magic Level 1" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c26f-75e3-6fba-f6ba" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de6e-06c7-8cc9-fe80" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2442,7 +2400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2472,13 +2430,13 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="13.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d908-3a05-3a53-2198" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2493,13 +2451,13 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="15.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2507,7 +2465,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6d39-0600-70c9-0078" name="Spirit Guide or Familiar" hidden="false" collective="false" type="upgrade">
@@ -2524,7 +2482,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2532,7 +2490,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2548,7 +2506,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dc26-4813-9f27-2cb6" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2560,7 +2518,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee12-1783-a93d-3c9e" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2572,7 +2530,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5934-e2cb-9775-cb90" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2584,7 +2542,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed09-ac42-8f78-3b4b" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2596,7 +2554,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0654-7129-936f-cb5f" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2608,7 +2566,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a141-1e19-e7dc-23ea" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2620,7 +2578,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fced-a0e1-eec9-6ef8" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2632,7 +2590,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="92bc-4c47-f81f-142f" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2644,7 +2602,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b829-9a59-07c3-4ec3" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2656,7 +2614,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91fe-a6d8-45c9-4bbd" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2668,7 +2626,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b32-0d70-0c5b-598c" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2680,7 +2638,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a13a-fcaa-35e0-a128" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2692,7 +2650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e28c-8fd7-1cb3-6fbc" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2704,7 +2662,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2721,7 +2679,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d99-5a52-b681-233c" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2730,7 +2688,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="871a-e506-76da-f7b3" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2739,7 +2697,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c84-6172-7bb8-e63b" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2748,7 +2706,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="441a-3676-3700-6364" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2757,7 +2715,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fff7-9886-42bf-7f53" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2766,7 +2724,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d0c8-da64-786f-eced" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2775,7 +2733,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6600-b242-d0d4-dd19" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2784,7 +2742,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="604d-9f2d-2d7d-87d6" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2793,7 +2751,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af35-89ba-8b23-de5f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2802,7 +2760,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7f0f-5247-026c-6a9a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2811,7 +2769,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="40c8-3e5d-6acf-d17b" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2820,7 +2778,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="512a-1df6-69a3-c735" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2829,7 +2787,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0996-90b0-3594-8553" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2838,7 +2796,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2854,7 +2812,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="984a-ffd3-3276-758f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2863,7 +2821,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8c19-03ce-0e96-c8c7" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2872,7 +2830,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8676-f3bc-3f23-528e" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2881,7 +2839,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="deac-b18e-64b1-cb60" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2890,7 +2848,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9acc-6cfe-a338-613e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2899,7 +2857,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed9e-c016-78f4-80f4" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2908,7 +2866,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2916,13 +2874,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f46f-c1d1-3df5-62dc" name="Beastman Shaman in Chariot" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="15dd-1f9d-5f63-9f54" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
         <categoryLink id="3286-24eb-7a25-19e2" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
@@ -2947,7 +2902,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="148.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bfe0-8281-1337-e4dc" name="Beastman Crew" hidden="false" collective="false" type="model">
@@ -2960,7 +2915,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2974,19 +2929,19 @@
             <selectionEntry id="fbcb-9050-e962-5e4a" name="Magic Level 1" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d432-ae84-9d12-5a0a" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d3fd-047d-dc28-2605" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3002,7 +2957,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3022,7 +2977,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3039,7 +2994,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e47e-9adb-c20e-9276" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -3048,7 +3003,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3062,13 +3017,13 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f08c-0970-935e-33ba" name="Additional Spell" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3085,7 +3040,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7324-ffce-42e5-c07c" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -3094,7 +3049,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="830c-dba6-2cc8-aa3a" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -3103,7 +3058,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ecd-d085-25cf-1775" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -3112,7 +3067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af0e-bfb5-a111-1912" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -3121,7 +3076,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa46-5a1e-34d6-ad31" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -3130,7 +3085,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1885-1784-05c7-7c8b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -3139,7 +3094,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6b1-9828-8546-4a87" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -3148,7 +3103,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="baaf-4802-dbab-fc40" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -3157,7 +3112,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a5d-15f5-d1a7-a7e9" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -3166,7 +3121,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df5d-34a3-8e11-1360" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -3175,7 +3130,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c21a-25dc-07e0-65d4" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -3184,7 +3139,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e83-c4b7-9e10-95c7" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -3193,7 +3148,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5559-9de3-e1b9-49db" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -3202,7 +3157,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3218,7 +3173,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c4f-4465-f076-487a" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -3230,7 +3185,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0204-e123-2de6-f650" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -3242,7 +3197,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d54f-916f-0314-5449" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -3254,7 +3209,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c80-1b2e-21e2-c730" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -3266,7 +3221,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e7e9-8499-3de9-848e" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -3278,7 +3233,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="85c1-cbd6-fc72-4416" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -3290,7 +3245,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b438-6732-2255-08ec" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -3302,7 +3257,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9d1e-2d68-a1de-0b92" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -3314,7 +3269,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73c1-9a09-134f-383c" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -3326,7 +3281,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e07-bae3-f2e0-e767" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -3338,7 +3293,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e793-f567-f39f-9780" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -3350,7 +3305,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="76b0-bfce-578b-0169" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -3362,7 +3317,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c213-1e50-9ed0-05d3" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -3374,7 +3329,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3390,7 +3345,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f92f-be44-041a-4db7" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -3399,7 +3354,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b051-3351-9086-002f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -3408,7 +3363,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5770-6d44-04fd-f4ce" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -3417,7 +3372,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="002e-afe1-43e4-8f95" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -3426,7 +3381,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b09c-db48-6ae6-40c0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -3435,7 +3390,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="49d3-94d1-217d-8a78" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -3444,7 +3399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3452,7 +3407,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Beastmen.cat
+++ b/Beastmen.cat
@@ -1694,6 +1694,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ee-4a94-601c-f119" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82d3-b1f8-56a6-299c" type="max"/>
           </constraints>
+          <infoLinks>
+            <infoLink id="4bde-6c53-9fba-87db" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+          </infoLinks>
           <selectionEntries>
             <selectionEntry id="5b9c-8a02-8fd0-71a7" name="Small Bolt Thrower" hidden="false" collective="false" type="upgrade">
               <infoLinks>
@@ -1707,6 +1710,7 @@
             <selectionEntry id="3995-525a-7cc0-9494" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="0014-6ec5-1a88-9ed9" name="Large Bolt Thrower" hidden="false" targetId="fbdf-a3cf-f1d1-8d05" type="profile"/>
+                <infoLink id="6685-d4ff-2644-bccc" name="Unstoppable" hidden="false" targetId="a8bf-f48c-1b08-58e6" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
@@ -1888,77 +1892,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="779b-77f0-41fb-5ba5" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="554a-7984-58ee-b09b" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="ef6d-4bad-d585-1c2c" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="aec0-cc7b-281f-88b3" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7258-496c-012b-4adb" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="051f-e854-042f-7935" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0db0-83a8-347d-8543" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="72d9-ee3b-ab30-a6ca" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8659-a62f-9569-8fa4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5057-3fd2-e01c-55aa" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="24aa-5ea6-22d4-db99" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="57c7-bfe6-be19-65b0" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="cff6-6dea-13bb-acd2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="3101-aa2f-b8ab-3864" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="20ae-e372-6022-2cfc" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4994-49c5-8829-09bd" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="ea6a-76aa-9290-8286" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -2165,77 +2102,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="893f-af51-8868-5942" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9b8-0a3b-f16e-9bbd" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="89e2-30f5-f369-8f88" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="64c1-a874-bfe5-b9a1" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f859-065a-1b0d-36d1" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="be52-eb33-923b-7db3" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6866-8134-56e2-9b4f" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b72d-eebb-4709-b825" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="02ff-462c-7bd4-dda9" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5d47-70aa-b8b7-3c5c" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="60f7-3d48-d995-aaad" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="3351-b62a-1553-a167" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f6bf-a7f6-ab86-954e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a8ce-a0f4-9937-83a5" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7632-c3c1-d859-b9fa" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="64c1-80aa-b9ed-0642" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="02ff-3c02-8b9b-1081" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -2711,77 +2581,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e0ae-fc2e-cda4-d09b" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5add-c366-6449-746b" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="8a09-f678-ba6c-4037" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="fdc9-0a60-2455-3aeb" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="984a-ffd3-3276-758f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="60e5-f844-aa00-a061" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8c19-03ce-0e96-c8c7" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="afed-065d-2433-5f31" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8676-f3bc-3f23-528e" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="74cb-8899-15f8-682b" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="deac-b18e-64b1-cb60" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b763-53d6-fb56-c5e5" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9acc-6cfe-a338-613e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="6657-fa90-96f6-6877" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ed9e-c016-78f4-80f4" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="28d2-73ab-c3f1-4e41" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4047-33aa-3178-a8c9" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -3227,77 +3030,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9453-47eb-afee-6745" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63f9-9118-b907-49fa" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="5324-fff0-b2aa-6dab" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b567-9f88-0dd8-9740" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f92f-be44-041a-4db7" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c70e-9319-8c74-f6cc" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b051-3351-9086-002f" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c82b-1a5e-8ac3-993d" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5770-6d44-04fd-f4ce" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="f4e9-3c5a-6880-b46a" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="002e-afe1-43e4-8f95" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="22ee-5949-499e-e823" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b09c-db48-6ae6-40c0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9f4b-f991-4f6f-4280" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="49d3-94d1-217d-8a78" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1bef-8472-f9d7-0e6a" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="47d5-7c54-e343-cf88" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>

--- a/Beastmen.cat
+++ b/Beastmen.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="495c-99bf-3793-41ba" name="Beastmen" revision="3" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="495c-99bf-3793-41ba" name="Beastmen" revision="4" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="c9f0-8ebd-86ff-209f" name="Shaman" hidden="false">
       <constraints>
@@ -29,6 +29,12 @@
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f421-0714-a6ab-69fe" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="4821-8722-63ce-9d05" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+        <infoLink id="2c83-2cd8-f7d5-c9db" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="b9b1-d940-5c5c-775d" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="176b-3ea4-9b4c-49be" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="560e-175e-30ee-8a1d" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -40,10 +46,6 @@
           </constraints>
           <infoLinks>
             <infoLink id="c72d-dc03-1a9e-1ab8" name="Centaur Lord" hidden="false" targetId="44a2-1e8b-a9a2-8df6" type="profile"/>
-            <infoLink id="6fc2-d7b7-367e-7745" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-            <infoLink id="533e-28ed-f413-c3e0" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-            <infoLink id="8537-1b65-a6e3-3ece" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
-            <infoLink id="6e28-fff1-a065-e09d" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -52,24 +54,15 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="671c-b5f8-39a4-169e" name="HTH Weapon" hidden="false" collective="false" defaultSelectionEntryId="9918-2be2-5217-4550">
+        <selectionEntryGroup id="671c-b5f8-39a4-169e" name="HtH Weapon" hidden="false" collective="false" defaultSelectionEntryId="9918-2be2-5217-4550">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba4d-8c5a-9cdc-9b44" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1378-5e10-d9e1-fc26" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="9918-2be2-5217-4550" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9918-2be2-5217-4550" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="29a1-fb00-f222-a785" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8191-ed28-15fe-4939" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0531-d5eb-2da1-2407" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -112,7 +105,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3c1a-d3ea-aa88-025b" name="Dead Eye Shot Upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="3c1a-d3ea-aa88-025b" name="Deadeye Shot Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="869d-7cfc-62af-9e32" type="max"/>
           </constraints>
@@ -144,76 +137,6 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6361-a8fa-b081-d694" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c917-0624-63d5-3255" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="2d86-38cf-d0c1-29fb" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="88bc-1924-3b81-254e" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="245c-597b-ebbd-8c79" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="965c-1d52-5441-6ce7" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4d31-1b9e-ac37-0383" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b11a-e539-c888-2964" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5c86-96d7-7226-1844" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8d8f-ca06-cbb1-36a0" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c810-20ff-6395-e97a" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c391-216a-c271-f0b8" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8e23-0119-f5d3-cc26" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="25d6-8937-3ff9-9f67" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5170-b6f8-9436-2430" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="df84-6881-5f16-68dc" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="52.0"/>
@@ -224,11 +147,16 @@
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc22-bd2b-b3b7-2331" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="aca0-293b-ad8f-0e2b" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="46b5-ff3c-95cd-c943" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="a408-5b67-9c72-e124" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="3570-148a-b302-bed6" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="9954-1dbd-c83c-1021" name="Model" hidden="false" collective="false" defaultSelectionEntryId="c039-26f2-33aa-3961">
+        <selectionEntryGroup id="9954-1dbd-c83c-1021" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="c039-26f2-33aa-3961">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1434-4247-4c7a-efcf" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b51b-8368-d67e-c08e" type="max"/>
@@ -245,9 +173,6 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="6340-8b80-f14f-6481" name="Minotaur Lord" hidden="false" targetId="f925-b5ec-1c26-1a44" type="profile"/>
-                        <infoLink id="ddf8-1ea9-492a-112e" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                        <infoLink id="674a-7479-6c9a-be4e" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                        <infoLink id="aac9-c42b-54ca-728a" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="66.0"/>
@@ -272,9 +197,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="565e-5684-55cd-a5f6" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="b255-4722-3230-7907" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                        <infoLink id="eef5-918f-ae2d-ba76" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                        <infoLink id="3afc-1aa6-c500-22dc" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
                         <infoLink id="f78d-8fa9-0ac0-3e7e" name="Minotaur Lord in Medium Armour" hidden="false" targetId="4669-1cfd-5f0a-a05f" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -298,18 +220,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dd5-af28-ad8b-dd54" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="dad2-c026-be31-d921" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="dad2-c026-be31-d921" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="1baa-900b-831b-73dc" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b5f1-c16f-0aa0-a683" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="118c-24f0-f42a-3b68" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -403,12 +316,14 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="a878-9926-c79b-52f9" name="Beastman Guard" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d7e-cc45-f364-1f35" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="d512-74a1-8db4-8b9d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
-        <categoryLink id="1226-e7f5-7ba8-6ffc" name="Guard Unit" hidden="false" targetId="af51-60b9-09ce-ed3f" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4464-843a-9de1-11c0" name="Models" hidden="false" collective="false" defaultSelectionEntryId="c6c7-b1cd-9bc1-7e56">
+        <selectionEntryGroup id="4464-843a-9de1-11c0" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="c6c7-b1cd-9bc1-7e56">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43e5-83b2-ac64-9822" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="198e-2ce6-d573-6b89" type="min"/>
@@ -416,7 +331,7 @@
           <selectionEntries>
             <selectionEntry id="c6c7-b1cd-9bc1-7e56" name="Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="938a-a97d-d284-a6c5" name="Light Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="938a-a97d-d284-a6c5" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="01b1-b6ff-91f8-f33b" name="Beastman" hidden="false" collective="false" type="model">
                       <constraints>
@@ -455,7 +370,7 @@
             </selectionEntry>
             <selectionEntry id="123c-8f08-a41b-a4d9" name="Medium Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="62d7-aac9-a745-87af" name="Medium Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="62d7-aac9-a745-87af" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="9e57-ba65-68a2-b3af" name="Beastman" hidden="false" collective="false" type="model">
                       <constraints>
@@ -500,18 +415,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8618-e3eb-1768-e578" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="1172-fac7-04d1-0ed5" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1172-fac7-04d1-0ed5" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="0934-d30f-ffae-ddfb" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="426b-f70f-042c-454a" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="10cc-0bbd-9658-9646" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -561,7 +467,7 @@
           <selectionEntries>
             <selectionEntry id="4ded-abcd-b45d-a06d" name="Savage" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="a878-9926-c79b-52f9" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -584,11 +490,14 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="09df-5d39-3dd7-ebd4" name="Beastman Warriors" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="a716-21d2-e5a1-6248" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="079c-502a-44fe-2257" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d3af-4838-efe0-f612" name="Models" hidden="false" collective="false" defaultSelectionEntryId="0724-8b09-09df-6347">
+        <selectionEntryGroup id="d3af-4838-efe0-f612" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="0724-8b09-09df-6347">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27ee-6145-b303-677c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79ed-f8d8-ebc1-69f6" type="max"/>
@@ -596,7 +505,7 @@
           <selectionEntries>
             <selectionEntry id="0724-8b09-09df-6347" name="No Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="f3e6-dc3a-f4be-e1fa" name="No Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="f3e6-dc3a-f4be-e1fa" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="eb37-ef70-e6aa-67f9" name="Beastman" hidden="false" collective="false" type="model">
                       <constraints>
@@ -617,7 +526,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8429-f5b1-cfaa-bcc4" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="5e74-2dd7-2f57-22ed" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="2918-4b47-abb0-1e50" name="Beastman Warrior Leader" hidden="false" targetId="f736-da47-48f5-fd54" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -635,7 +543,7 @@
             </selectionEntry>
             <selectionEntry id="4e0a-2fb3-0822-21c8" name="Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="91eb-340d-11b8-ed3a" name="Light Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="91eb-340d-11b8-ed3a" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="4984-94f5-c80f-668e" name="Beastman" hidden="false" collective="false" type="model">
                       <constraints>
@@ -656,7 +564,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc05-b9a9-c168-7f67" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="a8e2-0acc-666a-cf25" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="129b-f1a2-9112-49f5" name="Beastman Warrior Leader in Light Armour" hidden="false" targetId="48f9-27fe-c617-e171" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -683,15 +590,6 @@
             <selectionEntry id="87d2-e1bb-567b-46e8" name="Sword" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="e3cd-8764-d3c9-0751" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="611d-26f9-0216-a406" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1413-e981-f067-790e" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -764,11 +662,14 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="8306-d0be-5ab8-5c90" name="Low Beastman Warriors" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="af4d-e2b8-893e-4c2d" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="8cd2-d288-bd09-9bb2" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="cd48-cc87-50ae-9db8" name="Models" hidden="false" collective="false" defaultSelectionEntryId="89c7-b849-016a-9408">
+        <selectionEntryGroup id="cd48-cc87-50ae-9db8" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="89c7-b849-016a-9408">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2075-c0df-4cb2-ff69" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2716-0bfc-8131-2ea1" type="max"/>
@@ -776,7 +677,7 @@
           <selectionEntries>
             <selectionEntry id="89c7-b849-016a-9408" name="No Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="454b-c996-9b95-f6d2" name="No Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="454b-c996-9b95-f6d2" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="b35a-95ec-6eb1-27f9" name="Low Beastman Warrior" hidden="false" collective="false" type="model">
                       <constraints>
@@ -797,7 +698,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c6e-20d9-34c3-4204" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="38f9-7cd2-3027-3317" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="4e97-2169-047b-1258" name="Low Beastman Warrior Leader" hidden="false" targetId="27f5-4745-6732-8a6f" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -815,7 +715,7 @@
             </selectionEntry>
             <selectionEntry id="2625-0cb2-db95-f8f5" name="Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="78f1-89a8-30db-6160" name="Light Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="78f1-89a8-30db-6160" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="9fbe-75a7-264d-d756" name="Low Beastman Warrior" hidden="false" collective="false" type="model">
                       <constraints>
@@ -836,7 +736,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6091-1811-8d3a-4b9c" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="c46c-f46f-9c9b-466b" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="dc4b-3583-7743-75d2" name="Low Beastman Warrior Leader in Light Armour" hidden="false" targetId="55b0-758b-824c-d20c" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -945,7 +844,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="04e2-ebf4-b38f-2db0" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="04e2-ebf4-b38f-2db0" name="Choose 4 to 9" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="7e02-1cbd-f5d8-263c" name="Low Beastman Archer Leader" hidden="false" collective="false" type="model">
               <constraints>
@@ -953,7 +852,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37a4-0b45-2fd8-8952" type="min"/>
               </constraints>
               <infoLinks>
-                <infoLink id="b081-66f4-6500-2ee1" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+                <infoLink id="b081-66f4-6500-2ee1" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                 <infoLink id="b256-990a-11da-51e4" name="Low Beastman Archer Leader" hidden="false" targetId="1666-733e-c86c-f5c3" type="profile"/>
               </infoLinks>
               <costs>
@@ -976,13 +875,13 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="bdd0-f354-fa2b-63f0" name="HTH Weapon Choice" hidden="false" collective="false" defaultSelectionEntryId="88ad-2da9-7dab-e3da">
+        <selectionEntryGroup id="bdd0-f354-fa2b-63f0" name="HtH Weapon Choice" hidden="false" collective="false" defaultSelectionEntryId="88ad-2da9-7dab-e3da">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1179-3c94-3fa7-0f28" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21af-05cb-ca27-29a8" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="1295-abb3-3f8d-2828" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1295-abb3-3f8d-2828" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="2">
                   <repeats>
@@ -992,22 +891,6 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="2401-ca1a-f1a4-450f" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="09fa-14dd-6651-f785" name="Axe" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="2">
-                  <repeats>
-                    <repeat field="selections" scope="48b1-55f2-458e-7da3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="a666-1a46-01a6-1538" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1032,11 +915,18 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="229d-a488-92e7-b61c" name="Minotaurs" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7aa1-a339-7dcb-d5f5" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="ea24-b3be-ba7e-4c9b" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="1bd7-475e-4057-0998" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="aff1-bead-b023-5d06" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ebf3-e72f-b533-52a2" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="ebf3-e72f-b533-52a2" name="Choose 2 to 4" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="0150-7bc5-7eae-d486" name="Minotaur" hidden="false" collective="false" type="model">
               <constraints>
@@ -1045,7 +935,6 @@
               </constraints>
               <infoLinks>
                 <infoLink id="2a3a-d25c-250c-55d3" name="Minotaurs" hidden="false" targetId="1178-6657-496d-0cbb" type="profile"/>
-                <infoLink id="fd22-923f-63a8-bda7" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
@@ -1059,8 +948,6 @@
               </constraints>
               <infoLinks>
                 <infoLink id="f0c9-7662-2a03-06d8" name="Minotaurs (Champion)" hidden="false" targetId="df87-0e9a-4987-59ed" type="profile"/>
-                <infoLink id="9ea0-5215-e8a5-0a7a" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                <infoLink id="80c1-7f3a-f992-8eb5" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
@@ -1077,7 +964,7 @@
           <selectionEntries>
             <selectionEntry id="5ac2-34d3-601d-06d9" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="4a36-3616-cb88-a0f4" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="4a36-3616-cb88-a0f4" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1111,7 +998,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="58fd-281f-07c9-f520" name="Charge" hidden="false" collective="false" defaultSelectionEntryId="ec22-3d23-e908-1307">
+        <selectionEntryGroup id="58fd-281f-07c9-f520" name="Charge Upgrade" hidden="false" collective="false" defaultSelectionEntryId="ec22-3d23-e908-1307">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76ef-8f64-98da-2c33" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="655b-3ea0-8824-f21a" type="min"/>
@@ -1151,12 +1038,17 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="99f4-211b-3162-038d" name="Beast Hounds" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="d263-5119-022a-4c22" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
+        <infoLink id="193c-501c-063b-ab69" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
+        <infoLink id="5f84-c997-2163-000a" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="fb3f-a4ba-fcc1-9771" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="false"/>
         <categoryLink id="e7d4-f5c6-295a-47a7" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e086-0d8b-2129-615e" name="Hounds" hidden="false" collective="false">
+        <selectionEntryGroup id="e086-0d8b-2129-615e" name="Select 4 to 9" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="0263-00d2-294c-0b0f" name="Beast Hounds" hidden="false" collective="false" type="model">
               <constraints>
@@ -1165,8 +1057,6 @@
               </constraints>
               <infoLinks>
                 <infoLink id="8bb4-9512-9fb2-6515" name="Beast Hounds" hidden="false" targetId="b590-eb52-39a5-587a" type="profile"/>
-                <infoLink id="57cc-d2e7-e549-07fe" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
-                <infoLink id="a47c-57f8-31ef-3cd9" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
@@ -1190,32 +1080,6 @@
               </constraints>
               <infoLinks>
                 <infoLink id="5c0d-e61e-89c5-fe1e" name="Choking" hidden="false" targetId="7ff2-1650-fc0e-5a3a" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="3943-8c53-b9cc-38e6" name="Packmaster weapon" hidden="false" collective="false" defaultSelectionEntryId="dd4b-b21a-fc13-f855">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30b5-f60a-a0b4-ab3b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4176-f0fd-a417-43e2" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="dd4b-b21a-fc13-f855" name="Sword" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="6814-e92a-2bad-1d5d" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9883-770c-0e26-69f9" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="84f0-7d5e-37c9-cfc6" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1305,7 +1169,7 @@
         <categoryLink id="dd9a-2934-8da9-aade" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6d2f-1513-ccc0-af48" name="Models" hidden="false" collective="false" defaultSelectionEntryId="824b-173c-3be4-8e1c">
+        <selectionEntryGroup id="6d2f-1513-ccc0-af48" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="824b-173c-3be4-8e1c">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="992d-a7bb-ccba-45b7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f824-7637-1dea-6922" type="max"/>
@@ -1313,7 +1177,7 @@
           <selectionEntries>
             <selectionEntry id="824b-173c-3be4-8e1c" name="No Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="af3a-e081-8cbc-aa5d" name="No Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="af3a-e081-8cbc-aa5d" name="Choose 2 to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="0496-e30b-e260-b351" name="Centaur" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1352,7 +1216,7 @@
             </selectionEntry>
             <selectionEntry id="2064-340b-bfba-e4c0" name="Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="6c2d-2b61-cea7-16e4" name="Light Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="6c2d-2b61-cea7-16e4" name="Choose 2 to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="8607-5ee6-d0bb-8984" name="Centaur" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1391,7 +1255,7 @@
             </selectionEntry>
             <selectionEntry id="0a42-7c7f-0e0e-ad1c" name="Medium Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="12cf-e11f-1ec5-775c" name="Medium Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="12cf-e11f-1ec5-775c" name="Choose 2 to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="0e64-f562-10b5-67a7" name="Centaur" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1430,7 +1294,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="485d-592a-fd3b-f3db" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="fd5e-7531-a1f7-e904">
+        <selectionEntryGroup id="485d-592a-fd3b-f3db" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="fd5e-7531-a1f7-e904">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="704f-900d-c78d-83bf" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d737-7f88-90c3-0862" type="min"/>
@@ -1445,7 +1309,7 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="21b9-5061-e069-c829" name="Swords" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="21b9-5061-e069-c829" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="2">
                   <repeats>
@@ -1455,22 +1319,6 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="c33e-256e-8973-5c63" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="cf7e-df25-d805-31dc" name="Axes" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="2">
-                  <repeats>
-                    <repeat field="selections" scope="e6ed-5b98-5c6a-7096" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="ca3a-dc38-8d0a-eefc" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1534,12 +1382,12 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3476-1798-4863-4a07" name="Dead Eye Shot Upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="3476-1798-4863-4a07" name="Deadeye Shot Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cd7-2d03-e0c4-84bf" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="2c93-1c63-4c8e-9d96" name="Dead Eye Shot" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2c93-1c63-4c8e-9d96" name="Deadeye Shot" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="ffcd-10b8-4049-e5af" name="Deadeye Shot" hidden="false" targetId="d055-98ce-6f28-1600" type="rule"/>
               </infoLinks>
@@ -1560,11 +1408,15 @@
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d273-9341-bb49-0329" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="a124-2ca1-6c6d-f317" name="Fast 10" hidden="false" targetId="0034-82ae-f695-d446" type="rule"/>
+        <infoLink id="396b-ec10-6a19-a63c" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="4f86-0b14-d18e-3e21" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="1eea-12a0-8ba3-b176" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="1eea-12a0-8ba3-b176" name="Choose 3 to 5" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="ab76-78d8-a01b-65cc" name="Harpies with rocks" hidden="false" collective="false" type="model">
               <constraints>
@@ -1573,9 +1425,7 @@
               </constraints>
               <infoLinks>
                 <infoLink id="a057-7384-14ba-acc9" name="Harpies with Rocks" hidden="false" targetId="4077-f4ee-bc64-edc2" type="profile"/>
-                <infoLink id="8b58-5715-5739-9ac0" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
-                <infoLink id="552b-12a8-4e7f-6c12" name="Rocks (HTH)" hidden="false" targetId="88d0-6821-ceff-0382" type="profile"/>
-                <infoLink id="a4ac-0f11-b096-2856" name="Fast 10" hidden="false" targetId="0034-82ae-f695-d446" type="rule"/>
+                <infoLink id="552b-12a8-4e7f-6c12" name="Rocks (HtH)" hidden="false" targetId="88d0-6821-ceff-0382" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
@@ -1584,12 +1434,12 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="fcbd-bca4-8bc9-0b0e" name="Dead Eye Shot Upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="fcbd-bca4-8bc9-0b0e" name="Deadeye Shot Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca8a-7e4e-2ac5-4d8c" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="b7c2-b51c-0b46-80a9" name="Dead Eye Shot" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b7c2-b51c-0b46-80a9" name="Deadeye Shot" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="beab-a817-30f1-4451" name="Deadeye Shot" hidden="false" targetId="d055-98ce-6f28-1600" type="rule"/>
               </infoLinks>
@@ -1600,7 +1450,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d418-560e-4158-dff7" name="Vengeful Rule Upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="d418-560e-4158-dff7" name="Vengeful Upgrade" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="7efb-82b8-7c49-6394" name="Vengeful" hidden="false" collective="false" type="upgrade">
               <modifiers>
@@ -1630,60 +1480,28 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="67f5-eb29-60ba-e402" name="Beastman Bolt Thrower" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="8693-da5a-e369-a0fc" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+        <infoLink id="f651-0389-e30a-26a2" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="ba0a-713f-7056-d7d5" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="165d-5f06-9d9c-1a93" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="ff30-a715-e4df-e017" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="67c2-d185-ae7b-a39c" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="67c2-d185-ae7b-a39c" name="Choose 3 to 5" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="cac8-70f8-653d-201f" name="Bolt Thrower" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e08d-c8e8-c671-4ece" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b23-7364-b320-00ac" type="min"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="8bbc-ff85-f34f-c7fb" name="Beastman Crew" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4120-dfed-0f95-0209" type="min"/>
                 <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f967-157f-ed96-ced0" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="c8a5-f595-13db-2242" name="Beastman Bolt Thrower" hidden="false" targetId="c020-9bee-5d3d-95d8" type="profile"/>
-                <infoLink id="990a-8833-5c6a-1603" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="0e2e-ba3d-c80d-b11a" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+                <infoLink id="c8a5-f595-13db-2242" name="Beastman Crew with Bolt Throwing Engine" hidden="false" targetId="c020-9bee-5d3d-95d8" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="a701-f96b-08ae-e786" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="e8f7-7508-a924-65b1">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f116-4343-a96c-4888" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61bf-c708-18b5-8e53" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="e8f7-7508-a924-65b1" name="Swords" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0748-42a8-a348-b028" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e981-6fa8-87ab-99d4" name="Axes" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1ff5-d3ae-0724-c1ed" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -1694,9 +1512,6 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3ee-4a94-601c-f119" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82d3-b1f8-56a6-299c" type="max"/>
           </constraints>
-          <infoLinks>
-            <infoLink id="4bde-6c53-9fba-87db" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
-          </infoLinks>
           <selectionEntries>
             <selectionEntry id="5b9c-8a02-8fd0-71a7" name="Small Bolt Thrower" hidden="false" collective="false" type="upgrade">
               <infoLinks>
@@ -1730,24 +1545,26 @@
         <categoryLink id="a862-20e7-8392-0907" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="ed2a-3bf2-5e2f-04a8" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f0e9-3880-efab-1549" name="Beastman Chieftain" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e343-332c-0756-a90f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20b7-4109-ceb2-e3ec" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="88da-a83c-c5b4-de9c" name="Beastman Chieftain (on foot)" hidden="false" targetId="4f79-4003-209e-db8c" type="profile"/>
+            <infoLink id="55fd-e9d7-fc97-a90d" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+            <infoLink id="4bcf-14df-616d-b8c5" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="80.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="843b-c537-ccf5-2255" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="843b-c537-ccf5-2255" name="Choose 2 to 4" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="13a8-3114-54a2-a6a9" name="Beastman Chieftain" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4418-16af-22e0-4938" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70bd-8231-1c05-b6e2" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="24de-16dc-bf85-a76a" name="Beastman Chieftain (on foot)" hidden="false" targetId="4f79-4003-209e-db8c" type="profile"/>
-                <infoLink id="10c5-768a-0dbc-f978" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                <infoLink id="7dfe-d1b9-c81e-4184" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="80.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="994f-b68f-0164-d6a3" name="Beastman Bodyguard" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2810-e06f-4192-6f35" type="min"/>
@@ -1769,18 +1586,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c3e-cb80-162b-53bb" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="01f7-5ab5-0c60-54f7" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="01f7-5ab5-0c60-54f7" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="404b-31fc-aee6-c717" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="90d8-bd28-17a1-8ba1" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0c8c-2747-5eb4-73bd" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1807,7 +1615,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3877-3f25-3bd2-e83a" name="Chieftain Wound Selection" hidden="false" collective="false" defaultSelectionEntryId="86ee-fdc6-f0e3-aebf">
+        <selectionEntryGroup id="3877-3f25-3bd2-e83a" name="Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="86ee-fdc6-f0e3-aebf">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fd3-25e6-e892-1aca" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9c0-62de-9cba-abda" type="max"/>
@@ -1842,7 +1650,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="dfdd-dca0-8984-8242" name="Chieftain Tough Selection" hidden="false" collective="false" defaultSelectionEntryId="0a4e-9096-64e8-efe6">
+        <selectionEntryGroup id="dfdd-dca0-8984-8242" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="0a4e-9096-64e8-efe6">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e8f-aa16-1a65-3941" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ed0-256f-8b85-b401" type="max"/>
@@ -1902,12 +1710,49 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="0fe7-f569-45ac-b1df" name="Beastman Chieftain in Chariot" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="2dc2-acf0-0d99-0425" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
+        <infoLink id="031e-4956-e4c4-d99f" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+        <infoLink id="900c-3b48-d793-fb84" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="b29e-16c2-e877-99c6" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="5d71-aec5-3507-a79d" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+        <infoLink id="103e-08a1-d6bd-8ac2" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="57b3-a1a2-5336-ecff" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="683f-34ff-b931-046e" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6067-05d3-1aea-a9a5" name="Chariot" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9467-b59c-fc02-0d37" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1696-a01a-8bbc-546d" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="3022-69cd-717a-7c70" name="Chariot with Chieftain and crew in chariot pulled by wild boars" hidden="false" targetId="96cd-c5d4-e5aa-5f52" type="profile"/>
+            <infoLink id="4b34-07a8-fd91-b19d" name="Wild Boars (Chariot)" hidden="false" targetId="dc8c-e7aa-91a4-873e" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2cea-51ee-2ade-f47a" name="Beastman Chieftain" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb17-583b-aa81-1dc1" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b17e-3d6d-1b2d-b11f" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2c20-8b3d-1903-4510" name="Beastman Chieftain riding chariot" hidden="false" targetId="c0ba-8436-9fc7-45eb" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="166.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="dc2f-c651-7484-8bee" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="dc2f-c651-7484-8bee" name="Choose 1 to 3" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="02a1-448b-e51b-08ee" name="Beastman Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -1922,39 +1767,6 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="631f-5c61-c79f-9d93" name="Beastman Chieftain" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9888-86fb-6e9f-db05" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4aa-3d0b-6f6b-40a1" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="37b1-c104-30fa-0316" name="Beastman Chieftain" hidden="false" targetId="c0ba-8436-9fc7-45eb" type="profile"/>
-                <infoLink id="4e7e-db03-9386-0cee" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                <infoLink id="8045-92fd-78d8-b73d" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="166.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d794-06af-fcfc-3fe5" name="Chariot" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0dc-7d57-3a2b-09d1" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e2a-0972-204c-2026" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="b004-de8c-d800-6557" name="Chariot with Chieftain and crew in chariot pulled by wild boars" hidden="false" targetId="96cd-c5d4-e5aa-5f52" type="profile"/>
-                <infoLink id="cfe0-3fe2-02c8-c26a" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="e611-2480-f2d1-8134" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                <infoLink id="5999-356b-af7f-b86c" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
-                <infoLink id="971b-428e-eda8-5308" name="Wild Boars (Chariot)" hidden="false" targetId="dc8c-e7aa-91a4-873e" type="profile"/>
-                <infoLink id="f205-7bc7-b833-693b" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="2dbb-f2b6-d45e-6e69" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="8b93-7f77-63b3-f599">
@@ -1963,18 +1775,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e48-39c0-5461-b8ab" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8b93-7f77-63b3-f599" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8b93-7f77-63b3-f599" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="6150-9d85-7e8c-c309" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ff4c-410f-1334-001a" name="Axes" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="961c-0699-40de-5a3f" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="6150-9d85-7e8c-c309" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2001,7 +1804,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ec54-5ed8-ce35-a041" name="Chieftain Wound Selection" hidden="false" collective="false" defaultSelectionEntryId="3658-0a9c-f4ce-98a0">
+        <selectionEntryGroup id="ec54-5ed8-ce35-a041" name="Wound Upgrade [on foot]" hidden="false" collective="false" defaultSelectionEntryId="3658-0a9c-f4ce-98a0">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2622-6a29-ecec-da6c" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d1b-a343-2bf7-3eb0" type="min"/>
@@ -2052,7 +1855,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f58b-5874-896e-0dd1" name="Chieftain Tough Upgrade (on foot only)" hidden="false" collective="false" defaultSelectionEntryId="184c-e6ff-ef34-f986">
+        <selectionEntryGroup id="f58b-5874-896e-0dd1" name="Tough Upgrade [on foot]" hidden="false" collective="false" defaultSelectionEntryId="184c-e6ff-ef34-f986">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe64-f226-8584-3743" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89a0-9966-4cef-d95c" type="max"/>
@@ -2078,19 +1881,19 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ff56-0f29-5d80-6b71" name="Savage Rule Upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="ff56-0f29-5d80-6b71" name="Savage Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4af9-152e-df6d-69c8" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="81f5-325e-b77e-4e93" name="Savage" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="0fe7-f569-45ac-b1df" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
-                <modifier type="increment" field="points" value="4"/>
+                <modifier type="increment" field="points" value="4.0"/>
               </modifiers>
               <infoLinks>
                 <infoLink id="7c18-5931-efa9-b57e" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
@@ -2112,30 +1915,30 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="f4ae-d5fd-7d7d-7001" name="Beastman Shaman" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="1869-467d-3d09-5721" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="802c-5001-b460-b57d" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="9d24-e284-748b-6b9a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
         <categoryLink id="e37f-81b0-5fce-4471" name="Shaman" hidden="false" targetId="c9f0-8ebd-86ff-209f" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7c12-8575-7406-8e03" name="Beastman Shaman" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14a6-5018-440a-b621" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daae-b325-4740-3e62" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0e21-eab4-434f-9574" name="Beastman Shaman (on foot)" hidden="false" targetId="4a55-c0e0-6b12-9163" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="62.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ce4d-4970-bf78-b93d" name="Models" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="bee1-185c-c908-064f" name="Beastman Shaman" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7530-4c64-6474-2fe2" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d483-fee8-97ef-f3d8" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="b8c0-e6e5-3e95-a4c0" name="Beastman Shaman" hidden="false" targetId="4a55-c0e0-6b12-9163" type="profile"/>
-                <infoLink id="54e8-8f20-c248-af6b" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                <infoLink id="ad6e-ad9b-c0b6-b810" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="62.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
         <selectionEntryGroup id="a84d-f00d-b5f2-3cb9" name="Magic Level" hidden="false" collective="false" defaultSelectionEntryId="0a1a-8204-4493-83f9">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b611-f193-f813-476e" type="max"/>
@@ -2206,7 +2009,6 @@
                           </constraints>
                           <infoLinks>
                             <infoLink id="0630-e55f-7cd8-b2eb" name="Beastman Shamanic Cultists" hidden="false" targetId="1596-f4ee-96a9-7aa6" type="profile"/>
-                            <infoLink id="8be7-d994-8457-4d85" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="13.0"/>
@@ -2221,13 +2023,12 @@
                     </selectionEntry>
                     <selectionEntry id="d908-3a05-3a53-2198" name="Light Armour" hidden="false" collective="false" type="upgrade">
                       <selectionEntries>
-                        <selectionEntry id="daab-23b7-424c-d735" name="Beastman Shamanic Cultists" hidden="false" collective="false" type="model">
+                        <selectionEntry id="daab-23b7-424c-d735" name="Beastman Shamanic Cultists in Light Armour" hidden="false" collective="false" type="model">
                           <constraints>
                             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6e8-b2b6-f596-45a3" type="max"/>
                           </constraints>
                           <infoLinks>
                             <infoLink id="747b-01f8-e2e4-a178" name="Shamanic Cultists in Light Armour" hidden="false" targetId="950c-38fa-a240-7625" type="profile"/>
-                            <infoLink id="eb96-5059-e1a6-fc99" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="15.0"/>
@@ -2250,7 +2051,7 @@
             </selectionEntry>
             <selectionEntry id="6d39-0600-70c9-0078" name="Spirit Guide or Familiar" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="4249-96bc-46f7-56bf" name="Spirit Guide or Familiar" hidden="false" collective="false">
+                <selectionEntryGroup id="4249-96bc-46f7-56bf" name="Choose up to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="c309-25b5-e103-9b95" name="Animal Spirit Guide or Familiar" hidden="false" collective="false" type="model">
                       <constraints>
@@ -2591,33 +2392,38 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="f46f-c1d1-3df5-62dc" name="Beastman Shaman in Chariot" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="b61f-2601-fb28-31ae" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="15dd-1f9d-5f63-9f54" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
         <categoryLink id="80fb-b33f-7eba-01e4" name="Shaman" hidden="false" targetId="c9f0-8ebd-86ff-209f" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5304-c710-c6f5-596e" name="Beastman Shaman" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a48d-a4fb-bf47-d177" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74ff-e2c3-3b3e-5727" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="9df5-642b-5d88-1d33" name="Beastman Shaman" hidden="false" targetId="520a-a76e-993a-6cb9" type="profile"/>
+            <infoLink id="5ee7-6694-d043-be77" name="Chariot with Shaman and crew, pulled by wild boars" hidden="false" targetId="8843-47cf-79c0-7804" type="profile"/>
+            <infoLink id="b661-2349-5248-decf" name="Wild Boars (Chariot)" hidden="false" targetId="dc8c-e7aa-91a4-873e" type="profile"/>
+            <infoLink id="13bb-33e3-34d6-546b" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+            <infoLink id="71ed-52c8-014f-3940" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+            <infoLink id="ae84-1d09-e828-3640" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+            <infoLink id="4cee-4cdf-f197-6e0c" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+            <infoLink id="ad84-786b-a827-3028" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="148.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d8ff-f1ad-6edd-0916" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="d8ff-f1ad-6edd-0916" name="Choose 1 to 3" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="073f-8c08-3eab-7b16" name="Beastman Shaman" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb01-02cd-6646-c756" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9054-9e57-e877-e252" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="5297-b430-4581-23a0" name="Beastman Shaman" hidden="false" targetId="520a-a76e-993a-6cb9" type="profile"/>
-                <infoLink id="f522-e27e-f839-a4ea" name="Chariot with Shaman and crew, pulled by wild boars" hidden="false" targetId="8843-47cf-79c0-7804" type="profile"/>
-                <infoLink id="17f4-0ba3-6604-2f76" name="Wild Boars (Chariot)" hidden="false" targetId="dc8c-e7aa-91a4-873e" type="profile"/>
-                <infoLink id="ed1e-92e0-4009-adc8" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="0566-d567-25fe-ba34" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                <infoLink id="51f1-610e-2a8e-8207" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
-                <infoLink id="85d5-db48-4e97-d1df" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
-                <infoLink id="2b8a-7a11-84ac-b064" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="148.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="bfe0-8281-1337-e4dc" name="Beastman Crew" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17ba-4a29-e6fb-18d9" type="max"/>
@@ -2690,32 +2496,6 @@
               </constraints>
               <infoLinks>
                 <infoLink id="1af3-c315-4ed9-1215" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="b997-7652-441a-56c9" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="d642-1258-620b-888d">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a5f-f8eb-5865-b707" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ac6-a3cf-7301-1ced" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="d642-1258-620b-888d" name="Swords" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1627-080c-f6bb-08e6" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e47e-9adb-c20e-9276" name="Axes" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="76cd-258c-4b20-51d5" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -3049,7 +2829,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough 1, Fast 8, 3xHTH, Wound 1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough 1, Fast 8, 3xHtH, Wound 1</characteristic>
       </characteristics>
     </profile>
     <profile id="f925-b5ec-1c26-1a44" name="Minotaur Lord" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3060,7 +2840,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">8(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough, 3xHTH, Frenzied Charge, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough, 3xHtH, Frenzied Charge, Wound</characteristic>
       </characteristics>
     </profile>
     <profile id="3816-9908-3b1e-099d" name="Beastman Guard Leader in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3159,7 +2939,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">8</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough, 2xHTH, Frenzied Charge</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough, 2xHtH, Frenzied Charge</characteristic>
       </characteristics>
     </profile>
     <profile id="1178-6657-496d-0cbb" name="Minotaurs" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3170,7 +2950,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">8</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 2xHTH, Frenzied Charge</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 2xHtH, Frenzied Charge</characteristic>
       </characteristics>
     </profile>
     <profile id="b590-eb52-39a5-587a" name="Beast Hounds" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3203,7 +2983,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Large, Fast 8, 2xHTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Large, Fast 8, 2xHtH</characteristic>
       </characteristics>
     </profile>
     <profile id="7eb3-d387-0418-5b77" name="Centaur" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3214,7 +2994,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Fast 8, 2xHTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Fast 8, 2xHtH</characteristic>
       </characteristics>
     </profile>
     <profile id="4077-f4ee-bc64-edc2" name="Harpies with Rocks" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3225,7 +3005,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">9</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Flies, Fast 10, 2xHTH SV1, 1xDrops SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Flies, Fast 10, 2xHtH SV1, 1xDrops SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="c020-9bee-5d3d-95d8" name="Beastman Crew with Bolt Throwing Engine" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3247,7 +3027,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 3xHTH, Wound X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="6a05-94e9-fca8-0453" name="Beastman Bodyguard" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3280,7 +3060,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[6(8)]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, Follow, 3xHTH, [Wound X], [on foot]</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, Follow, 3xHtH, [Wound X], [on foot]</characteristic>
       </characteristics>
     </profile>
     <profile id="d909-19ba-d47c-1b22" name="Beastman Crew (in chariot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3302,7 +3082,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHTH SV3</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHtH SV3</characteristic>
       </characteristics>
     </profile>
     <profile id="3f6d-528f-fde9-a9f7" name="Chariot Scythes" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
@@ -3341,7 +3121,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">3</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Spirit, 1xHTH SV1, Exchange of Missiles SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Spirit, 1xHtH SV1, Exchange of Missiles SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="8843-47cf-79c0-7804" name="Chariot with Shaman and crew, pulled by wild boars" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3385,7 +3165,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">8(10)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough, 3xHTH, Frenzied Charge, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough, 3xHtH, Frenzied Charge, Wound</characteristic>
       </characteristics>
     </profile>
     <profile id="b716-323f-83aa-625b" name="Beastman Guard Leader in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3473,7 +3253,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Fast 8, 2xHTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Fast 8, 2xHtH</characteristic>
       </characteristics>
     </profile>
     <profile id="3e56-4168-7915-9d24" name="Centaur in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3484,7 +3264,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Fast 8, 2xHTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Fast 8, 2xHtH</characteristic>
       </characteristics>
     </profile>
     <profile id="db21-8112-39c9-2559" name="Centaur Champion in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3495,7 +3275,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Large, Fast 8, 2xHTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Large, Fast 8, 2xHtH</characteristic>
       </characteristics>
     </profile>
     <profile id="3a20-859a-0d11-147e" name="Centaur Champion in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3506,7 +3286,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Large, Fast 8, 2xHTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Large, Fast 8, 2xHtH</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Beastmen.cat
+++ b/Beastmen.cat
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue id="495c-99bf-3793-41ba" name="Beastmen" revision="3" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="c9f0-8ebd-86ff-209f" name="Shaman" hidden="false">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5f5-aa0c-4fd3-3c13" type="max"/>
+      </constraints>
+    </categoryEntry>
+  </categoryEntries>
   <entryLinks>
     <entryLink id="d341-7808-1528-80dd" name="Centaur Lord" hidden="false" collective="false" targetId="eebd-c5bd-500d-1128" type="selectionEntry"/>
     <entryLink id="5920-ac53-718c-9dba" name="Minotaur Lord" hidden="false" collective="false" targetId="ec37-7732-2e11-9c4a" type="selectionEntry"/>
@@ -19,6 +26,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="eebd-c5bd-500d-1128" name="Centaur Lord" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f421-0714-a6ab-69fe" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="560e-175e-30ee-8a1d" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -33,11 +43,11 @@
             <infoLink id="6fc2-d7b7-367e-7745" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
             <infoLink id="533e-28ed-f413-c3e0" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
             <infoLink id="8537-1b65-a6e3-3ece" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
-            <infoLink id="192d-9f49-acc8-9650" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+            <infoLink id="6e28-fff1-a065-e09d" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -54,7 +64,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8191-ed28-15fe-4939" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -63,7 +73,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6639-f58f-fd9e-7f95" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -72,7 +82,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3ad5-73f4-2cb9-4d5e" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -81,7 +91,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -97,49 +107,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="257e-5776-82de-edaf" name="Ranged Magic Weapons" hidden="false" collective="false" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="9355-da24-4481-052d" name="Ranged Magic Weapons" hidden="false" collective="false" defaultSelectionEntryId="cd2f-2ee1-9c8d-ae90">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f0e-89f7-196d-9cc5" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="694f-9178-ba80-1c27" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="4c12-23f0-2485-b756" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="cd2f-2ee1-9c8d-ae90" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="928e-7d21-0d8c-1b15" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="8b86-33bb-680c-9377" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="de5b-944e-0ef8-d81b" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -155,7 +123,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -166,9 +134,12 @@
           </constraints>
           <selectionEntries>
             <selectionEntry id="9c7f-08a9-b243-14e7" name="Savage" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="4a56-e3c8-bce1-e215" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -184,7 +155,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="245c-597b-ebbd-8c79" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -193,7 +164,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d31-1b9e-ac37-0383" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -202,7 +173,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5c86-96d7-7226-1844" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -211,7 +182,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c810-20ff-6395-e97a" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -220,7 +191,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8e23-0119-f5d3-cc26" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -229,7 +200,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5170-b6f8-9436-2430" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -238,7 +209,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -246,7 +217,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="52.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ec37-7732-2e11-9c4a" name="Minotaur Lord" hidden="false" collective="false" type="unit">
@@ -280,7 +251,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="66.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -288,7 +259,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a85b-bdd1-8049-ff8f" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -308,7 +279,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="76.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -316,7 +287,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -333,7 +304,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5f1-c16f-0aa0-a683" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -342,7 +313,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0900-d64c-d274-edfe" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -351,7 +322,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30f8-d758-a278-36b2" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -360,7 +331,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78a8-4b52-3b32-77fc" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -369,7 +340,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="069e-7f63-a7be-ca08" name="Bloomin Big Axe" hidden="false" collective="false" type="upgrade">
@@ -378,85 +349,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1987-f299-6bb6-28ad" name="Magic Weapon" hidden="false" collective="false" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="f78d-e19e-ab59-685b" name="Magic Weapon " hidden="false" collective="false">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4c9-06e4-7942-d2ba" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="0049-ab00-2599-aeab" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="cc39-6f14-5ece-e880" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="b73d-2764-cbef-b258" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="cd73-b167-9983-fdca" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="c538-7361-eb84-68f9" name="War Bringer" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="e7cc-6961-8ccb-294f" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="3df2-58f8-0243-3aed" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="be53-03de-1971-274b" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="72d1-d8bf-ac8e-2044" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="6b5d-446d-dca0-dc97" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="fc8b-eb76-8231-90b2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="d659-7836-4981-d799" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="588c-7afc-75d7-459b" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="95fb-fbf9-e2c4-65df" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -473,7 +366,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b558-c63a-65e4-b13e" name="Irresistible Charge" hidden="false" collective="false" type="upgrade">
@@ -482,7 +375,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -498,7 +391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -506,12 +399,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a878-9926-c79b-52f9" name="Beastman Guard" hidden="false" collective="false" type="unit">
       <categoryLinks>
         <categoryLink id="d512-74a1-8db4-8b9d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
+        <categoryLink id="1226-e7f5-7ba8-6ffc" name="Guard Unit" hidden="false" targetId="af51-60b9-09ce-ed3f" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="4464-843a-9de1-11c0" name="Models" hidden="false" collective="false" defaultSelectionEntryId="c6c7-b1cd-9bc1-7e56">
@@ -534,7 +428,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="91a7-c477-55e2-ca33" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -548,7 +442,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -556,7 +450,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="123c-8f08-a41b-a4d9" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -573,7 +467,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="dc2c-1804-1e25-0ec4" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -587,7 +481,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -595,7 +489,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -612,7 +506,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="426b-f70f-042c-454a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -621,7 +515,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18f3-c91c-b03b-bf0e" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -630,7 +524,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a1f6-3522-9eea-fe6d" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -646,7 +540,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="671b-8e4c-0a6a-f24f" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -655,7 +549,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -678,7 +572,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -686,7 +580,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="09df-5d39-3dd7-ebd4" name="Beastman Warriors" hidden="false" collective="false" type="unit">
@@ -714,7 +608,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e340-d92c-e18b-dea6" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -728,7 +622,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -736,7 +630,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4e0a-2fb3-0822-21c8" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -753,7 +647,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8126-4076-bd74-ccab" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -767,7 +661,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -775,7 +669,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -792,7 +686,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="611d-26f9-0216-a406" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -801,7 +695,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5682-4851-d858-93e4" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -810,7 +704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b1c7-0ba8-9d8d-afc2" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -826,7 +720,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="caf0-ac47-d61c-a87e" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -835,7 +729,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -858,7 +752,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -866,7 +760,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8306-d0be-5ab8-5c90" name="Low Beastman Warriors" hidden="false" collective="false" type="unit">
@@ -894,7 +788,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0ffc-c050-5c94-8614" name="Low Beastman Warrior Leader" hidden="false" collective="false" type="model">
@@ -908,7 +802,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -916,7 +810,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2625-0cb2-db95-f8f5" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -933,7 +827,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1521-d702-cafa-92cd" name="Low Beastman Warrior Leader" hidden="false" collective="false" type="model">
@@ -947,7 +841,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -955,7 +849,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -979,7 +873,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1464-a592-9f11-5c94" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -995,7 +889,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30e3-95ee-424d-463a" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1011,7 +905,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebd3-7c54-caea-c0f7" name="Clubs" hidden="false" collective="false" type="upgrade">
@@ -1020,7 +914,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1028,7 +922,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="48b1-55f2-458e-7da3" name="Low Beastman Archers" hidden="false" collective="false" type="unit">
@@ -1046,7 +940,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1064,7 +958,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5b7-faa2-99aa-cc48" name="Low Beastman Archer" hidden="false" collective="false" type="model">
@@ -1077,7 +971,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1101,7 +995,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="09fa-14dd-6651-f785" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1117,7 +1011,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88ad-2da9-7dab-e3da" name="Clubs" hidden="false" collective="false" type="upgrade">
@@ -1126,7 +1020,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1134,7 +1028,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="229d-a488-92e7-b61c" name="Minotaurs" hidden="false" collective="false" type="unit">
@@ -1155,7 +1049,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88a5-d308-2eed-67dd" name="Minotaur Champion" hidden="false" collective="false" type="model">
@@ -1170,7 +1064,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1187,7 +1081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89d4-b366-5c21-5532" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1196,7 +1090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="887a-7031-a813-625f" name="Bloomin Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1212,7 +1106,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1229,7 +1123,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9864-7e05-45d1-df5b" name="Irresistible Charge" hidden="false" collective="false" type="upgrade">
@@ -1245,7 +1139,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1253,12 +1147,12 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="99f4-211b-3162-038d" name="Beast Hounds" hidden="false" collective="false" type="unit">
       <categoryLinks>
-        <categoryLink id="fb3f-a4ba-fcc1-9771" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
+        <categoryLink id="fb3f-a4ba-fcc1-9771" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="false"/>
         <categoryLink id="e7d4-f5c6-295a-47a7" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
@@ -1276,7 +1170,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1285,7 +1179,7 @@
           <selectionEntries>
             <selectionEntry id="d1ef-f68b-02fb-9b3d" name="Dog Breath (Gives Beast Hounds Choking Attacks)" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="99f4-211b-3162-038d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -1294,9 +1188,12 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="717d-3889-6abc-c104" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="5c0d-e61e-89c5-fe1e" name="Choking" hidden="false" targetId="7ff2-1650-fc0e-5a3a" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1313,7 +1210,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9883-770c-0e26-69f9" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1322,7 +1219,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1349,7 +1246,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1357,7 +1254,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="43ac-cc6b-b21b-7d80" name="Pack Master in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1376,7 +1273,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1384,7 +1281,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1392,10 +1289,18 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e6ed-5b98-5c6a-7096" name="Centaurs" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5eca-affd-7bda-0fb3" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="38a9-2bcb-8bb5-6d87" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="5d44-5489-d839-8fea" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="35f1-bfd2-2aba-5b64" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="dd9a-2934-8da9-aade" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -1420,7 +1325,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b2de-1d26-3518-f6f0" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -1434,7 +1339,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="44.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1442,7 +1347,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2064-340b-bfba-e4c0" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1459,7 +1364,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6ffa-4ea8-4436-941e" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -1473,7 +1378,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="46.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1481,7 +1386,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0a42-7c7f-0e0e-ad1c" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1498,7 +1403,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="36.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9dba-b719-22a8-18dc" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -1512,7 +1417,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="48.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1520,7 +1425,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1537,7 +1442,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="21b9-5061-e069-c829" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -1553,7 +1458,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf7e-df25-d805-31dc" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1569,7 +1474,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c94e-d5ef-a2f4-42e3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1585,7 +1490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4832-7fa7-cf23-be91" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -1601,7 +1506,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1624,7 +1529,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1640,7 +1545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1648,10 +1553,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="18b6-72e8-624b-489a" name="Harpies" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d273-9341-bb49-0329" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="4f86-0b14-d18e-3e21" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1667,10 +1575,11 @@
                 <infoLink id="a057-7384-14ba-acc9" name="Harpies with Rocks" hidden="false" targetId="4077-f4ee-bc64-edc2" type="profile"/>
                 <infoLink id="8b58-5715-5739-9ac0" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
                 <infoLink id="552b-12a8-4e7f-6c12" name="Rocks (HTH)" hidden="false" targetId="88d0-6821-ceff-0382" type="profile"/>
+                <infoLink id="a4ac-0f11-b096-2856" name="Fast 10" hidden="false" targetId="0034-82ae-f695-d446" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1686,7 +1595,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1709,7 +1618,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1717,7 +1626,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="67f5-eb29-60ba-e402" name="Beastman Bolt Thrower" hidden="false" collective="false" type="unit">
@@ -1732,12 +1641,9 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e08d-c8e8-c671-4ece" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b23-7364-b320-00ac" type="min"/>
               </constraints>
-              <infoLinks>
-                <infoLink id="0864-1c83-a279-a0e0" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bbc-ff85-f34f-c7fb" name="Beastman Crew" hidden="false" collective="false" type="model">
@@ -1747,10 +1653,12 @@
               </constraints>
               <infoLinks>
                 <infoLink id="c8a5-f595-13db-2242" name="Beastman Bolt Thrower" hidden="false" targetId="c020-9bee-5d3d-95d8" type="profile"/>
+                <infoLink id="990a-8833-5c6a-1603" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+                <infoLink id="0e2e-ba3d-c80d-b11a" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1767,7 +1675,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e981-6fa8-87ab-99d4" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1776,7 +1684,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1793,7 +1701,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3995-525a-7cc0-9494" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -1802,7 +1710,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1810,7 +1718,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8605-371b-3b15-4600" name="Beastman Chieftain" hidden="false" collective="false" type="unit">
@@ -1829,10 +1737,11 @@
               <infoLinks>
                 <infoLink id="24de-16dc-bf85-a76a" name="Beastman Chieftain (on foot)" hidden="false" targetId="4f79-4003-209e-db8c" type="profile"/>
                 <infoLink id="10c5-768a-0dbc-f978" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+                <infoLink id="7dfe-d1b9-c81e-4184" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="80.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="994f-b68f-0164-d6a3" name="Beastman Bodyguard" hidden="false" collective="false" type="model">
@@ -1845,7 +1754,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1862,7 +1771,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90d8-bd28-17a1-8ba1" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1871,7 +1780,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="70a9-d90a-0657-cb1e" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -1880,7 +1789,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c77a-5258-0c60-eb7d" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1889,7 +1798,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1906,7 +1815,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3241-012a-1440-e53d" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1915,7 +1824,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b42-ca29-f289-f3b5" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1924,7 +1833,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1941,7 +1850,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a281-bfd7-9d59-ef5d" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1950,7 +1859,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1974,7 +1883,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1990,7 +1899,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7258-496c-012b-4adb" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1999,7 +1908,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0db0-83a8-347d-8543" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2008,7 +1917,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8659-a62f-9569-8fa4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2017,7 +1926,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="24aa-5ea6-22d4-db99" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2026,7 +1935,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cff6-6dea-13bb-acd2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2035,7 +1944,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="20ae-e372-6022-2cfc" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2044,7 +1953,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2052,7 +1961,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0fe7-f569-45ac-b1df" name="Beastman Chieftain in Chariot" hidden="false" collective="false" type="unit">
@@ -2073,7 +1982,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="631f-5c61-c79f-9d93" name="Beastman Chieftain" hidden="false" collective="false" type="model">
@@ -2082,13 +1991,13 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4aa-3d0b-6f6b-40a1" type="min"/>
               </constraints>
               <infoLinks>
-                <infoLink id="37b1-c104-30fa-0316" name="Beastman Chieftain (in chariot)" hidden="false" targetId="c0ba-8436-9fc7-45eb" type="profile"/>
+                <infoLink id="37b1-c104-30fa-0316" name="Beastman Chieftain" hidden="false" targetId="c0ba-8436-9fc7-45eb" type="profile"/>
                 <infoLink id="4e7e-db03-9386-0cee" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
                 <infoLink id="8045-92fd-78d8-b73d" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="166.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d794-06af-fcfc-3fe5" name="Chariot" hidden="false" collective="false" type="upgrade">
@@ -2102,10 +2011,11 @@
                 <infoLink id="e611-2480-f2d1-8134" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                 <infoLink id="5999-356b-af7f-b86c" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
                 <infoLink id="971b-428e-eda8-5308" name="Wild Boars (Chariot)" hidden="false" targetId="dc8c-e7aa-91a4-873e" type="profile"/>
+                <infoLink id="f205-7bc7-b833-693b" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2122,7 +2032,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff4c-410f-1334-001a" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -2131,7 +2041,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c6aa-12d4-1f9b-239e" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -2140,7 +2050,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7fb5-7476-d2df-8b81" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -2149,7 +2059,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2166,7 +2076,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8a43-3db2-f216-b65c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2175,7 +2085,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d0f-b441-03e5-b9cb" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -2184,7 +2094,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2200,7 +2110,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2217,7 +2127,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29ef-7b9c-9f4b-53f6" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2226,7 +2136,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2250,7 +2160,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2266,7 +2176,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f859-065a-1b0d-36d1" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2275,7 +2185,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6866-8134-56e2-9b4f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2284,7 +2194,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02ff-462c-7bd4-dda9" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2293,7 +2203,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="60f7-3d48-d995-aaad" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2302,7 +2212,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6bf-a7f6-ab86-954e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2311,7 +2221,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7632-c3c1-d859-b9fa" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2320,7 +2230,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2328,13 +2238,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f4ae-d5fd-7d7d-7001" name="Beastman Shaman" hidden="false" collective="false" type="unit">
       <categoryLinks>
-        <categoryLink id="9d24-e284-748b-6b9a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
-        <categoryLink id="8dc7-00dc-1b07-78e1" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
+        <categoryLink id="9d24-e284-748b-6b9a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
+        <categoryLink id="e37f-81b0-5fce-4471" name="Shaman" hidden="false" targetId="c9f0-8ebd-86ff-209f" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ce4d-4970-bf78-b93d" name="Models" hidden="false" collective="false">
@@ -2351,7 +2261,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2365,19 +2275,19 @@
             <selectionEntry id="0a1a-8204-4493-83f9" name="Magic Level 1" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c26f-75e3-6fba-f6ba" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de6e-06c7-8cc9-fe80" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2400,7 +2310,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2430,13 +2340,13 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="13.0"/>
-                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                            <cost name=" order dice" typeId="orderDice" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d908-3a05-3a53-2198" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2451,13 +2361,13 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="15.0"/>
-                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                            <cost name=" order dice" typeId="orderDice" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2465,7 +2375,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6d39-0600-70c9-0078" name="Spirit Guide or Familiar" hidden="false" collective="false" type="upgrade">
@@ -2482,7 +2392,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2490,7 +2400,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2506,7 +2416,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dc26-4813-9f27-2cb6" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2518,7 +2428,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee12-1783-a93d-3c9e" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2530,7 +2440,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5934-e2cb-9775-cb90" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2542,7 +2452,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed09-ac42-8f78-3b4b" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2554,7 +2464,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0654-7129-936f-cb5f" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2566,7 +2476,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a141-1e19-e7dc-23ea" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2578,7 +2488,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fced-a0e1-eec9-6ef8" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2590,7 +2500,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="92bc-4c47-f81f-142f" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2602,7 +2512,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b829-9a59-07c3-4ec3" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2614,7 +2524,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91fe-a6d8-45c9-4bbd" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2626,7 +2536,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b32-0d70-0c5b-598c" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2638,7 +2548,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a13a-fcaa-35e0-a128" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2650,7 +2560,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e28c-8fd7-1cb3-6fbc" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2662,7 +2572,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2679,7 +2589,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d99-5a52-b681-233c" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2688,7 +2598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="871a-e506-76da-f7b3" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2697,7 +2607,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c84-6172-7bb8-e63b" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2706,7 +2616,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="441a-3676-3700-6364" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2715,7 +2625,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fff7-9886-42bf-7f53" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2724,7 +2634,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d0c8-da64-786f-eced" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2733,7 +2643,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6600-b242-d0d4-dd19" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2742,7 +2652,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="604d-9f2d-2d7d-87d6" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2751,7 +2661,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af35-89ba-8b23-de5f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2760,7 +2670,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7f0f-5247-026c-6a9a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2769,7 +2679,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="40c8-3e5d-6acf-d17b" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2778,7 +2688,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="512a-1df6-69a3-c735" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2787,7 +2697,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0996-90b0-3594-8553" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2796,7 +2706,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2812,7 +2722,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="984a-ffd3-3276-758f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2821,7 +2731,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8c19-03ce-0e96-c8c7" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2830,7 +2740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8676-f3bc-3f23-528e" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2839,7 +2749,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="deac-b18e-64b1-cb60" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2848,7 +2758,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9acc-6cfe-a338-613e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2857,7 +2767,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed9e-c016-78f4-80f4" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2866,7 +2776,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2874,13 +2784,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f46f-c1d1-3df5-62dc" name="Beastman Shaman in Chariot" hidden="false" collective="false" type="unit">
       <categoryLinks>
-        <categoryLink id="15dd-1f9d-5f63-9f54" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
-        <categoryLink id="3286-24eb-7a25-19e2" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
+        <categoryLink id="15dd-1f9d-5f63-9f54" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
+        <categoryLink id="80fb-b33f-7eba-01e4" name="Shaman" hidden="false" targetId="c9f0-8ebd-86ff-209f" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="d8ff-f1ad-6edd-0916" name="Models" hidden="false" collective="false">
@@ -2895,14 +2805,14 @@
                 <infoLink id="f522-e27e-f839-a4ea" name="Chariot with Shaman and crew, pulled by wild boars" hidden="false" targetId="8843-47cf-79c0-7804" type="profile"/>
                 <infoLink id="17f4-0ba3-6604-2f76" name="Wild Boars (Chariot)" hidden="false" targetId="dc8c-e7aa-91a4-873e" type="profile"/>
                 <infoLink id="ed1e-92e0-4009-adc8" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="0566-d567-25fe-ba34" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+                <infoLink id="0566-d567-25fe-ba34" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                 <infoLink id="51f1-610e-2a8e-8207" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
-                <infoLink id="e9f5-979f-792a-d0fe" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                <infoLink id="85d5-db48-4e97-d1df" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+                <infoLink id="85d5-db48-4e97-d1df" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+                <infoLink id="2b8a-7a11-84ac-b064" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="148.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bfe0-8281-1337-e4dc" name="Beastman Crew" hidden="false" collective="false" type="model">
@@ -2915,7 +2825,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2929,19 +2839,19 @@
             <selectionEntry id="fbcb-9050-e962-5e4a" name="Magic Level 1" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d432-ae84-9d12-5a0a" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d3fd-047d-dc28-2605" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2957,7 +2867,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2966,7 +2876,7 @@
           <selectionEntries>
             <selectionEntry id="2d50-bbd9-c0b7-38aa" name="Savage" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="f46f-c1d1-3df5-62dc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -2975,9 +2885,12 @@
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="618c-b785-1114-a121" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="1af3-c315-4ed9-1215" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2994,7 +2907,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e47e-9adb-c20e-9276" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -3003,27 +2916,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="5afa-8fcc-c02c-a4d2" name="Spells" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="c7a7-0884-577b-29a7" name="Free Spell" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ce5-9fe8-4917-1a21" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3c0-6e10-5f72-6f71" type="min"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f08c-0970-935e-33ba" name="Additional Spell" hidden="false" collective="false" type="upgrade">
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3040,7 +2933,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7324-ffce-42e5-c07c" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -3049,7 +2942,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="830c-dba6-2cc8-aa3a" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -3058,7 +2951,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ecd-d085-25cf-1775" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -3067,7 +2960,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af0e-bfb5-a111-1912" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -3076,7 +2969,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa46-5a1e-34d6-ad31" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -3085,7 +2978,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1885-1784-05c7-7c8b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -3094,7 +2987,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6b1-9828-8546-4a87" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -3103,7 +2996,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="baaf-4802-dbab-fc40" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -3112,7 +3005,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a5d-15f5-d1a7-a7e9" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -3121,7 +3014,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df5d-34a3-8e11-1360" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -3130,7 +3023,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c21a-25dc-07e0-65d4" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -3139,7 +3032,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e83-c4b7-9e10-95c7" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -3148,7 +3041,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5559-9de3-e1b9-49db" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -3157,7 +3050,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3173,7 +3066,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c4f-4465-f076-487a" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -3185,7 +3078,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0204-e123-2de6-f650" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -3197,7 +3090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d54f-916f-0314-5449" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -3209,7 +3102,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c80-1b2e-21e2-c730" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -3221,7 +3114,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e7e9-8499-3de9-848e" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -3233,7 +3126,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="85c1-cbd6-fc72-4416" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -3245,7 +3138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b438-6732-2255-08ec" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -3257,7 +3150,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9d1e-2d68-a1de-0b92" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -3269,7 +3162,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73c1-9a09-134f-383c" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -3281,7 +3174,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e07-bae3-f2e0-e767" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -3293,7 +3186,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e793-f567-f39f-9780" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -3305,7 +3198,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="76b0-bfce-578b-0169" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -3317,7 +3210,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c213-1e50-9ed0-05d3" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -3329,7 +3222,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3345,7 +3238,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f92f-be44-041a-4db7" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -3354,7 +3247,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b051-3351-9086-002f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -3363,7 +3256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5770-6d44-04fd-f4ce" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -3372,7 +3265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="002e-afe1-43e4-8f95" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -3381,7 +3274,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b09c-db48-6ae6-40c0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -3390,7 +3283,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="49d3-94d1-217d-8a78" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -3399,7 +3292,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3407,7 +3300,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -3690,7 +3583,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Wound, Magic Level X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Wound 1, Magic Level X</characteristic>
       </characteristics>
     </profile>
     <profile id="1596-f4ee-96a9-7aa6" name="Beastman Shamanic Cultists" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3734,7 +3627,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[6]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough], [Wound], Magic Level X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough 1], [Wound 1], Magic Level X</characteristic>
       </characteristics>
     </profile>
     <profile id="950c-38fa-a240-7625" name="Shamanic Cultists in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">

--- a/Beastmen.cat
+++ b/Beastmen.cat
@@ -3313,7 +3313,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough, Fast 8, 3xHTH, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough 1, Fast 8, 3xHTH, Wound 1</characteristic>
       </characteristics>
     </profile>
     <profile id="f925-b5ec-1c26-1a44" name="Minotaur Lord" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3335,7 +3335,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="12fe-e30e-e2ab-4863" name="Beastman Guard in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3467,7 +3467,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Large, Fast 8, 2xHTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Large, Fast 8, 2xHTH</characteristic>
       </characteristics>
     </profile>
     <profile id="7eb3-d387-0418-5b77" name="Centaur" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3492,7 +3492,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Flies, Fast 10, 2xHTH SV1, 1xDrops SV1</characteristic>
       </characteristics>
     </profile>
-    <profile id="c020-9bee-5d3d-95d8" name="Beastman Crew with bolt throwing engine" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="c020-9bee-5d3d-95d8" name="Beastman Crew with Bolt Throwing Engine" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3511,7 +3511,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Command, 3xHTH, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 3xHTH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="6a05-94e9-fca8-0453" name="Beastman Bodyguard" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3536,7 +3536,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough, Fast 6, Irresistible Charge</characteristic>
       </characteristics>
     </profile>
-    <profile id="c0ba-8436-9fc7-45eb" name="Beastman Chieftain" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="c0ba-8436-9fc7-45eb" name="Beastman Chieftain riding chariot" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">[5]</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">[4]</characteristic>
@@ -3544,7 +3544,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[6(8)]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough], Command, Follow, 3xHTH, [Wound]</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, Follow, 3xHTH, [Wound X], [on foot]</characteristic>
       </characteristics>
     </profile>
     <profile id="d909-19ba-d47c-1b22" name="Beastman Crew (in chariot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3660,7 +3660,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="074a-a320-6def-11ae" name="Beastman Guard in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3682,7 +3682,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="b1de-b513-c301-85f1" name="Beastman Warrior in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3759,7 +3759,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Large, Fast 8, 2xHTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Large, Fast 8, 2xHTH</characteristic>
       </characteristics>
     </profile>
     <profile id="3a20-859a-0d11-147e" name="Centaur Champion in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3770,7 +3770,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Large, Fast 8, 2xHTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Large, Fast 8, 2xHTH</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Beastmen.cat
+++ b/Beastmen.cat
@@ -784,7 +784,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="b88a-3519-8f20-43d1" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="b88a-3519-8f20-43d1" name="axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>

--- a/Beastmen.cat
+++ b/Beastmen.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="495c-99bf-3793-41ba" name="Beastmen" revision="1" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="495c-99bf-3793-41ba" name="Beastmen" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d341-7808-1528-80dd" name="Centaur Lord" hidden="false" collective="false" targetId="eebd-c5bd-500d-1128" type="selectionEntry"/>
     <entryLink id="5920-ac53-718c-9dba" name="Minotaur Lord" hidden="false" collective="false" targetId="ec37-7732-2e11-9c4a" type="selectionEntry"/>
@@ -19,6 +19,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="eebd-c5bd-500d-1128" name="Centaur Lord" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="560e-175e-30ee-8a1d" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -37,6 +40,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -53,6 +57,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8191-ed28-15fe-4939" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -61,6 +66,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6639-f58f-fd9e-7f95" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -69,6 +75,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3ad5-73f4-2cb9-4d5e" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -77,6 +84,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -92,6 +100,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="257e-5776-82de-edaf" name="Ranged Magic Weapons" hidden="false" collective="false" type="upgrade">
@@ -107,6 +116,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="cd2f-2ee1-9c8d-ae90" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -115,6 +125,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8b86-33bb-680c-9377" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -123,6 +134,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -130,6 +142,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -145,6 +158,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -157,6 +171,7 @@
             <selectionEntry id="9c7f-08a9-b243-14e7" name="Savage" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -172,6 +187,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="245c-597b-ebbd-8c79" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -180,6 +196,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d31-1b9e-ac37-0383" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -188,6 +205,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5c86-96d7-7226-1844" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -196,6 +214,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c810-20ff-6395-e97a" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -204,6 +223,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8e23-0119-f5d3-cc26" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -212,6 +232,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5170-b6f8-9436-2430" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -220,6 +241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -227,9 +249,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="52.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ec37-7732-2e11-9c4a" name="Minotaur Lord" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc22-bd2b-b3b7-2331" type="max"/>
       </constraints>
@@ -260,6 +286,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="66.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -267,6 +294,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a85b-bdd1-8049-ff8f" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -286,6 +314,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="76.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -293,6 +322,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -309,6 +339,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5f1-c16f-0aa0-a683" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -317,6 +348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0900-d64c-d274-edfe" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -325,6 +357,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30f8-d758-a278-36b2" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -333,6 +366,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78a8-4b52-3b32-77fc" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -341,6 +375,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="069e-7f63-a7be-ca08" name="Bloomin Big Axe" hidden="false" collective="false" type="upgrade">
@@ -349,6 +384,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1987-f299-6bb6-28ad" name="Magic Weapon" hidden="false" collective="false" type="upgrade">
@@ -364,6 +400,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b73d-2764-cbef-b258" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -372,6 +409,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c538-7361-eb84-68f9" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -380,6 +418,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3df2-58f8-0243-3aed" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -388,6 +427,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="72d1-d8bf-ac8e-2044" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -396,6 +436,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fc8b-eb76-8231-90b2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -404,6 +445,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="588c-7afc-75d7-459b" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -412,6 +454,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -419,6 +462,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -435,6 +479,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b558-c63a-65e4-b13e" name="Irresistible Charge" hidden="false" collective="false" type="upgrade">
@@ -443,6 +488,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -458,6 +504,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -465,9 +512,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a878-9926-c79b-52f9" name="Beastman Guard" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d512-74a1-8db4-8b9d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -492,6 +543,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="91a7-c477-55e2-ca33" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -505,6 +557,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -512,6 +565,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="123c-8f08-a41b-a4d9" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -528,6 +582,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="dc2c-1804-1e25-0ec4" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -541,6 +596,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -548,6 +604,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -564,6 +621,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="426b-f70f-042c-454a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -572,6 +630,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18f3-c91c-b03b-bf0e" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -580,6 +639,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a1f6-3522-9eea-fe6d" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -595,6 +655,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="671b-8e4c-0a6a-f24f" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -603,6 +664,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -625,6 +687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -632,9 +695,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="09df-5d39-3dd7-ebd4" name="Beastman Warriors" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="079c-502a-44fe-2257" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -659,6 +726,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e340-d92c-e18b-dea6" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -672,6 +740,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -679,6 +748,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4e0a-2fb3-0822-21c8" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -695,6 +765,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8126-4076-bd74-ccab" name="Beastman Leader" hidden="false" collective="false" type="model">
@@ -708,6 +779,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -715,6 +787,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -731,6 +804,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="611d-26f9-0216-a406" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -739,6 +813,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5682-4851-d858-93e4" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -747,6 +822,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b1c7-0ba8-9d8d-afc2" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -762,6 +838,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="caf0-ac47-d61c-a87e" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -770,6 +847,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -792,6 +870,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -799,9 +878,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8306-d0be-5ab8-5c90" name="Low Beastman Warriors" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="8cd2-d288-bd09-9bb2" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -826,6 +909,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0ffc-c050-5c94-8614" name="Low Beastman Warrior Leader" hidden="false" collective="false" type="model">
@@ -839,6 +923,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -846,6 +931,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2625-0cb2-db95-f8f5" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -862,6 +948,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1521-d702-cafa-92cd" name="Low Beastman Warrior Leader" hidden="false" collective="false" type="model">
@@ -875,6 +962,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -882,6 +970,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -905,6 +994,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1464-a592-9f11-5c94" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -920,6 +1010,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30e3-95ee-424d-463a" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -935,6 +1026,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebd3-7c54-caea-c0f7" name="Clubs" hidden="false" collective="false" type="upgrade">
@@ -943,6 +1035,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -950,9 +1043,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="48b1-55f2-458e-7da3" name="Low Beastman Archers" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="88b3-9f1e-e217-d3d9" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -967,6 +1064,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -984,6 +1082,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5b7-faa2-99aa-cc48" name="Low Beastman Archer" hidden="false" collective="false" type="model">
@@ -996,6 +1095,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1019,6 +1119,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="09fa-14dd-6651-f785" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1034,6 +1135,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88ad-2da9-7dab-e3da" name="Clubs" hidden="false" collective="false" type="upgrade">
@@ -1042,6 +1144,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1049,9 +1152,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="229d-a488-92e7-b61c" name="Minotaurs" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="aff1-bead-b023-5d06" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -1069,6 +1176,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88a5-d308-2eed-67dd" name="Minotaur Champion" hidden="false" collective="false" type="model">
@@ -1083,6 +1191,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1099,6 +1208,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89d4-b366-5c21-5532" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1107,6 +1217,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="887a-7031-a813-625f" name="Bloomin Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1122,6 +1233,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1138,6 +1250,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9864-7e05-45d1-df5b" name="Irresistible Charge" hidden="false" collective="false" type="upgrade">
@@ -1153,6 +1266,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1160,9 +1274,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="99f4-211b-3162-038d" name="Beast Hounds" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="fb3f-a4ba-fcc1-9771" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
         <categoryLink id="e7d4-f5c6-295a-47a7" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1178,10 +1296,11 @@
               <infoLinks>
                 <infoLink id="8bb4-9512-9fb2-6515" name="Beast Hounds" hidden="false" targetId="b590-eb52-39a5-587a" type="profile"/>
                 <infoLink id="57cc-d2e7-e549-07fe" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
-                <infoLink id="a47c-57f8-31ef-3cd9" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                <infoLink id="a47c-57f8-31ef-3cd9" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1201,6 +1320,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1217,6 +1337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9883-770c-0e26-69f9" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1225,6 +1346,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1247,10 +1369,11 @@
                       <infoLinks>
                         <infoLink id="b5ba-1655-3a2e-3de7" name="Pack Master" hidden="false" targetId="1d03-5868-0a88-efa4" type="profile"/>
                         <infoLink id="9b78-894f-0c27-0dc0" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                        <infoLink id="b401-8789-f7db-ddc8" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                        <infoLink id="b401-8789-f7db-ddc8" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1258,6 +1381,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="43ac-cc6b-b21b-7d80" name="Pack Master in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1272,10 +1396,11 @@
                       <infoLinks>
                         <infoLink id="2807-6214-fa5f-1a5c" name="Pack Master in Medium Armour" hidden="false" targetId="6291-460b-8fd8-be34" type="profile"/>
                         <infoLink id="e5e4-0e06-26d4-f4cf" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                        <infoLink id="794c-407a-976f-09f7" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                        <infoLink id="794c-407a-976f-09f7" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1283,6 +1408,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1290,9 +1416,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e6ed-5b98-5c6a-7096" name="Centaurs" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="dd9a-2934-8da9-aade" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -1317,6 +1447,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b2de-1d26-3518-f6f0" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -1330,6 +1461,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="44.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1337,6 +1469,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2064-340b-bfba-e4c0" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1353,6 +1486,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6ffa-4ea8-4436-941e" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -1366,6 +1500,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="46.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1373,6 +1508,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0a42-7c7f-0e0e-ad1c" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1389,6 +1525,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="36.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9dba-b719-22a8-18dc" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -1402,6 +1539,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="48.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1409,6 +1547,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1425,6 +1564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="21b9-5061-e069-c829" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -1440,6 +1580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf7e-df25-d805-31dc" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1455,6 +1596,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c94e-d5ef-a2f4-42e3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1470,6 +1612,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4832-7fa7-cf23-be91" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -1485,6 +1628,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1507,6 +1651,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1522,6 +1667,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1529,9 +1675,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="18b6-72e8-624b-489a" name="Harpies" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="4f86-0b14-d18e-3e21" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1550,6 +1700,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1565,6 +1716,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1587,6 +1739,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1594,9 +1747,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="67f5-eb29-60ba-e402" name="Beastman Bolt Thrower" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="ff30-a715-e4df-e017" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -1613,6 +1770,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bbc-ff85-f34f-c7fb" name="Beastman Crew" hidden="false" collective="false" type="model">
@@ -1625,6 +1783,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1641,6 +1800,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e981-6fa8-87ab-99d4" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1649,6 +1809,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1665,6 +1826,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3995-525a-7cc0-9494" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -1673,6 +1835,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1680,9 +1843,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8605-371b-3b15-4600" name="Beastman Chieftain" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="a862-20e7-8392-0907" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="ed2a-3bf2-5e2f-04a8" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1701,6 +1868,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="80.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="994f-b68f-0164-d6a3" name="Beastman Bodyguard" hidden="false" collective="false" type="model">
@@ -1713,6 +1881,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1729,6 +1898,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90d8-bd28-17a1-8ba1" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1737,6 +1907,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="70a9-d90a-0657-cb1e" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -1745,6 +1916,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c77a-5258-0c60-eb7d" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1753,6 +1925,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1769,6 +1942,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3241-012a-1440-e53d" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1777,6 +1951,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b42-ca29-f289-f3b5" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1785,6 +1960,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1801,6 +1977,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a281-bfd7-9d59-ef5d" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1809,6 +1986,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1832,6 +2010,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1847,6 +2026,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7258-496c-012b-4adb" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1855,6 +2035,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0db0-83a8-347d-8543" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1863,6 +2044,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8659-a62f-9569-8fa4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1871,6 +2053,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="24aa-5ea6-22d4-db99" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1879,6 +2062,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cff6-6dea-13bb-acd2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1887,6 +2071,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="20ae-e372-6022-2cfc" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1895,6 +2080,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1902,9 +2088,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0fe7-f569-45ac-b1df" name="Beastman Chieftain in Chariot" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="57b3-a1a2-5336-ecff" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="683f-34ff-b931-046e" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
@@ -1922,6 +2112,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="631f-5c61-c79f-9d93" name="Beastman Chieftain" hidden="false" collective="false" type="model">
@@ -1936,6 +2127,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="166.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d794-06af-fcfc-3fe5" name="Chariot" hidden="false" collective="false" type="upgrade">
@@ -1952,6 +2144,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1968,6 +2161,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff4c-410f-1334-001a" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1976,6 +2170,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c6aa-12d4-1f9b-239e" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1984,6 +2179,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7fb5-7476-d2df-8b81" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1992,6 +2188,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2008,6 +2205,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8a43-3db2-f216-b65c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2016,6 +2214,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d0f-b441-03e5-b9cb" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -2024,6 +2223,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2039,6 +2239,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2055,6 +2256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29ef-7b9c-9f4b-53f6" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2063,6 +2265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2086,6 +2289,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2101,6 +2305,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f859-065a-1b0d-36d1" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2109,6 +2314,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6866-8134-56e2-9b4f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2117,6 +2323,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02ff-462c-7bd4-dda9" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2125,6 +2332,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="60f7-3d48-d995-aaad" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2133,6 +2341,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6bf-a7f6-ab86-954e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2141,6 +2350,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7632-c3c1-d859-b9fa" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2149,6 +2359,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2156,9 +2367,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f4ae-d5fd-7d7d-7001" name="Beastman Shaman" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9d24-e284-748b-6b9a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="8dc7-00dc-1b07-78e1" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
@@ -2178,6 +2393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2191,16 +2407,19 @@
             <selectionEntry id="0a1a-8204-4493-83f9" name="Magic Level 1" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c26f-75e3-6fba-f6ba" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de6e-06c7-8cc9-fe80" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2223,6 +2442,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2252,11 +2472,13 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="13.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d908-3a05-3a53-2198" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2271,11 +2493,13 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="15.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2283,6 +2507,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6d39-0600-70c9-0078" name="Spirit Guide or Familiar" hidden="false" collective="false" type="upgrade">
@@ -2299,6 +2524,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2306,6 +2532,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2321,6 +2548,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dc26-4813-9f27-2cb6" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2332,6 +2560,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee12-1783-a93d-3c9e" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2343,6 +2572,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5934-e2cb-9775-cb90" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2354,6 +2584,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed09-ac42-8f78-3b4b" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2365,6 +2596,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0654-7129-936f-cb5f" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2376,6 +2608,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a141-1e19-e7dc-23ea" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2387,6 +2620,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fced-a0e1-eec9-6ef8" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2398,6 +2632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="92bc-4c47-f81f-142f" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2409,6 +2644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b829-9a59-07c3-4ec3" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2420,6 +2656,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91fe-a6d8-45c9-4bbd" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2431,6 +2668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b32-0d70-0c5b-598c" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2442,6 +2680,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a13a-fcaa-35e0-a128" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2453,6 +2692,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e28c-8fd7-1cb3-6fbc" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2464,6 +2704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2480,6 +2721,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d99-5a52-b681-233c" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2488,6 +2730,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="871a-e506-76da-f7b3" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2496,6 +2739,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c84-6172-7bb8-e63b" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2504,6 +2748,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="441a-3676-3700-6364" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2512,6 +2757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fff7-9886-42bf-7f53" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2520,6 +2766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d0c8-da64-786f-eced" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2528,6 +2775,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6600-b242-d0d4-dd19" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2536,6 +2784,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="604d-9f2d-2d7d-87d6" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2544,6 +2793,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af35-89ba-8b23-de5f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2552,6 +2802,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7f0f-5247-026c-6a9a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2560,6 +2811,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="40c8-3e5d-6acf-d17b" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2568,6 +2820,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="512a-1df6-69a3-c735" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2576,6 +2829,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0996-90b0-3594-8553" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2584,6 +2838,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2599,6 +2854,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="984a-ffd3-3276-758f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2607,6 +2863,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8c19-03ce-0e96-c8c7" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2615,6 +2872,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8676-f3bc-3f23-528e" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2623,6 +2881,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="deac-b18e-64b1-cb60" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2631,6 +2890,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9acc-6cfe-a338-613e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2639,6 +2899,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed9e-c016-78f4-80f4" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2647,6 +2908,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2654,9 +2916,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f46f-c1d1-3df5-62dc" name="Beastman Shaman in Chariot" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="15dd-1f9d-5f63-9f54" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
         <categoryLink id="3286-24eb-7a25-19e2" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
@@ -2681,6 +2947,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="148.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bfe0-8281-1337-e4dc" name="Beastman Crew" hidden="false" collective="false" type="model">
@@ -2693,6 +2960,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2706,16 +2974,19 @@
             <selectionEntry id="fbcb-9050-e962-5e4a" name="Magic Level 1" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d432-ae84-9d12-5a0a" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d3fd-047d-dc28-2605" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2731,6 +3002,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2750,6 +3022,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2766,6 +3039,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e47e-9adb-c20e-9276" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -2774,6 +3048,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2787,11 +3062,13 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f08c-0970-935e-33ba" name="Additional Spell" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2808,6 +3085,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7324-ffce-42e5-c07c" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2816,6 +3094,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="830c-dba6-2cc8-aa3a" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2824,6 +3103,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ecd-d085-25cf-1775" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2832,6 +3112,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af0e-bfb5-a111-1912" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2840,6 +3121,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa46-5a1e-34d6-ad31" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2848,6 +3130,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1885-1784-05c7-7c8b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2856,6 +3139,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6b1-9828-8546-4a87" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2864,6 +3148,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="baaf-4802-dbab-fc40" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2872,6 +3157,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a5d-15f5-d1a7-a7e9" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2880,6 +3166,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df5d-34a3-8e11-1360" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2888,6 +3175,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c21a-25dc-07e0-65d4" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2896,6 +3184,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e83-c4b7-9e10-95c7" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2904,6 +3193,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5559-9de3-e1b9-49db" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2912,6 +3202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2927,6 +3218,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c4f-4465-f076-487a" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2938,6 +3230,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0204-e123-2de6-f650" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2949,6 +3242,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d54f-916f-0314-5449" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2960,6 +3254,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c80-1b2e-21e2-c730" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2971,6 +3266,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e7e9-8499-3de9-848e" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2982,6 +3278,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="85c1-cbd6-fc72-4416" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2993,6 +3290,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b438-6732-2255-08ec" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -3004,6 +3302,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9d1e-2d68-a1de-0b92" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -3015,6 +3314,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73c1-9a09-134f-383c" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -3026,6 +3326,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e07-bae3-f2e0-e767" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -3037,6 +3338,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e793-f567-f39f-9780" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -3048,6 +3350,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="76b0-bfce-578b-0169" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -3059,6 +3362,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c213-1e50-9ed0-05d3" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -3070,6 +3374,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3085,6 +3390,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f92f-be44-041a-4db7" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -3093,6 +3399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b051-3351-9086-002f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -3101,6 +3408,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5770-6d44-04fd-f4ce" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -3109,6 +3417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="002e-afe1-43e4-8f95" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -3117,6 +3426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b09c-db48-6ae6-40c0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -3125,6 +3435,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="49d3-94d1-217d-8a78" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -3133,6 +3444,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3140,6 +3452,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -3408,7 +3721,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHTH SV3</characteristic>
       </characteristics>
     </profile>
-    <profile id="3f6d-528f-fde9-a9f7" name="Chariot Scythes" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="3f6d-528f-fde9-a9f7" name="Chariot Scythes" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">D6 SV1 Impact hits on Charge</characteristic>

--- a/Dwarfs.cat
+++ b/Dwarfs.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3b46-1dfa-75fc-f98f" name="Dwarfs" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3b46-1dfa-75fc-f98f" name="Dwarfs" revision="3" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="6dbd-0ad3-a92f-c7f6" name="Dwarf Lord" hidden="false" collective="false" targetId="c721-3183-d63d-d213" type="selectionEntry"/>
     <entryLink id="68b2-8587-0f02-6bc9" name="Dwarf Runesmith [81 pts]" hidden="false" collective="false" targetId="c40e-98bb-55a2-ca4c" type="selectionEntry"/>
@@ -22,9 +22,6 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="c721-3183-d63d-d213" name="Dwarf Lord [87 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="3150-2ae0-b3a7-dfe9" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="091e-879b-f9f5-3246" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -46,7 +43,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="86b3-51c0-74b9-d290" name="Bloomin Big Axes" hidden="false" collective="false" type="upgrade">
@@ -62,7 +59,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b6c-f559-7abe-9f67" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -71,7 +68,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -94,7 +91,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -111,7 +108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da24-0bc6-b820-f473" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -120,7 +117,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -137,7 +134,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="894d-371e-c5ad-4372" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -146,7 +143,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -171,7 +168,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="82.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5989-181d-8651-3f65" name="Dwarf Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -184,7 +181,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -192,7 +189,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6a71-aabb-c1b4-5401" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
@@ -210,7 +207,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="91.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0476-19e4-21f0-6208" name="Dwarf Bodyguard in Heavy Armour" hidden="false" collective="false" type="model">
@@ -223,7 +220,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -231,7 +228,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -247,7 +244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4c3d-e8d5-ab5d-100c" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -256,7 +253,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="574e-d74e-cd44-886f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -265,7 +262,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4527-eefa-999e-58e0" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -274,7 +271,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e57c-bc5a-db83-b243" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -283,7 +280,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="77a9-85f5-e1b0-25aa" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -292,7 +289,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dafd-fc76-27a9-2707" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -301,7 +298,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -309,13 +306,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c40e-98bb-55a2-ca4c" name="Dwarf Runesmith [81 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="35d3-b106-1a67-064f" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="5c48-c938-3c5a-408d" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
@@ -333,7 +327,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d113-18d9-f23c-454e" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -342,7 +336,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3364-d3a7-35f6-d38d" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -351,7 +345,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -368,7 +362,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6817-4901-87fc-f085" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -377,7 +371,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -394,7 +388,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99c1-8b8d-ac0a-4af9" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -403,7 +397,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -421,7 +415,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a315-0a3e-9a26-e5f1" name="Apprentice Runesmith" hidden="false" collective="false" type="model">
@@ -433,7 +427,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -456,7 +450,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -472,7 +466,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9bcf-b631-0b0d-9a5a" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -484,7 +478,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e87-2e4b-6418-d573" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -496,7 +490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a624-77ca-be20-6432" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -508,7 +502,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="593c-bc90-96fa-23df" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -520,7 +514,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f393-cade-edf1-a4c8" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -532,7 +526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0189-f869-65dc-1f2b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -544,7 +538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="57b2-ff8e-b26e-16f1" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -556,7 +550,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2558-5c4d-c2bf-d8d1" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -568,7 +562,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbe7-0c59-a463-f3c2" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -580,7 +574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3153-e1ca-ffac-5a0c" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -592,7 +586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96a5-5cc4-3ebc-b95e" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -604,7 +598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d84e-820e-ea50-bfe5" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -616,7 +610,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e1bd-a535-d0e0-b121" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -628,7 +622,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -645,7 +639,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="72c5-67b6-fabc-52d8" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -654,7 +648,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ccd-a11d-e9c4-2ed1" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -663,7 +657,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a22d-b502-dd76-78dc" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -672,7 +666,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4265-52e6-b76f-20e2" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -681,7 +675,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a559-df7d-526f-1a25" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -690,7 +684,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff05-fa81-4367-6180" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -699,7 +693,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5aa2-83e5-5e79-1f53" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -708,7 +702,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d8ac-7bfa-f5b5-d4ac" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -717,7 +711,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6772-4143-fd80-1c8f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -726,7 +720,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="122d-7e13-00ff-0b71" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -735,7 +729,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ceca-8f2b-16f5-a042" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -744,7 +738,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c6d7-4bfb-d5e0-0ba0" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -753,7 +747,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="744e-e030-9c59-cb11" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -762,7 +756,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -778,7 +772,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d8af-af6d-34d6-5aff" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -787,7 +781,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="783f-c219-f28f-a2df" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -796,7 +790,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="041e-fffd-f288-6a39" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -805,7 +799,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bec5-e879-7936-d0a3" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -814,7 +808,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="37f5-81a7-f3df-0459" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -823,7 +817,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="46a1-2e6f-8f21-70b1" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -832,7 +826,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -840,13 +834,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a6db-bd48-1d3e-8292" name="Dwarf Hero [86 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="7aa9-16f7-1283-d9cf" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
       </infoLinks>
@@ -865,7 +856,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -882,7 +873,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c138-df81-da8d-a098" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -891,7 +882,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -908,7 +899,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3739-8036-7b0e-927a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -917,7 +908,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aaa7-9443-7dae-5b41" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -926,7 +917,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -942,7 +933,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -958,7 +949,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -975,7 +966,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3f51-bc10-6c09-45fd" name="Dwarf Hero in Heavy Armour" hidden="false" collective="false" type="model">
@@ -984,7 +975,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3bcb-bb94-69eb-1ecf" name="Dwarf Hero, Crazed Psychotic (No Armour)" hidden="false" collective="false" type="model">
@@ -994,7 +985,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="87.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1011,7 +1002,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ecd8-da49-612a-346f" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1020,7 +1011,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1036,7 +1027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="151c-0ab7-5d64-317f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1045,7 +1036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d4d4-97cc-5deb-c714" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1054,7 +1045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="38a5-33b9-6e86-006d" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1063,7 +1054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="768d-fa50-7f62-6bee" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1072,7 +1063,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d54-8e25-ed90-c245" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1081,7 +1072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="efc0-dd43-2732-bbd8" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1090,7 +1081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1098,13 +1089,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3737-797e-c49a-bd2e" name="Dwarf Guard [115 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="f1ee-3612-a118-2e94" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
       </infoLinks>
@@ -1125,7 +1113,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7242-cd1b-74f6-b8b3" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1134,7 +1122,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1161,7 +1149,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4d9c-08b7-f862-57b1" name="Dwarf Guard" hidden="false" collective="false" type="model">
@@ -1174,7 +1162,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1182,7 +1170,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eac7-0b3a-cf5b-613f" name="Dwarf Guard in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1200,7 +1188,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3be7-e411-54a5-9a80" name="Dwarf Guard" hidden="false" collective="false" type="model">
@@ -1213,7 +1201,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1221,7 +1209,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1229,13 +1217,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0af2-4120-b7ef-ed73" name="Dwarf Warriors [100 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="1565-f8fe-ea4f-7b8d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1262,7 +1247,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4b27-6479-27fd-2189" name="Dwarf Warrior" hidden="false" collective="false" type="model">
@@ -1275,7 +1260,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1283,7 +1268,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="683e-3a8b-10c4-b24f" name="Dwarf Warriors in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1301,7 +1286,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1243-0fc6-7980-34af" name="Dwarf Warrior" hidden="false" collective="false" type="model">
@@ -1314,7 +1299,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1322,7 +1307,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1347,7 +1332,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04c0-2158-168c-2d02" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1356,7 +1341,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3faa-e697-9a05-083f" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1365,7 +1350,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bf3a-d27a-e592-1111" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1374,7 +1359,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fd7b-549b-3973-848d" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1394,7 +1379,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1402,13 +1387,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0120-dc29-e7a3-7a46" name="Dwarf Archers [100 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="16ac-b9d5-d590-94a3" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
       </infoLinks>
@@ -1437,7 +1419,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a89b-cfbb-18f7-dbb8" name="Dwarf Archer" hidden="false" collective="false" type="model">
@@ -1450,7 +1432,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1458,7 +1440,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a70-2217-86dc-03f0" name="Dwarf Archers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1476,7 +1458,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="159b-b450-bbc9-884e" name="Dwarf Archer" hidden="false" collective="false" type="model">
@@ -1489,7 +1471,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1497,7 +1479,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1514,7 +1496,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="69af-eb55-a24d-4267" name="Crossbow" hidden="false" collective="false" type="upgrade">
@@ -1530,7 +1512,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1538,13 +1520,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8600-3664-2ff7-0154" name="Dwarf Handgunners [110 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="4201-3261-ac27-eeff" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
         <infoLink id="b68e-0da9-b61a-5dad" name="Handgun" hidden="false" targetId="c6ac-d307-29c2-4ef1" type="profile"/>
@@ -1574,7 +1553,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="09c3-0f1d-0c79-6ffb" name="Dwarf Handgunner" hidden="false" collective="false" type="model">
@@ -1587,7 +1566,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1595,7 +1574,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1660-d9da-eeee-93e1" name="Dwarf Handgunners in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1613,7 +1592,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2359-0904-458a-8915" name="Dwarf Handgunner" hidden="false" collective="false" type="model">
@@ -1626,7 +1605,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1634,7 +1613,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1642,13 +1621,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c3c0-1daa-695f-77ce" name="Dwarf Pony Riders [70 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="034b-4146-4c27-d7fa" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -1677,7 +1653,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="bc3d-f58e-d8f9-5f05" name="Dwarf Pony Rider" hidden="false" collective="false" type="model">
@@ -1690,7 +1666,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1698,7 +1674,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8814-e0ea-0db2-a3bc" name="Dwarf Pony Riders in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1716,7 +1692,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1641-820c-099b-fe0d" name="Dwarf Pony Rider" hidden="false" collective="false" type="model">
@@ -1729,7 +1705,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1737,7 +1713,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1754,7 +1730,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9a6f-73f6-31c6-02ba" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1763,7 +1739,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1771,13 +1747,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ce6-e262-f72d-7f94" name="Dwarf Rangers [112 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="d842-da47-74cd-3826" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
         <infoLink id="b625-ac56-05f4-ffe3" name="Vengeful" hidden="false" targetId="5e63-c99b-00b4-24eb" type="rule"/>
@@ -1807,7 +1780,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="479b-2011-1673-9b12" name="Dwarf Ranger" hidden="false" collective="false" type="model">
@@ -1820,7 +1793,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1828,7 +1801,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8e77-d307-2416-a4bf" name="Dwarf Rangers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1846,7 +1819,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ae9d-7ca4-16a9-b011" name="Dwarf Ranger" hidden="false" collective="false" type="model">
@@ -1859,7 +1832,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1867,7 +1840,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1884,7 +1857,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="229a-d0b0-45cf-dd7d" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1901,7 +1874,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1924,7 +1897,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1932,13 +1905,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d21b-4748-3e74-0e99" name="Dwarf Crazed Psychotic Axe-wielding Maniacs [117 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="dec8-d0f8-7998-f28a" name="Crazed Psychotics" hidden="false" targetId="2b40-80c8-12cf-8f44" type="rule"/>
         <infoLink id="ed08-d328-683a-4395" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
@@ -1967,7 +1937,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29d1-a06a-4baf-d6c5" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1976,7 +1946,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1994,7 +1964,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="33.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="276b-6b61-b1b8-d49d" name="Maniac" hidden="false" collective="false" type="model">
@@ -2007,7 +1977,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2015,13 +1985,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5b61-10d0-464f-e4bf" name="Dwarf Stone Thrower [102 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="fca3-67c3-8e81-c0ba" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="913d-aef7-9d58-1ef1" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2043,7 +2010,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1ccb-6fac-9c0f-24bd" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -2052,7 +2019,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2069,7 +2036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2077,13 +2044,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="caa8-a18a-d2a9-ee72" name="Dwarf Cannon [98 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="9769-b86a-4858-2c28" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="b19f-ad64-bf7b-6d7d" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2106,7 +2070,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4bf2-d3bd-d61b-f63d" name="Large Cannon" hidden="false" collective="false" type="upgrade">
@@ -2115,7 +2079,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="100.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2132,7 +2096,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2140,13 +2104,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="55f2-2eeb-c566-db0a" name="Dwarf Bombard [93 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="83f7-d5f6-88a3-d5f5" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="8fc5-dce6-1e09-7439" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2168,7 +2129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="45.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2185,7 +2146,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2193,13 +2154,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6f26-e1ce-d8ff-b54c" name="Dwarf Fire Cannon [108 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="a027-e0e9-2744-51a4" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
       </infoLinks>
@@ -2219,7 +2177,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2238,7 +2196,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2246,13 +2204,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5310-7ff4-c260-fc1f" name="Dwarf Bolt Thrower [90 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="790b-d4a5-4d29-2e02" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="97ed-e67a-be81-02b3" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2274,7 +2229,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83ee-bd8c-e8c7-59c6" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2284,7 +2239,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2301,7 +2256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2309,13 +2264,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a844-a11e-a600-98e7" name="Dwarf Flying Machine" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="389f-1c24-2058-bf2e" type="max"/>
       </constraints>
@@ -2335,7 +2287,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="94.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2352,7 +2304,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f930-f93d-c612-99b8" name="Bombs" hidden="false" collective="false" type="upgrade">
@@ -2361,7 +2313,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2383,7 +2335,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2399,7 +2351,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2407,13 +2359,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a75b-c3ef-93c9-ec24" name="Dwarf Steam Juggernaut [245 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="3.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="c588-6c81-ab4a-9f61" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
         <infoLink id="83c9-9029-2019-a319" name="Juggernaut" hidden="false" targetId="db5d-a96a-7bfb-66f3" type="rule"/>
@@ -2437,7 +2386,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="215.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2454,7 +2403,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2477,7 +2426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e117-43d7-fd7d-34ea" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -2493,7 +2442,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2509,7 +2458,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2526,7 +2475,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1eb2-2c27-84c0-87e3" name="Large Cannon" hidden="false" collective="false" type="upgrade">
@@ -2536,7 +2485,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ccf-e126-235d-2834" name="Fire Cannon" hidden="false" collective="false" type="upgrade">
@@ -2545,7 +2494,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7afc-c651-8c20-1a63" name="Organ Gun" hidden="false" collective="false" type="upgrade">
@@ -2554,7 +2503,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2562,13 +2511,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="3.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d036-c54c-7e19-e1a9" name="Dwarf Organ Gun" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="169d-15b8-ae92-e1ec" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="d3f9-4f0e-d07b-497e" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2590,7 +2536,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2607,7 +2553,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2615,7 +2561,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Dwarfs.cat
+++ b/Dwarfs.cat
@@ -43,7 +43,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="86b3-51c0-74b9-d290" name="Bloomin Big Axes" hidden="false" collective="false" type="upgrade">
@@ -59,7 +59,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b6c-f559-7abe-9f67" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -68,7 +68,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -91,7 +91,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -108,7 +108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da24-0bc6-b820-f473" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -117,7 +117,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -134,7 +134,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="894d-371e-c5ad-4372" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -143,7 +143,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -168,7 +168,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="82.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5989-181d-8651-3f65" name="Dwarf Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -181,7 +181,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -189,7 +189,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6a71-aabb-c1b4-5401" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
@@ -207,7 +207,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="91.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0476-19e4-21f0-6208" name="Dwarf Bodyguard in Heavy Armour" hidden="false" collective="false" type="model">
@@ -220,7 +220,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -228,7 +228,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -244,7 +244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4c3d-e8d5-ab5d-100c" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -253,7 +253,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="574e-d74e-cd44-886f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -262,7 +262,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4527-eefa-999e-58e0" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -271,7 +271,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e57c-bc5a-db83-b243" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -280,7 +280,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="77a9-85f5-e1b0-25aa" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -289,7 +289,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dafd-fc76-27a9-2707" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -298,7 +298,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -306,7 +306,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c40e-98bb-55a2-ca4c" name="Dwarf Runesmith [81 pts]" hidden="false" collective="false" type="unit">
@@ -327,7 +327,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d113-18d9-f23c-454e" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -336,7 +336,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3364-d3a7-35f6-d38d" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -345,7 +345,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -362,7 +362,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6817-4901-87fc-f085" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -371,7 +371,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -388,7 +388,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99c1-8b8d-ac0a-4af9" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -397,7 +397,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -415,7 +415,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a315-0a3e-9a26-e5f1" name="Apprentice Runesmith" hidden="false" collective="false" type="model">
@@ -427,7 +427,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -450,7 +450,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -466,7 +466,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9bcf-b631-0b0d-9a5a" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -478,7 +478,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e87-2e4b-6418-d573" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -490,7 +490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a624-77ca-be20-6432" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -502,7 +502,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="593c-bc90-96fa-23df" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -514,7 +514,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f393-cade-edf1-a4c8" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -526,7 +526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0189-f869-65dc-1f2b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -538,7 +538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="57b2-ff8e-b26e-16f1" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -550,7 +550,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2558-5c4d-c2bf-d8d1" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -562,7 +562,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbe7-0c59-a463-f3c2" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -574,7 +574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3153-e1ca-ffac-5a0c" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -586,7 +586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96a5-5cc4-3ebc-b95e" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -598,7 +598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d84e-820e-ea50-bfe5" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -610,7 +610,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e1bd-a535-d0e0-b121" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -622,7 +622,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -639,7 +639,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="72c5-67b6-fabc-52d8" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -648,7 +648,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ccd-a11d-e9c4-2ed1" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -657,7 +657,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a22d-b502-dd76-78dc" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -666,7 +666,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4265-52e6-b76f-20e2" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -675,7 +675,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a559-df7d-526f-1a25" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -684,7 +684,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff05-fa81-4367-6180" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -693,7 +693,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5aa2-83e5-5e79-1f53" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -702,7 +702,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d8ac-7bfa-f5b5-d4ac" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -711,7 +711,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6772-4143-fd80-1c8f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -720,7 +720,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="122d-7e13-00ff-0b71" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -729,7 +729,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ceca-8f2b-16f5-a042" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -738,7 +738,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c6d7-4bfb-d5e0-0ba0" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -747,7 +747,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="744e-e030-9c59-cb11" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -756,7 +756,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -772,7 +772,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d8af-af6d-34d6-5aff" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -781,7 +781,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="783f-c219-f28f-a2df" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -790,7 +790,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="041e-fffd-f288-6a39" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -799,7 +799,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bec5-e879-7936-d0a3" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -808,7 +808,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="37f5-81a7-f3df-0459" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -817,7 +817,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="46a1-2e6f-8f21-70b1" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -826,7 +826,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -834,15 +834,19 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a6db-bd48-1d3e-8292" name="Dwarf Hero [86 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01d9-ac41-bed1-7df2" type="max"/>
+      </constraints>
       <infoLinks>
         <infoLink id="7aa9-16f7-1283-d9cf" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="990b-5f21-0315-a7cd" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
+        <categoryLink id="3a8f-6eca-ce88-d29b" name="Hero Unit" hidden="false" targetId="hero unit" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="328e-881e-5c23-9754" name="Stubborn Upgrade" hidden="false" collective="false">
@@ -856,7 +860,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -873,7 +877,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c138-df81-da8d-a098" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -882,7 +886,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -899,7 +903,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3739-8036-7b0e-927a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -908,7 +912,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aaa7-9443-7dae-5b41" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -917,7 +921,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -933,7 +937,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -949,7 +953,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -966,7 +970,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3f51-bc10-6c09-45fd" name="Dwarf Hero in Heavy Armour" hidden="false" collective="false" type="model">
@@ -975,7 +979,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3bcb-bb94-69eb-1ecf" name="Dwarf Hero, Crazed Psychotic (No Armour)" hidden="false" collective="false" type="model">
@@ -985,7 +989,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="87.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1002,7 +1006,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ecd8-da49-612a-346f" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1011,7 +1015,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1027,7 +1031,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="151c-0ab7-5d64-317f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1036,7 +1040,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d4d4-97cc-5deb-c714" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1045,7 +1049,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="38a5-33b9-6e86-006d" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1054,7 +1058,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="768d-fa50-7f62-6bee" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1063,7 +1067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d54-8e25-ed90-c245" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1072,7 +1076,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="efc0-dd43-2732-bbd8" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1081,7 +1085,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1089,10 +1093,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3737-797e-c49a-bd2e" name="Dwarf Guard [115 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="860f-ada0-f836-2aa0" type="max"/>
+      </constraints>
       <infoLinks>
         <infoLink id="f1ee-3612-a118-2e94" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
       </infoLinks>
@@ -1113,7 +1120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7242-cd1b-74f6-b8b3" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1122,7 +1129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1149,7 +1156,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4d9c-08b7-f862-57b1" name="Dwarf Guard" hidden="false" collective="false" type="model">
@@ -1162,7 +1169,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1170,7 +1177,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eac7-0b3a-cf5b-613f" name="Dwarf Guard in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1188,7 +1195,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3be7-e411-54a5-9a80" name="Dwarf Guard" hidden="false" collective="false" type="model">
@@ -1201,7 +1208,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1209,7 +1216,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1217,7 +1224,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0af2-4120-b7ef-ed73" name="Dwarf Warriors [100 pts]" hidden="false" collective="false" type="unit">
@@ -1247,7 +1254,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4b27-6479-27fd-2189" name="Dwarf Warrior" hidden="false" collective="false" type="model">
@@ -1260,7 +1267,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1268,7 +1275,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="683e-3a8b-10c4-b24f" name="Dwarf Warriors in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1286,7 +1293,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1243-0fc6-7980-34af" name="Dwarf Warrior" hidden="false" collective="false" type="model">
@@ -1299,7 +1306,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1307,7 +1314,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1332,7 +1339,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04c0-2158-168c-2d02" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1341,7 +1348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3faa-e697-9a05-083f" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1350,7 +1357,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bf3a-d27a-e592-1111" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1359,7 +1366,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fd7b-549b-3973-848d" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1379,7 +1386,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1387,7 +1394,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0120-dc29-e7a3-7a46" name="Dwarf Archers [100 pts]" hidden="false" collective="false" type="unit">
@@ -1419,7 +1426,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a89b-cfbb-18f7-dbb8" name="Dwarf Archer" hidden="false" collective="false" type="model">
@@ -1432,7 +1439,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1440,7 +1447,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a70-2217-86dc-03f0" name="Dwarf Archers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1458,7 +1465,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="159b-b450-bbc9-884e" name="Dwarf Archer" hidden="false" collective="false" type="model">
@@ -1471,7 +1478,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1479,7 +1486,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1496,7 +1503,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="69af-eb55-a24d-4267" name="Crossbow" hidden="false" collective="false" type="upgrade">
@@ -1512,7 +1519,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1520,7 +1527,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8600-3664-2ff7-0154" name="Dwarf Handgunners [110 pts]" hidden="false" collective="false" type="unit">
@@ -1553,7 +1560,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="09c3-0f1d-0c79-6ffb" name="Dwarf Handgunner" hidden="false" collective="false" type="model">
@@ -1566,7 +1573,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1574,7 +1581,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1660-d9da-eeee-93e1" name="Dwarf Handgunners in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1592,7 +1599,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2359-0904-458a-8915" name="Dwarf Handgunner" hidden="false" collective="false" type="model">
@@ -1605,7 +1612,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1613,7 +1620,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1621,12 +1628,12 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c3c0-1daa-695f-77ce" name="Dwarf Pony Riders [70 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="034b-4146-4c27-d7fa" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="c4e4-7bfb-d29d-14a8" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1484-6f8a-ef0a-bbe8" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
@@ -1653,7 +1660,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="bc3d-f58e-d8f9-5f05" name="Dwarf Pony Rider" hidden="false" collective="false" type="model">
@@ -1666,7 +1673,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1674,7 +1681,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8814-e0ea-0db2-a3bc" name="Dwarf Pony Riders in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1692,7 +1699,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1641-820c-099b-fe0d" name="Dwarf Pony Rider" hidden="false" collective="false" type="model">
@@ -1705,7 +1712,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1713,7 +1720,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1730,7 +1737,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9a6f-73f6-31c6-02ba" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1739,7 +1746,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1747,7 +1754,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ce6-e262-f72d-7f94" name="Dwarf Rangers [112 pts]" hidden="false" collective="false" type="unit">
@@ -1780,7 +1787,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="479b-2011-1673-9b12" name="Dwarf Ranger" hidden="false" collective="false" type="model">
@@ -1793,7 +1800,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1801,7 +1808,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8e77-d307-2416-a4bf" name="Dwarf Rangers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1819,7 +1826,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ae9d-7ca4-16a9-b011" name="Dwarf Ranger" hidden="false" collective="false" type="model">
@@ -1832,7 +1839,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1840,12 +1847,12 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="19e1-1a84-7184-7f44" name="HTH Weapon" hidden="false" collective="false" defaultSelectionEntryId="1512-6f75-4f70-33ba">
+        <selectionEntryGroup id="19e1-1a84-7184-7f44" name="HtH Weapon" hidden="false" collective="false" defaultSelectionEntryId="1512-6f75-4f70-33ba">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c950-4ed9-9706-1fe3" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c35-b053-e405-037b" type="min"/>
@@ -1857,7 +1864,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="229a-d0b0-45cf-dd7d" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1874,7 +1881,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1897,7 +1904,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1905,7 +1912,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d21b-4748-3e74-0e99" name="Dwarf Crazed Psychotic Axe-wielding Maniacs [117 pts]" hidden="false" collective="false" type="unit">
@@ -1937,7 +1944,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29d1-a06a-4baf-d6c5" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1946,7 +1953,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1964,7 +1971,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="33.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="276b-6b61-b1b8-d49d" name="Maniac" hidden="false" collective="false" type="model">
@@ -1977,7 +1984,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1985,14 +1992,14 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5b61-10d0-464f-e4bf" name="Dwarf Stone Thrower [102 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="fca3-67c3-8e81-c0ba" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="913d-aef7-9d58-1ef1" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
         <infoLink id="0afa-0253-9bde-5c68" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="3981-2f8b-e016-c829" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="eeeb-58b8-013b-5b6f" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
@@ -2010,7 +2017,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1ccb-6fac-9c0f-24bd" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -2019,7 +2026,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2036,7 +2043,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2044,15 +2051,15 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="caa8-a18a-d2a9-ee72" name="Dwarf Cannon [98 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="9769-b86a-4858-2c28" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="b19f-ad64-bf7b-6d7d" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
         <infoLink id="c94f-05da-fe75-96d8" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
         <infoLink id="50d1-e4a0-e928-8ce4" name="Unstoppable" hidden="false" targetId="a8bf-f48c-1b08-58e6" type="rule"/>
+        <infoLink id="9e4a-4214-9919-05a7" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="cf89-f7fc-cc96-7eeb" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
@@ -2070,7 +2077,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4bf2-d3bd-d61b-f63d" name="Large Cannon" hidden="false" collective="false" type="upgrade">
@@ -2079,7 +2086,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="100.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2096,7 +2103,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2104,7 +2111,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="55f2-2eeb-c566-db0a" name="Dwarf Bombard [93 pts]" hidden="false" collective="false" type="unit">
@@ -2129,7 +2136,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="45.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2146,7 +2153,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2154,12 +2161,14 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6f26-e1ce-d8ff-b54c" name="Dwarf Fire Cannon [108 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="a027-e0e9-2744-51a4" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="d6ae-0e7b-7b77-80ec" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="a939-17da-f510-5402" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4840-1e56-24e2-7c40" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
@@ -2177,7 +2186,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2196,7 +2205,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2204,14 +2213,14 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5310-7ff4-c260-fc1f" name="Dwarf Bolt Thrower [90 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="790b-d4a5-4d29-2e02" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="97ed-e67a-be81-02b3" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
         <infoLink id="2cce-dacc-7923-4972" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="c72b-fce0-cffe-0aab" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="28df-e7a4-a6aa-2cef" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
@@ -2229,7 +2238,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83ee-bd8c-e8c7-59c6" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2239,7 +2248,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2256,7 +2265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2264,7 +2273,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a844-a11e-a600-98e7" name="Dwarf Flying Machine" hidden="false" collective="false" type="unit">
@@ -2287,7 +2296,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="94.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2304,7 +2313,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f930-f93d-c612-99b8" name="Bombs" hidden="false" collective="false" type="upgrade">
@@ -2313,7 +2322,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2335,7 +2344,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2351,7 +2360,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2359,7 +2368,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a75b-c3ef-93c9-ec24" name="Dwarf Steam Juggernaut [245 pts]" hidden="false" collective="false" type="unit">
@@ -2386,7 +2395,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="215.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2403,7 +2412,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2426,7 +2435,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e117-43d7-fd7d-34ea" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -2442,7 +2451,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2458,7 +2467,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2475,7 +2484,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1eb2-2c27-84c0-87e3" name="Large Cannon" hidden="false" collective="false" type="upgrade">
@@ -2485,7 +2494,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ccf-e126-235d-2834" name="Fire Cannon" hidden="false" collective="false" type="upgrade">
@@ -2494,7 +2503,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7afc-c651-8c20-1a63" name="Organ Gun" hidden="false" collective="false" type="upgrade">
@@ -2503,7 +2512,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2511,7 +2520,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="3.0"/>
+        <cost name=" order dice" typeId="orderDice" value="3.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d036-c54c-7e19-e1a9" name="Dwarf Organ Gun" hidden="false" collective="false" type="unit">
@@ -2536,7 +2545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2553,7 +2562,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2561,7 +2570,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -2580,7 +2589,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, 3xHTH, Wound X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="64dd-c73a-1a36-f51b" name="Dwarf Lord in Heavy Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2591,7 +2600,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, 3xHTH, Wound X, Heavily Laden</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, 3xHtH, Wound X, Heavily Laden</characteristic>
       </characteristics>
     </profile>
     <profile id="30e0-c8fa-0417-4639" name="Dwarf Bodyguard in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2624,7 +2633,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, 2xHTH, Wound X, Magic Level X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, 2xHtH, Wound X, Magic Level X</characteristic>
       </characteristics>
     </profile>
     <profile id="c6df-b116-8ac3-d17e" name="Apprentice Runesmith in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2646,7 +2655,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">9</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHTH, Wound X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="256a-11af-644b-ef00" name="Dwarf Hero in Heavy Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2657,7 +2666,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">9</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHTH, Wound X, Heavily Laden</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHtH, Wound X, Heavily Laden</characteristic>
       </characteristics>
     </profile>
     <profile id="5789-afd4-c182-f27e" name="Dwarf Hero, Crazed Psychotic (No Armour)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2668,7 +2677,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">9</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHTH, Wound X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="4c60-2ba3-398c-0446" name="Dwarf Guard Leader in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2679,7 +2688,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Stubborn</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Stubborn</characteristic>
       </characteristics>
     </profile>
     <profile id="d394-0876-b7d2-77a2" name="Dwarf Guard Leader in Heavy Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2690,7 +2699,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Stubborn</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Stubborn</characteristic>
       </characteristics>
     </profile>
     <profile id="9d04-e866-f8a2-f421" name="Dwarf Guard in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2723,7 +2732,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="22a3-6219-8bce-3abf" name="Dwarf Warrior Leader in Heavy Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2734,7 +2743,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="1194-9433-8b26-a3bb" name="Dwarf Warrior in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2767,7 +2776,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="84ec-289b-c957-ca10" name="Dwarf Archer Leader in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2778,7 +2787,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="9f10-9fc3-4192-9710" name="Dwarf Archer in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2811,7 +2820,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="a153-e2b0-2268-9941" name="Dwarf Handgunner Leader in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2822,7 +2831,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="0873-fe47-1fe0-44fe" name="Dwarf Handgunner in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2855,7 +2864,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 6</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 6</characteristic>
       </characteristics>
     </profile>
     <profile id="b6a2-cf61-3f0b-c8d1" name="Dwarf Pony Rider Leader in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2866,7 +2875,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 6</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 6</characteristic>
       </characteristics>
     </profile>
     <profile id="a822-8fdc-6a29-28a5" name="Dwarf Pony Rider in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2899,7 +2908,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Vengeful</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Vengeful</characteristic>
       </characteristics>
     </profile>
     <profile id="e512-a6cd-04f8-99cb" name="Dwarf Ranger Leader in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2910,7 +2919,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Vengeful</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Vengeful</characteristic>
       </characteristics>
     </profile>
     <profile id="2b9b-9704-0eef-8867" name="Dwarf Ranger in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2943,7 +2952,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Crazed Psychotic, Stubborn</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Crazed Psychotic, Stubborn</characteristic>
       </characteristics>
     </profile>
     <profile id="d350-fa44-12c5-7899" name="Dwarf Maniac" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3020,7 +3029,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">10</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Flies, Fast 10, MOD2, 0xHTH, 3xDrop SV4 Fire (bombs), Ramshackle Contraption</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Flies, Fast 10, MOD2, 0xHtH, 3x Drop SV4 Fire (bombs), Ramshackle Contraption</characteristic>
       </characteristics>
     </profile>
     <profile id="46a0-3c62-e534-e7a0" name="Dwarf Pilot" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3042,7 +3051,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">15</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD3, 3xHTH SV5, Ramshackle Contraption, Surly</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD3, 3xHtH SV5, Ramshackle Contraption, Surly</characteristic>
       </characteristics>
     </profile>
     <profile id="1019-5d81-b0f4-66a9" name="Dwarf Crew (Juggernaut)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3062,7 +3071,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-20&quot;</characteristic>
         <characteristic name="Range Extreme" typeId="49d3-642a-08be-5817">20-30&quot;</characteristic>
         <characteristic name="Strike Value" typeId="47c7-dced-6203-6b76">3</characteristic>
-        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Fire order to shoot, D6 x Ranged SV3</characteristic>
+        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Fire order to shoot, D6x Ranged SV3</characteristic>
       </characteristics>
     </profile>
     <profile id="8aa4-6f6c-cdab-96a8" name="Dwarf Crew with Organ gun" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">

--- a/Dwarfs.cat
+++ b/Dwarfs.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3b46-1dfa-75fc-f98f" name="Dwarfs" revision="3" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3b46-1dfa-75fc-f98f" name="Dwarfs" revision="4" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="6dbd-0ad3-a92f-c7f6" name="Dwarf Lord" hidden="false" collective="false" targetId="c721-3183-d63d-d213" type="selectionEntry"/>
     <entryLink id="68b2-8587-0f02-6bc9" name="Dwarf Runesmith [81 pts]" hidden="false" collective="false" targetId="c40e-98bb-55a2-ca4c" type="selectionEntry"/>
@@ -39,7 +39,7 @@
           <selectionEntries>
             <selectionEntry id="d0fc-1ddc-dee8-9882" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="bf0b-edd7-863d-125e" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="bf0b-edd7-863d-125e" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -96,7 +96,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5a01-bd30-08ea-1a3f" name="Dwarf Lord Wounds upgrade" hidden="false" collective="false" defaultSelectionEntryId="209f-8982-4045-7b7f">
+        <selectionEntryGroup id="5a01-bd30-08ea-1a3f" name="Wounds upgrade" hidden="false" collective="false" defaultSelectionEntryId="209f-8982-4045-7b7f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aed2-7409-28ee-fb7b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12df-5792-bf4a-60dd" type="min"/>
@@ -122,7 +122,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="81f7-c51c-5dbf-b737" name="Dwarf Lord Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="0b44-d5d7-1c37-970b">
+        <selectionEntryGroup id="81f7-c51c-5dbf-b737" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="0b44-d5d7-1c37-970b">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1a6-5234-ab74-04bb" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d23-df37-1c10-ef13" type="min"/>
@@ -148,7 +148,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ae9e-144d-af12-99c4" name="Models" hidden="false" collective="false" defaultSelectionEntryId="506d-8280-00d3-d2e7">
+        <selectionEntryGroup id="ae9e-144d-af12-99c4" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="506d-8280-00d3-d2e7">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4615-8a7d-5bbf-e89e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="233a-a0d6-9e1c-b04b" type="min"/>
@@ -156,7 +156,7 @@
           <selectionEntries>
             <selectionEntry id="506d-8280-00d3-d2e7" name="Medium Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="f94c-c68f-a272-c4c2" name="Models" hidden="false" collective="false">
+                <selectionEntryGroup id="f94c-c68f-a272-c4c2" name="Choose 2 to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="d8e5-2ef6-d241-ce87" name="Dwarf Lord in Medium Armour" hidden="false" collective="false" type="model">
                       <constraints>
@@ -194,7 +194,10 @@
             </selectionEntry>
             <selectionEntry id="6a71-aabb-c1b4-5401" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="cec2-4c66-f52d-5000" name="Models" hidden="false" collective="false">
+                <selectionEntryGroup id="cec2-4c66-f52d-5000" name="Choose 2 to 4" hidden="false" collective="false">
+                  <infoLinks>
+                    <infoLink id="457e-74e9-3f15-14cf" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
+                  </infoLinks>
                   <selectionEntries>
                     <selectionEntry id="d923-b6e7-659e-19d8" name="Dwarf Lord in Heavy Armour" hidden="false" collective="false" type="model">
                       <constraints>
@@ -203,7 +206,6 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="8e24-b34a-6c17-65ef" name="Dwarf Lord in Heavy Armour" hidden="false" targetId="64dd-c73a-1a36-f51b" type="profile"/>
-                        <infoLink id="02db-1d4e-dd3e-525c" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="91.0"/>
@@ -243,12 +245,30 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="c40e-98bb-55a2-ca4c" name="Dwarf Runesmith [81 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="550e-e225-6523-8603" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="35d3-b106-1a67-064f" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="5c48-c938-3c5a-408d" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="515a-6d3a-3be1-31a7" name="Dwarf Runesmith" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c74f-d4dc-b9ca-18ba" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6757-72dc-c2cf-87bf" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="3066-7b96-c253-e85c" name="Dwarf Runesmith in Medium Armour" hidden="false" targetId="7468-3f90-ccae-52ca" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="81.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="0881-94ca-d471-973a" name="Runesmith Magic Level" hidden="false" collective="false" defaultSelectionEntryId="dfa6-d144-4a4b-42bc">
+        <selectionEntryGroup id="0881-94ca-d471-973a" name="Magic Level" hidden="false" collective="false" defaultSelectionEntryId="dfa6-d144-4a4b-42bc">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66b6-2a1f-2278-c648" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a29a-3269-5d31-d613" type="min"/>
@@ -283,7 +303,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="135f-cdd7-66e9-9433" name="Runesmith Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="30a0-084c-fbca-6526">
+        <selectionEntryGroup id="135f-cdd7-66e9-9433" name="Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="30a0-084c-fbca-6526">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5d3-fae3-e18f-a4f6" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f595-815a-2609-bdd4" type="min"/>
@@ -309,7 +329,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="66db-a27b-8a2a-be06" name="Runesmith Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="1e8e-29bd-7699-165d">
+        <selectionEntryGroup id="66db-a27b-8a2a-be06" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="1e8e-29bd-7699-165d">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="596f-6a29-1af9-0b40" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cded-873c-6289-01b6" type="min"/>
@@ -335,22 +355,8 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="731f-8af9-41c7-6f19" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="731f-8af9-41c7-6f19" name="Choose up to 4" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="b3fe-e917-cda8-168d" name="Dwarf Runesmith" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51d3-43ae-da33-dad5" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c98-3181-259f-e17c" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="c4f5-4ce6-a62a-422e" name="Dwarf Runesmith in Medium Armour" hidden="false" targetId="7468-3f90-ccae-52ca" type="profile"/>
-                <infoLink id="412e-441a-ba28-c60d" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="a315-0a3e-9a26-e5f1" name="Apprentice Runesmith" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6051-e286-dc06-0578" type="max"/>
@@ -731,7 +737,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="592f-d6d8-9661-7717" name="Hero Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="63e6-0626-588d-38a6">
+        <selectionEntryGroup id="592f-d6d8-9661-7717" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="63e6-0626-588d-38a6">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26ef-c9c6-d735-1f98" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13c0-ce7a-7c92-5af2" type="min"/>
@@ -824,7 +830,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4752-dad0-fab8-f0f9" name="Dwarf Hero" hidden="false" collective="false" defaultSelectionEntryId="1e8f-d965-bd1b-e548">
+        <selectionEntryGroup id="4752-dad0-fab8-f0f9" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="1e8f-d965-bd1b-e548">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ba3-6542-93d7-c141" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da86-7a84-e0b8-2afd" type="min"/>
@@ -842,6 +848,7 @@
             <selectionEntry id="3f51-bc10-6c09-45fd" name="Dwarf Hero in Heavy Armour" hidden="false" collective="false" type="model">
               <infoLinks>
                 <infoLink id="76fa-853e-df5d-7c56" name="Dwarf Hero in Heavy Armour" hidden="false" targetId="256a-11af-644b-ef00" type="profile"/>
+                <infoLink id="de7b-b5f5-b5aa-1e67" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
@@ -901,6 +908,7 @@
       </constraints>
       <infoLinks>
         <infoLink id="f1ee-3612-a118-2e94" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
+        <infoLink id="cc62-f1b3-50db-1718" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="b02e-44af-9433-ef84" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -933,7 +941,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ec19-92c5-3edd-433c" name="Models" hidden="false" collective="false" defaultSelectionEntryId="eac7-0b3a-cf5b-613f">
+        <selectionEntryGroup id="ec19-92c5-3edd-433c" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="eac7-0b3a-cf5b-613f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e294-2fb5-e6c0-8c20" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40d0-e9aa-ae9d-01cd" type="max"/>
@@ -941,7 +949,10 @@
           <selectionEntries>
             <selectionEntry id="7c4f-b564-3d0d-ccdb" name="Dwarf Guard in Heavy Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="44ec-8596-1588-3bda" name="Dwarf Guard in Heavy Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="44ec-8596-1588-3bda" name="Choose 4 to 9" hidden="false" collective="false">
+                  <infoLinks>
+                    <infoLink id="694a-8735-f3c1-2d2e" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
+                  </infoLinks>
                   <selectionEntries>
                     <selectionEntry id="f490-ede7-d883-adba" name="Dwarf Guard Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -949,9 +960,7 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21a5-b7cb-0078-9b4c" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="71eb-d806-36dc-739f" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="6a8f-cc94-c85a-9fe3" name="Dwarf Guard Leader in Heavy Armour" hidden="false" targetId="d394-0876-b7d2-77a2" type="profile"/>
-                        <infoLink id="7cd3-375b-3943-6b37" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
@@ -981,7 +990,7 @@
             </selectionEntry>
             <selectionEntry id="eac7-0b3a-cf5b-613f" name="Dwarf Guard in Medium Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="cd95-1f2c-e360-adf4" name="Dwarf Guard in Medium Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="cd95-1f2c-e360-adf4" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="030b-9fc7-2378-10d5" name="Dwarf Guard Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -990,7 +999,6 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="b7ab-94b8-6bad-0291" name="Dwarf Guard Leader in Medium Armour" hidden="false" targetId="4c60-2ba3-398c-0446" type="profile"/>
-                        <infoLink id="b244-a7a3-1ba9-0146" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
@@ -1027,19 +1035,25 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="0af2-4120-b7ef-ed73" name="Dwarf Warriors [100 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="9e50-3aef-f06a-6b87" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="1565-f8fe-ea4f-7b8d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="07af-30f8-6b74-3929" name="Models" hidden="false" collective="false" defaultSelectionEntryId="683e-3a8b-10c4-b24f">
+        <selectionEntryGroup id="07af-30f8-6b74-3929" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="683e-3a8b-10c4-b24f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8b1-c2b5-0d03-85be" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75ea-bdb2-d108-61fe" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="efa2-f5e5-7a84-6cda" name="Dwarf Warriors in Heavy Armour" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="7074-edee-38d4-d31d" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
+              </infoLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="983b-eacc-931a-75a1" name="Dwarf Warrior in Heavy Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="983b-eacc-931a-75a1" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="c686-5664-ee4d-009a" name="Dwarf Warrior Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1047,9 +1061,7 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2679-e2c0-dbc9-8b3d" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="434f-3a93-d348-78b8" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="c97b-39b2-0b6b-7fd7" name="Dwarf Warrior Leader in Heavy Armour" hidden="false" targetId="22a3-6219-8bce-3abf" type="profile"/>
-                        <infoLink id="5b67-f259-688b-99ae" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
@@ -1079,7 +1091,7 @@
             </selectionEntry>
             <selectionEntry id="683e-3a8b-10c4-b24f" name="Dwarf Warriors in Medium Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="7901-8767-67f2-28e1" name="Dwarf Warrior in Medium Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="7901-8767-67f2-28e1" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="3615-8968-cf20-2941" name="Dwarf Warrior Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1087,7 +1099,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ff0-ed81-7da8-a73b" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="3a85-5277-58b1-c845" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="270b-0b5b-d822-7fb0" name="Dwarf Warrior Leader in Medium Armour" hidden="false" targetId="44cd-0e54-6110-001b" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -1152,7 +1163,7 @@
             </selectionEntry>
             <selectionEntry id="3faa-e697-9a05-083f" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="c690-01b4-d14d-6721" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="c690-01b4-d14d-6721" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1198,13 +1209,14 @@
     </selectionEntry>
     <selectionEntry id="0120-dc29-e7a3-7a46" name="Dwarf Archers [100 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="16ac-b9d5-d590-94a3" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="80a1-8f5c-eabb-4638" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="6b25-9e62-4ed4-c47e" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="770c-abf8-05d4-2263" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="15a0-3ba2-0493-402f" name="Models" hidden="false" collective="false" defaultSelectionEntryId="1a70-2217-86dc-03f0">
+        <selectionEntryGroup id="15a0-3ba2-0493-402f" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="1a70-2217-86dc-03f0">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6f5-cd73-e511-e8d8" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62dd-0167-5d20-470a" type="max"/>
@@ -1212,7 +1224,7 @@
           <selectionEntries>
             <selectionEntry id="25eb-f01e-7c5c-9567" name="Dwarf Archers in Medium Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="d5de-fca3-f159-a57c" name="Dwarf Archer in Heavy Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="d5de-fca3-f159-a57c" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="30aa-800f-15a1-e1e9" name="Dwarf Archer Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1220,7 +1232,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="387a-cfcd-93c3-55ba" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="3359-be5c-5768-d209" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="b372-97c8-b30a-e29b" name="Dwarf Archer Leader in Medium Armour" hidden="false" targetId="84ec-289b-c957-ca10" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -1251,7 +1262,7 @@
             </selectionEntry>
             <selectionEntry id="1a70-2217-86dc-03f0" name="Dwarf Archers in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="ed56-6ecc-54d2-68e6" name="Dwarf Archer in Light Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="ed56-6ecc-54d2-68e6" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="9a37-f462-62c3-9346" name="Dwarf Archer Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1259,7 +1270,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1396-3078-51b3-9fef" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="100b-8b8a-ee8d-b6f1" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="e93c-19cf-e52d-334b" name="Dwarf Archer Leader in Light Armour" hidden="false" targetId="d31b-6031-95ac-45ac" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -1332,15 +1342,16 @@
     </selectionEntry>
     <selectionEntry id="8600-3664-2ff7-0154" name="Dwarf Handgunners [110 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="4201-3261-ac27-eeff" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="4201-3261-ac27-eeff" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="b68e-0da9-b61a-5dad" name="Handgun" hidden="false" targetId="c6ac-d307-29c2-4ef1" type="profile"/>
         <infoLink id="d6c8-1f57-4e4a-588d" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+        <infoLink id="69ce-88e4-af12-6624" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a764-2034-aa55-fcd7" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="eff3-8e72-e87e-d9cf" name="Models" hidden="false" collective="false" defaultSelectionEntryId="1660-d9da-eeee-93e1">
+        <selectionEntryGroup id="eff3-8e72-e87e-d9cf" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="1660-d9da-eeee-93e1">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a180-516c-402f-5eb1" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ab1-3754-be8f-2579" type="max"/>
@@ -1348,7 +1359,7 @@
           <selectionEntries>
             <selectionEntry id="dbc0-2629-ed4f-0b37" name="Dwarf Handgunners in Medium Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="61fe-cea2-b98b-f823" name="Dwarf Handgunner in Heavy Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="61fe-cea2-b98b-f823" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="0485-773f-e692-3db8" name="Dwarf Handgunner Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1356,7 +1367,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a31b-bf10-2d14-6f9a" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="baa1-98b2-a1cc-eb6a" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="59d4-fdbd-c2c9-f34e" name="Dwarf Handgunner Leader in Medium Armour" hidden="false" targetId="a153-e2b0-2268-9941" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -1387,7 +1397,7 @@
             </selectionEntry>
             <selectionEntry id="1660-d9da-eeee-93e1" name="Dwarf Handgunners in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="fe00-4583-2424-9b38" name="Dwarf Handgunner in Light Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="fe00-4583-2424-9b38" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="1d5b-0a4f-db2a-14c3" name="Dwarf Handgunner Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1395,7 +1405,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="680a-9019-1fda-697d" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="78db-fff3-87f6-fdf6" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="1628-be35-fc0e-d1ba" name="Dwarf Handgunner Leader in Light Armour" hidden="false" targetId="52d2-00d9-227a-48b2" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -1435,12 +1444,13 @@
     <selectionEntry id="c3c0-1daa-695f-77ce" name="Dwarf Pony Riders [70 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="c4e4-7bfb-d29d-14a8" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
+        <infoLink id="9d9c-8b6d-5fdf-b912" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1484-6f8a-ef0a-bbe8" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="06ea-94ec-38ba-73dc" name="Models" hidden="false" collective="false" defaultSelectionEntryId="9d32-8f9f-1c6e-30e5">
+        <selectionEntryGroup id="06ea-94ec-38ba-73dc" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="9d32-8f9f-1c6e-30e5">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d061-e80b-ae1b-23cd" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab70-0ba8-9cda-60c4" type="max"/>
@@ -1448,7 +1458,7 @@
           <selectionEntries>
             <selectionEntry id="9d32-8f9f-1c6e-30e5" name="Dwarf Pony Riders in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="fa5d-9c3c-5c78-d840" name="Dwarf Pony Riders in Light Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="fa5d-9c3c-5c78-d840" name="Choose 2 to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="6aba-cf6a-2edd-7309" name="Dwarf Pony Rider Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1456,7 +1466,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a09f-62cc-e2c8-ae74" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="c35c-5415-d2ce-bacd" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="afd6-66a7-61c3-f4b7" name="Dwarf Pony Rider Leader in Light Armour" hidden="false" targetId="d7d3-0dd6-3363-c28c" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -1487,7 +1496,7 @@
             </selectionEntry>
             <selectionEntry id="8814-e0ea-0db2-a3bc" name="Dwarf Pony Riders in Medium Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="9057-2770-6355-c5cb" name="Dwarf Pony Rider in Medium Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="9057-2770-6355-c5cb" name="Choose 2 to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="074f-c0f7-01c0-7ec2" name="Dwarf Pony Rider Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1495,7 +1504,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbb6-7b67-fc56-932e" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="dbe0-5095-ff1e-0e28" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="92d1-281f-ce26-ff3b" name="Dwarf Pony Rider Leader in Medium Armour" hidden="false" targetId="b6a2-cf61-3f0b-c8d1" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -1534,7 +1542,7 @@
           <selectionEntries>
             <selectionEntry id="e24e-9b99-7d54-e4a8" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="2899-9b8d-c3b7-300b" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="2899-9b8d-c3b7-300b" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1563,12 +1571,13 @@
         <infoLink id="d842-da47-74cd-3826" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
         <infoLink id="b625-ac56-05f4-ffe3" name="Vengeful" hidden="false" targetId="5e63-c99b-00b4-24eb" type="rule"/>
         <infoLink id="3935-5ffd-0cd2-f917" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+        <infoLink id="4e08-db3b-9535-063e" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1fc1-99e6-f464-e3e7" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="9514-036d-256f-f4b3" name="Models" hidden="false" collective="false" defaultSelectionEntryId="8e77-d307-2416-a4bf">
+        <selectionEntryGroup id="9514-036d-256f-f4b3" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="8e77-d307-2416-a4bf">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a692-2140-9110-6c27" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f93b-15d2-4965-017b" type="max"/>
@@ -1576,7 +1585,7 @@
           <selectionEntries>
             <selectionEntry id="1cf4-06d1-ccc0-6c1c" name="Dwarf Rangers in Medium Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="a225-685b-18be-94ca" name="Dwarf Ranger in Heavy Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="a225-685b-18be-94ca" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="4d8c-d179-20b5-d943" name="Dwarf Ranger Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1584,7 +1593,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d087-5aa3-5b38-d1ce" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="ff72-e9cb-cb3c-e2f8" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="7495-0b19-d3ec-91f4" name="Dwarf Ranger Leader in Medium Armour" hidden="false" targetId="e512-a6cd-04f8-99cb" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -1615,7 +1623,7 @@
             </selectionEntry>
             <selectionEntry id="8e77-d307-2416-a4bf" name="Dwarf Rangers in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="e5af-d35b-79c5-ba84" name="Dwarf Ranger in Light Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="e5af-d35b-79c5-ba84" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="f315-c22b-e80e-e201" name="Dwarf Ranger Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1623,7 +1631,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd32-92d9-a419-b9f0" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="e2ba-a114-914f-c0f0" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="6477-cf51-d0f1-add1" name="Dwarf Ranger Leader in Light Armour" hidden="false" targetId="cff9-1410-0464-6da8" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -1721,6 +1728,7 @@
       <infoLinks>
         <infoLink id="dec8-d0f8-7998-f28a" name="Crazed Psychotics" hidden="false" targetId="2b40-80c8-12cf-8f44" type="rule"/>
         <infoLink id="ed08-d328-683a-4395" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
+        <infoLink id="a356-e403-6dee-7813" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="dd24-9f6a-fd17-3f5f" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -1760,7 +1768,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c3f7-1f74-acbe-b2f8" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="c3f7-1f74-acbe-b2f8" name="Choose 4 to 9" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="f00c-edb7-88f3-a2d5" name="Maniac Leader" hidden="false" collective="false" type="model">
               <constraints>
@@ -1769,7 +1777,6 @@
               </constraints>
               <infoLinks>
                 <infoLink id="b198-d772-b32d-4ecb" name="Dwarf Maniac Leader" hidden="false" targetId="860c-5fd3-6005-5f42" type="profile"/>
-                <infoLink id="89ec-cff7-7207-da36" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="33.0"/>
@@ -1800,9 +1807,10 @@
     <selectionEntry id="5b61-10d0-464f-e4bf" name="Dwarf Stone Thrower [102 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="fca3-67c3-8e81-c0ba" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="0afa-0253-9bde-5c68" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="0afa-0253-9bde-5c68" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="3981-2f8b-e016-c829" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
         <infoLink id="0c8b-e96f-8245-fa91" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+        <infoLink id="5442-003e-51cc-43e1" name="Overhead" hidden="false" targetId="7751-622a-b896-4874" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="eeeb-58b8-013b-5b6f" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
@@ -1834,7 +1842,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6c00-0f03-7fbb-d34f" name="Crew" hidden="false" collective="false">
+        <selectionEntryGroup id="6c00-0f03-7fbb-d34f" name="Choose 3 to 5" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="c618-3726-acaf-97ec" name="Dwarf Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -1860,7 +1868,7 @@
     <selectionEntry id="caa8-a18a-d2a9-ee72" name="Dwarf Cannon [98 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="9769-b86a-4858-2c28" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="c94f-05da-fe75-96d8" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="c94f-05da-fe75-96d8" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="50d1-e4a0-e928-8ce4" name="Unstoppable" hidden="false" targetId="a8bf-f48c-1b08-58e6" type="rule"/>
         <infoLink id="9e4a-4214-9919-05a7" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
         <infoLink id="f564-8aa4-0f99-3615" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
@@ -1895,7 +1903,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f12c-420b-cfe7-811c" name="Crew" hidden="false" collective="false">
+        <selectionEntryGroup id="f12c-420b-cfe7-811c" name="Choose 3 to 5" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="8ed9-2f3e-4df7-33ba" name="Dwarf Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -1922,7 +1930,7 @@
       <infoLinks>
         <infoLink id="83f7-d5f6-88a3-d5f5" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="8fc5-dce6-1e09-7439" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
-        <infoLink id="0fd1-1866-7bb5-2b6b" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="0fd1-1866-7bb5-2b6b" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="fbe4-ce7f-b8c1-20d8" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
@@ -1944,7 +1952,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="8209-b6f4-406c-76c3" name="Crew" hidden="false" collective="false">
+        <selectionEntryGroup id="8209-b6f4-406c-76c3" name="Choose 3 to 5" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="b874-809b-9ec1-16e8" name="Dwarf Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -1969,7 +1977,7 @@
     </selectionEntry>
     <selectionEntry id="6f26-e1ce-d8ff-b54c" name="Dwarf Fire Cannon [108 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="a027-e0e9-2744-51a4" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="a027-e0e9-2744-51a4" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="d6ae-0e7b-7b77-80ec" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
         <infoLink id="a939-17da-f510-5402" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="20b7-2d03-76c0-872c" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
@@ -1993,7 +2001,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="33bb-7c09-b5d6-1ffe" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="5867-995a-6d51-9500">
+        <selectionEntryGroup id="33bb-7c09-b5d6-1ffe" name="Choose 3 to 5" hidden="false" collective="false" defaultSelectionEntryId="5867-995a-6d51-9500">
           <selectionEntries>
             <selectionEntry id="5867-995a-6d51-9500" name="Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -2019,7 +2027,7 @@
     <selectionEntry id="5310-7ff4-c260-fc1f" name="Dwarf Bolt Thrower [90 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="790b-d4a5-4d29-2e02" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="2cce-dacc-7923-4972" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="2cce-dacc-7923-4972" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="c72b-fce0-cffe-0aab" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
         <infoLink id="b201-6f86-3fdb-0ca4" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
@@ -2054,7 +2062,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="18ec-07ca-567f-4f2d" name="Crew" hidden="false" collective="false">
+        <selectionEntryGroup id="18ec-07ca-567f-4f2d" name="Choose 3 to 5" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="52fc-0385-7504-2def" name="Dwarf Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -2168,8 +2176,9 @@
     </selectionEntry>
     <selectionEntry id="a75b-c3ef-93c9-ec24" name="Dwarf Steam Juggernaut [245 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="c588-6c81-ab4a-9f61" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="c588-6c81-ab4a-9f61" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="83c9-9029-2019-a319" name="Juggernaut" hidden="false" targetId="db5d-a96a-7bfb-66f3" type="rule"/>
+        <infoLink id="e4b2-51cb-7b0a-808b" name="MoD3" hidden="false" targetId="a8ca-ba71-db97-bc20" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1410-35b4-ae4b-b69f" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
@@ -2182,7 +2191,6 @@
           </constraints>
           <infoLinks>
             <infoLink id="da97-1733-0fa3-0ee7" name="Steam Juggernaut with Cannon" hidden="false" targetId="8b88-6b2c-dd1c-751a" type="profile"/>
-            <infoLink id="b6be-43b7-1501-09ca" name="MoD3" hidden="false" targetId="a8ca-ba71-db97-bc20" type="rule"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="215.0"/>
@@ -2191,7 +2199,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="397c-26bc-1b2a-a8d3" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="789a-db01-71ca-6b7b">
+        <selectionEntryGroup id="397c-26bc-1b2a-a8d3" name="Choose 6 to 10" hidden="false" collective="false" defaultSelectionEntryId="789a-db01-71ca-6b7b">
           <selectionEntries>
             <selectionEntry id="789a-db01-71ca-6b7b" name="Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -2239,6 +2247,7 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="cbf2-2ec0-6727-a252" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
+                <infoLink id="1198-fa79-98eb-77b4" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2272,6 +2281,7 @@
             <selectionEntry id="3b47-9176-c9c9-32aa" name="Small Cannon" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="c69b-d7ca-df8d-bb90" name="Small Cannon" hidden="false" targetId="241a-1266-fce9-2638" type="profile"/>
+                <infoLink id="f82b-e3e6-1c1f-65f0" name="Unstoppable" hidden="false" targetId="a8bf-f48c-1b08-58e6" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2318,7 +2328,7 @@
       <infoLinks>
         <infoLink id="169d-15b8-ae92-e1ec" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="d3f9-4f0e-d07b-497e" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
-        <infoLink id="9c4d-2c02-32c7-9bd2" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="9c4d-2c02-32c7-9bd2" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="6ddc-0b79-3a34-9d47" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
@@ -2340,7 +2350,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="7515-071a-3e23-068c" name="Crew" hidden="false" collective="false">
+        <selectionEntryGroup id="7515-071a-3e23-068c" name="Choose 3 to 5" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="6179-596b-077f-b4fe" name="Dwarf Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -2855,7 +2865,7 @@ Cannon is fixed upon the deck or possibly in a turret and is permitted to fire w
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="a0f0-e080-e08b-fd51" name="Organ Gun" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="a0f0-e080-e08b-fd51" name="Organ Gun" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-20&quot;</characteristic>

--- a/Dwarfs.cat
+++ b/Dwarfs.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3b46-1dfa-75fc-f98f" name="Dwarfs" revision="1" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3b46-1dfa-75fc-f98f" name="Dwarfs" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="6dbd-0ad3-a92f-c7f6" name="Dwarf Lord" hidden="false" collective="false" targetId="c721-3183-d63d-d213" type="selectionEntry"/>
     <entryLink id="68b2-8587-0f02-6bc9" name="Dwarf Runesmith [81 pts]" hidden="false" collective="false" targetId="c40e-98bb-55a2-ca4c" type="selectionEntry"/>
@@ -22,6 +22,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="c721-3183-d63d-d213" name="Dwarf Lord [87 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="3150-2ae0-b3a7-dfe9" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="091e-879b-f9f5-3246" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -43,6 +46,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="86b3-51c0-74b9-d290" name="Bloomin Big Axes" hidden="false" collective="false" type="upgrade">
@@ -58,6 +62,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b6c-f559-7abe-9f67" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -66,6 +71,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -88,6 +94,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -104,6 +111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da24-0bc6-b820-f473" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -112,6 +120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -128,6 +137,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="894d-371e-c5ad-4372" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -136,6 +146,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -160,6 +171,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="82.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5989-181d-8651-3f65" name="Dwarf Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -172,6 +184,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -179,6 +192,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6a71-aabb-c1b4-5401" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
@@ -196,6 +210,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="91.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0476-19e4-21f0-6208" name="Dwarf Bodyguard in Heavy Armour" hidden="false" collective="false" type="model">
@@ -208,6 +223,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -215,6 +231,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -230,6 +247,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4c3d-e8d5-ab5d-100c" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -238,6 +256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="574e-d74e-cd44-886f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -246,6 +265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4527-eefa-999e-58e0" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -254,6 +274,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e57c-bc5a-db83-b243" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -262,6 +283,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="77a9-85f5-e1b0-25aa" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -270,6 +292,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dafd-fc76-27a9-2707" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -278,6 +301,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -285,9 +309,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c40e-98bb-55a2-ca4c" name="Dwarf Runesmith [81 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="35d3-b106-1a67-064f" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="5c48-c938-3c5a-408d" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
@@ -305,6 +333,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d113-18d9-f23c-454e" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -313,6 +342,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3364-d3a7-35f6-d38d" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -321,6 +351,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -337,6 +368,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6817-4901-87fc-f085" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -345,6 +377,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -361,6 +394,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99c1-8b8d-ac0a-4af9" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -369,6 +403,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -386,6 +421,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a315-0a3e-9a26-e5f1" name="Apprentice Runesmith" hidden="false" collective="false" type="model">
@@ -397,6 +433,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -419,6 +456,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -434,6 +472,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9bcf-b631-0b0d-9a5a" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -445,6 +484,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e87-2e4b-6418-d573" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -456,6 +496,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a624-77ca-be20-6432" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -467,6 +508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="593c-bc90-96fa-23df" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -478,6 +520,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f393-cade-edf1-a4c8" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -489,6 +532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0189-f869-65dc-1f2b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -500,6 +544,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="57b2-ff8e-b26e-16f1" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -511,6 +556,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2558-5c4d-c2bf-d8d1" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -522,6 +568,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbe7-0c59-a463-f3c2" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -533,6 +580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3153-e1ca-ffac-5a0c" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -544,6 +592,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96a5-5cc4-3ebc-b95e" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -555,6 +604,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d84e-820e-ea50-bfe5" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -566,6 +616,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e1bd-a535-d0e0-b121" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -577,6 +628,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -593,6 +645,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="72c5-67b6-fabc-52d8" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -601,6 +654,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ccd-a11d-e9c4-2ed1" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -609,6 +663,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a22d-b502-dd76-78dc" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -617,6 +672,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4265-52e6-b76f-20e2" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -625,6 +681,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a559-df7d-526f-1a25" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -633,6 +690,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff05-fa81-4367-6180" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -641,6 +699,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5aa2-83e5-5e79-1f53" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -649,6 +708,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d8ac-7bfa-f5b5-d4ac" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -657,6 +717,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6772-4143-fd80-1c8f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -665,6 +726,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="122d-7e13-00ff-0b71" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -673,6 +735,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ceca-8f2b-16f5-a042" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -681,6 +744,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c6d7-4bfb-d5e0-0ba0" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -689,6 +753,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="744e-e030-9c59-cb11" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -697,6 +762,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -712,6 +778,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d8af-af6d-34d6-5aff" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -720,6 +787,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="783f-c219-f28f-a2df" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -728,6 +796,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="041e-fffd-f288-6a39" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -736,6 +805,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bec5-e879-7936-d0a3" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -744,6 +814,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="37f5-81a7-f3df-0459" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -752,6 +823,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="46a1-2e6f-8f21-70b1" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -760,6 +832,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -767,9 +840,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a6db-bd48-1d3e-8292" name="Dwarf Hero [86 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="7aa9-16f7-1283-d9cf" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
       </infoLinks>
@@ -788,6 +865,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -804,6 +882,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c138-df81-da8d-a098" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -812,6 +891,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -828,6 +908,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3739-8036-7b0e-927a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -836,6 +917,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aaa7-9443-7dae-5b41" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -844,6 +926,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -859,6 +942,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -874,6 +958,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -890,6 +975,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3f51-bc10-6c09-45fd" name="Dwarf Hero in Heavy Armour" hidden="false" collective="false" type="model">
@@ -898,6 +984,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3bcb-bb94-69eb-1ecf" name="Dwarf Hero, Crazed Psychotic (No Armour)" hidden="false" collective="false" type="model">
@@ -907,6 +994,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="87.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -923,6 +1011,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ecd8-da49-612a-346f" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -931,6 +1020,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -946,6 +1036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="151c-0ab7-5d64-317f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -954,6 +1045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d4d4-97cc-5deb-c714" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -962,6 +1054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="38a5-33b9-6e86-006d" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -970,6 +1063,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="768d-fa50-7f62-6bee" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -978,6 +1072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d54-8e25-ed90-c245" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -986,6 +1081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="efc0-dd43-2732-bbd8" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -994,6 +1090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1001,9 +1098,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3737-797e-c49a-bd2e" name="Dwarf Guard [115 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="f1ee-3612-a118-2e94" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
       </infoLinks>
@@ -1024,6 +1125,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7242-cd1b-74f6-b8b3" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1032,6 +1134,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1058,6 +1161,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4d9c-08b7-f862-57b1" name="Dwarf Guard" hidden="false" collective="false" type="model">
@@ -1070,6 +1174,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1077,6 +1182,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eac7-0b3a-cf5b-613f" name="Dwarf Guard in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1094,6 +1200,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3be7-e411-54a5-9a80" name="Dwarf Guard" hidden="false" collective="false" type="model">
@@ -1106,6 +1213,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1113,6 +1221,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1120,9 +1229,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0af2-4120-b7ef-ed73" name="Dwarf Warriors [100 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="1565-f8fe-ea4f-7b8d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1149,6 +1262,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4b27-6479-27fd-2189" name="Dwarf Warrior" hidden="false" collective="false" type="model">
@@ -1161,6 +1275,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1168,6 +1283,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="683e-3a8b-10c4-b24f" name="Dwarf Warriors in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1185,6 +1301,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1243-0fc6-7980-34af" name="Dwarf Warrior" hidden="false" collective="false" type="model">
@@ -1197,6 +1314,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1204,6 +1322,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1228,6 +1347,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04c0-2158-168c-2d02" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1236,6 +1356,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3faa-e697-9a05-083f" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1244,6 +1365,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bf3a-d27a-e592-1111" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1252,6 +1374,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fd7b-549b-3973-848d" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1271,6 +1394,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1278,9 +1402,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0120-dc29-e7a3-7a46" name="Dwarf Archers [100 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="16ac-b9d5-d590-94a3" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
       </infoLinks>
@@ -1309,6 +1437,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a89b-cfbb-18f7-dbb8" name="Dwarf Archer" hidden="false" collective="false" type="model">
@@ -1321,6 +1450,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1328,6 +1458,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a70-2217-86dc-03f0" name="Dwarf Archers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1345,6 +1476,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="159b-b450-bbc9-884e" name="Dwarf Archer" hidden="false" collective="false" type="model">
@@ -1357,6 +1489,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1364,6 +1497,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1380,6 +1514,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="69af-eb55-a24d-4267" name="Crossbow" hidden="false" collective="false" type="upgrade">
@@ -1395,6 +1530,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1402,9 +1538,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8600-3664-2ff7-0154" name="Dwarf Handgunners [110 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="4201-3261-ac27-eeff" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
         <infoLink id="b68e-0da9-b61a-5dad" name="Handgun" hidden="false" targetId="c6ac-d307-29c2-4ef1" type="profile"/>
@@ -1434,6 +1574,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="09c3-0f1d-0c79-6ffb" name="Dwarf Handgunner" hidden="false" collective="false" type="model">
@@ -1446,6 +1587,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1453,6 +1595,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1660-d9da-eeee-93e1" name="Dwarf Handgunners in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1470,6 +1613,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2359-0904-458a-8915" name="Dwarf Handgunner" hidden="false" collective="false" type="model">
@@ -1482,6 +1626,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1489,6 +1634,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1496,9 +1642,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c3c0-1daa-695f-77ce" name="Dwarf Pony Riders [70 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="034b-4146-4c27-d7fa" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -1527,6 +1677,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="bc3d-f58e-d8f9-5f05" name="Dwarf Pony Rider" hidden="false" collective="false" type="model">
@@ -1539,6 +1690,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1546,6 +1698,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8814-e0ea-0db2-a3bc" name="Dwarf Pony Riders in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1563,6 +1716,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1641-820c-099b-fe0d" name="Dwarf Pony Rider" hidden="false" collective="false" type="model">
@@ -1575,6 +1729,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1582,6 +1737,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1598,6 +1754,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9a6f-73f6-31c6-02ba" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1606,6 +1763,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1613,9 +1771,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ce6-e262-f72d-7f94" name="Dwarf Rangers [112 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="d842-da47-74cd-3826" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
         <infoLink id="b625-ac56-05f4-ffe3" name="Vengeful" hidden="false" targetId="5e63-c99b-00b4-24eb" type="rule"/>
@@ -1645,6 +1807,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="479b-2011-1673-9b12" name="Dwarf Ranger" hidden="false" collective="false" type="model">
@@ -1657,6 +1820,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1664,6 +1828,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8e77-d307-2416-a4bf" name="Dwarf Rangers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1681,6 +1846,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ae9d-7ca4-16a9-b011" name="Dwarf Ranger" hidden="false" collective="false" type="model">
@@ -1693,6 +1859,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1700,6 +1867,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1716,6 +1884,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="229a-d0b0-45cf-dd7d" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1732,6 +1901,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1754,6 +1924,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1761,9 +1932,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d21b-4748-3e74-0e99" name="Dwarf Crazed Psychotic Axe-wielding Maniacs [117 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="dec8-d0f8-7998-f28a" name="Crazed Psychotics" hidden="false" targetId="2b40-80c8-12cf-8f44" type="rule"/>
         <infoLink id="ed08-d328-683a-4395" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
@@ -1792,6 +1967,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29d1-a06a-4baf-d6c5" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1800,6 +1976,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1817,6 +1994,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="33.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="276b-6b61-b1b8-d49d" name="Maniac" hidden="false" collective="false" type="model">
@@ -1829,6 +2007,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1836,9 +2015,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5b61-10d0-464f-e4bf" name="Dwarf Stone Thrower [102 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="fca3-67c3-8e81-c0ba" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="913d-aef7-9d58-1ef1" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1860,6 +2043,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1ccb-6fac-9c0f-24bd" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -1868,6 +2052,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1884,6 +2069,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1891,9 +2077,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="caa8-a18a-d2a9-ee72" name="Dwarf Cannon [98 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="9769-b86a-4858-2c28" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="b19f-ad64-bf7b-6d7d" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1916,6 +2106,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4bf2-d3bd-d61b-f63d" name="Large Cannon" hidden="false" collective="false" type="upgrade">
@@ -1924,6 +2115,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="100.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1940,6 +2132,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1947,9 +2140,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="55f2-2eeb-c566-db0a" name="Dwarf Bombard [93 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="83f7-d5f6-88a3-d5f5" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="8fc5-dce6-1e09-7439" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1971,6 +2168,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="45.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1987,6 +2185,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1994,9 +2193,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6f26-e1ce-d8ff-b54c" name="Dwarf Fire Cannon [108 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="a027-e0e9-2744-51a4" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
       </infoLinks>
@@ -2016,6 +2219,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2034,6 +2238,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2041,9 +2246,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5310-7ff4-c260-fc1f" name="Dwarf Bolt Thrower [90 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="790b-d4a5-4d29-2e02" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="97ed-e67a-be81-02b3" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2065,6 +2274,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83ee-bd8c-e8c7-59c6" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2074,6 +2284,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2090,6 +2301,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2097,9 +2309,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a844-a11e-a600-98e7" name="Dwarf Flying Machine" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="389f-1c24-2058-bf2e" type="max"/>
       </constraints>
@@ -2119,6 +2335,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="94.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2135,6 +2352,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f930-f93d-c612-99b8" name="Bombs" hidden="false" collective="false" type="upgrade">
@@ -2143,6 +2361,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2160,9 +2379,11 @@
                 <infoLink id="561d-640d-a8bc-6230" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
                 <infoLink id="e952-ad5a-9de5-6311" name="Ramshackle Contraption" hidden="false" targetId="182e-9b37-17f3-5b45" type="rule"/>
                 <infoLink id="b908-abb7-21f2-c2ae" name="Flying Machine With Bombs" hidden="false" targetId="953a-ca2d-befd-cc62" type="profile"/>
+                <infoLink id="808e-3e97-b5ae-3c53" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2178,6 +2399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2185,9 +2407,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a75b-c3ef-93c9-ec24" name="Dwarf Steam Juggernaut [245 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="3.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="c588-6c81-ab4a-9f61" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
         <infoLink id="83c9-9029-2019-a319" name="Juggernaut" hidden="false" targetId="db5d-a96a-7bfb-66f3" type="rule"/>
@@ -2201,6 +2427,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ada-d6e1-0313-f678" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4e2-fe55-9c03-ed0b" type="max"/>
           </constraints>
+          <infoLinks>
+            <infoLink id="0bca-5ba0-3040-fe3d" name="MoD3" hidden="false" targetId="a8ca-ba71-db97-bc20" type="rule"/>
+          </infoLinks>
           <selectionEntries>
             <selectionEntry id="4e07-8cb6-0f17-5dc6" name="Juggernaut" hidden="false" collective="false" type="upgrade">
               <infoLinks>
@@ -2208,6 +2437,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="215.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2224,6 +2454,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2246,6 +2477,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e117-43d7-fd7d-34ea" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -2261,6 +2493,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2276,6 +2509,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2292,6 +2526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1eb2-2c27-84c0-87e3" name="Large Cannon" hidden="false" collective="false" type="upgrade">
@@ -2301,6 +2536,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ccf-e126-235d-2834" name="Fire Cannon" hidden="false" collective="false" type="upgrade">
@@ -2309,6 +2545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7afc-c651-8c20-1a63" name="Organ Gun" hidden="false" collective="false" type="upgrade">
@@ -2317,6 +2554,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2324,9 +2562,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d036-c54c-7e19-e1a9" name="Dwarf Organ Gun" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="169d-15b8-ae92-e1ec" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="d3f9-4f0e-d07b-497e" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2348,6 +2590,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2364,6 +2607,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2371,6 +2615,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Dwarfs.cat
+++ b/Dwarfs.cat
@@ -233,77 +233,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0ef2-2279-417d-1212" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d42-70f0-34d8-d07d" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="02df-3449-d7bf-649e" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9945-d7d7-3ff3-a51e" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4c3d-e8d5-ab5d-100c" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ddae-03ed-e253-863d" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="574e-d74e-cd44-886f" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9ba9-d94e-f5b9-64bb" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4527-eefa-999e-58e0" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="2d0d-4de9-b423-8fb0" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e57c-bc5a-db83-b243" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="64f2-3928-e4e8-4228" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="77a9-85f5-e1b0-25aa" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="680b-f82e-99c1-5bb2" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="dafd-fc76-27a9-2707" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="83e4-72f3-b34c-b21a" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1a32-0539-ebe7-9e97" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -761,77 +694,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8d58-6131-0c1f-6186" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2b1-13da-d56f-649d" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="0c04-ca53-ff84-48ae" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="cfda-613b-1f6b-04df" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d8af-af6d-34d6-5aff" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1b4d-4094-2d4e-9ed8" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="783f-c219-f28f-a2df" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="87f5-dc52-cd99-12a8" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="041e-fffd-f288-6a39" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0dcb-5eda-dd94-37cb" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="bec5-e879-7936-d0a3" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c1a4-c1d3-672e-9319" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="37f5-81a7-f3df-0459" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e42f-34b2-53b9-f1c3" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="46a1-2e6f-8f21-70b1" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4d4f-4cde-9910-6da1" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="97c2-e718-76fc-dd0a" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -1020,77 +886,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="06ae-4512-80e5-122b" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d082-8ddb-12ba-1bd9" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="99f1-5853-05e5-f149" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a414-3a6f-94bb-ec2c" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="151c-0ab7-5d64-317f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="64a1-296c-afe3-1ad9" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d4d4-97cc-5deb-c714" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0fee-974d-d6ff-bb09" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="38a5-33b9-6e86-006d" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e60d-cbf2-8e36-b5c2" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="768d-fa50-7f62-6bee" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ff3d-ad23-77de-f5f2" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7d54-8e25-ed90-c245" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="3a16-32fc-7c51-5508" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="efc0-dd43-2732-bbd8" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="db38-a48f-964e-a092" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="908a-815e-c330-1f33" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -1508,7 +1307,7 @@
             </selectionEntry>
             <selectionEntry id="69af-eb55-a24d-4267" name="Crossbow" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="0120-dc29-e7a3-7a46" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -1516,6 +1315,7 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="2448-8be6-62e8-991c" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
+                <infoLink id="41f1-20fa-72a3-3c41" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1534,6 +1334,7 @@
       <infoLinks>
         <infoLink id="4201-3261-ac27-eeff" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
         <infoLink id="b68e-0da9-b61a-5dad" name="Handgun" hidden="false" targetId="c6ac-d307-29c2-4ef1" type="profile"/>
+        <infoLink id="d6c8-1f57-4e4a-588d" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a764-2034-aa55-fcd7" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -1761,6 +1562,7 @@
       <infoLinks>
         <infoLink id="d842-da47-74cd-3826" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
         <infoLink id="b625-ac56-05f4-ffe3" name="Vengeful" hidden="false" targetId="5e63-c99b-00b4-24eb" type="rule"/>
+        <infoLink id="3935-5ffd-0cd2-f917" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1fc1-99e6-f464-e3e7" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -2000,6 +1802,7 @@
         <infoLink id="fca3-67c3-8e81-c0ba" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="0afa-0253-9bde-5c68" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
         <infoLink id="3981-2f8b-e016-c829" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="0c8b-e96f-8245-fa91" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="eeeb-58b8-013b-5b6f" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
@@ -2060,6 +1863,7 @@
         <infoLink id="c94f-05da-fe75-96d8" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
         <infoLink id="50d1-e4a0-e928-8ce4" name="Unstoppable" hidden="false" targetId="a8bf-f48c-1b08-58e6" type="rule"/>
         <infoLink id="9e4a-4214-9919-05a7" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="f564-8aa4-0f99-3615" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="cf89-f7fc-cc96-7eeb" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
@@ -2119,28 +1923,27 @@
         <infoLink id="83f7-d5f6-88a3-d5f5" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="8fc5-dce6-1e09-7439" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
         <infoLink id="0fd1-1866-7bb5-2b6b" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="fbe4-ce7f-b8c1-20d8" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="efd0-9619-9b45-7928" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="fb5a-51f0-d5f5-f9cd" name="Bombard" hidden="false" collective="false" defaultSelectionEntryId="a7e2-2202-4473-2d83">
+      <selectionEntries>
+        <selectionEntry id="7044-8cd7-d34c-638d" name="Bombard" hidden="false" collective="false" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c347-0e9a-6abb-fd58" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33c2-282f-0833-5af6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f9f-eb7b-dbe8-20b0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7619-4ef2-a7e7-df1d" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="a7e2-2202-4473-2d83" name="Bombard" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c101-b30e-db19-4eb4" name="Bombard" hidden="false" targetId="83bd-49e2-6f9b-a638" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="45.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+          <infoLinks>
+            <infoLink id="0fda-817b-0048-c199" name="Bombard" hidden="false" targetId="83bd-49e2-6f9b-a638" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="45.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="8209-b6f4-406c-76c3" name="Crew" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="b874-809b-9ec1-16e8" name="Dwarf Crew" hidden="false" collective="false" type="model">
@@ -2169,10 +1972,26 @@
         <infoLink id="a027-e0e9-2744-51a4" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
         <infoLink id="d6ae-0e7b-7b77-80ec" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
         <infoLink id="a939-17da-f510-5402" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="20b7-2d03-76c0-872c" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4840-1e56-24e2-7c40" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2adf-663d-a5da-49d7" name="Fire Cannon" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e57-e844-4e48-f5ae" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fec4-2f70-77c7-3661" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2954-02f3-a8af-e8cf" name="Fire Cannon" hidden="false" targetId="fc55-3266-2aa3-9d8a" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="60.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="33bb-7c09-b5d6-1ffe" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="5867-995a-6d51-9500">
           <selectionEntries>
@@ -2191,25 +2010,6 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f0d4-4a09-ec99-2ba2" name="Fire Cannon" hidden="false" collective="false" defaultSelectionEntryId="845e-be82-554f-c34e">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e7f-b090-97af-7d7b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5e4-bfae-5120-f944" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="845e-be82-554f-c34e" name="Fire Cannon" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c744-f82e-4edd-5dfa" name="Fire Cannon" hidden="false" targetId="fc55-3266-2aa3-9d8a" type="profile"/>
-                <infoLink id="93c0-2c2b-b9e5-a43f" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="7c78-1af7-7cc4-a62d" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="60.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -2221,6 +2021,7 @@
         <infoLink id="790b-d4a5-4d29-2e02" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="2cce-dacc-7923-4972" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
         <infoLink id="c72b-fce0-cffe-0aab" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="b201-6f86-3fdb-0ca4" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="28df-e7a4-a6aa-2cef" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
@@ -2283,24 +2084,40 @@
       <categoryLinks>
         <categoryLink id="9d5f-5b00-3d76-aa5f" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="c749-efaa-ca64-12a5" name="Pilot" hidden="false" collective="false" defaultSelectionEntryId="4cb7-919d-4657-0d48">
+      <selectionEntries>
+        <selectionEntry id="18e7-5b81-d921-034a" name="Flying Machine" hidden="false" collective="false" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c7c-aec1-c8d2-94dd" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3db1-6ccd-0f45-2f32" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d296-b68f-abe5-ed96" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="696e-2c52-8558-c76e" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="4cb7-919d-4657-0d48" name="Pilot" hidden="false" collective="false" type="model">
-              <infoLinks>
-                <infoLink id="f7d3-048a-515e-2228" name="Dwarf Pilot" hidden="false" targetId="46a0-3c62-e534-e7a0" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="94.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+          <infoLinks>
+            <infoLink id="01ad-a40a-6455-bfc7" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+            <infoLink id="3aa3-aea7-2983-2266" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
+            <infoLink id="6d2f-f529-2de3-68f4" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+            <infoLink id="f391-5f3d-f23b-3d86" name="Ramshackle Contraption" hidden="false" targetId="182e-9b37-17f3-5b45" type="rule"/>
+            <infoLink id="cec7-01a8-0881-85d5" name="Flying Machine With Bombs" hidden="false" targetId="953a-ca2d-befd-cc62" type="profile"/>
+            <infoLink id="3de7-09bf-8a7b-66c7" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0771-d48f-2770-9cec" name="Pilot" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c464-2e83-86d8-af01" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="247e-462c-6e36-b03e" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="fd8b-63a5-b13f-990d" name="Dwarf Pilot" hidden="false" targetId="46a0-3c62-e534-e7a0" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="94.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="83b9-fa6f-1780-b376" name="Bouncing Bombs" hidden="false" collective="false" defaultSelectionEntryId="f930-f93d-c612-99b8">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ce2-937d-dd2f-4964" type="max"/>
@@ -2319,28 +2136,6 @@
             <selectionEntry id="f930-f93d-c612-99b8" name="Bombs" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="7cff-725a-ee9f-e62e" name="Bomb" hidden="false" targetId="8a33-4972-aa2d-d058" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="e007-b3f9-79aa-dcdb" name="Flying Machine" hidden="false" collective="false" defaultSelectionEntryId="c2f5-3e39-fcc8-a5ee">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a013-74b9-a209-8daa" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0df3-0528-8b48-81fc" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="c2f5-3e39-fcc8-a5ee" name="Flying Machine" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d2d2-73d2-3468-5020" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="8a63-bfa1-cfee-d309" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
-                <infoLink id="561d-640d-a8bc-6230" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-                <infoLink id="e952-ad5a-9de5-6311" name="Ramshackle Contraption" hidden="false" targetId="182e-9b37-17f3-5b45" type="rule"/>
-                <infoLink id="b908-abb7-21f2-c2ae" name="Flying Machine With Bombs" hidden="false" targetId="953a-ca2d-befd-cc62" type="profile"/>
-                <infoLink id="808e-3e97-b5ae-3c53" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2379,27 +2174,23 @@
       <categoryLinks>
         <categoryLink id="1410-35b4-ae4b-b69f" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="cc31-9b17-778f-60db" name="Juggernaut" hidden="false" collective="false" defaultSelectionEntryId="4e07-8cb6-0f17-5dc6">
+      <selectionEntries>
+        <selectionEntry id="f978-57f8-6c32-52c0" name="Juggernaut" hidden="false" collective="false" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ada-d6e1-0313-f678" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4e2-fe55-9c03-ed0b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="197d-43be-243a-c636" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="374e-bef0-9f20-45c6" type="min"/>
           </constraints>
           <infoLinks>
-            <infoLink id="0bca-5ba0-3040-fe3d" name="MoD3" hidden="false" targetId="a8ca-ba71-db97-bc20" type="rule"/>
+            <infoLink id="da97-1733-0fa3-0ee7" name="Steam Juggernaut with Cannon" hidden="false" targetId="8b88-6b2c-dd1c-751a" type="profile"/>
+            <infoLink id="b6be-43b7-1501-09ca" name="MoD3" hidden="false" targetId="a8ca-ba71-db97-bc20" type="rule"/>
           </infoLinks>
-          <selectionEntries>
-            <selectionEntry id="4e07-8cb6-0f17-5dc6" name="Juggernaut" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="62e2-6534-65a2-0a74" name="Steam Juggernaut with Cannon" hidden="false" targetId="8b88-6b2c-dd1c-751a" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="215.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+          <costs>
+            <cost name="pts" typeId="points" value="215.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="397c-26bc-1b2a-a8d3" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="789a-db01-71ca-6b7b">
           <selectionEntries>
             <selectionEntry id="789a-db01-71ca-6b7b" name="Crew" hidden="false" collective="false" type="model">
@@ -2526,30 +2317,29 @@
     <selectionEntry id="d036-c54c-7e19-e1a9" name="Dwarf Organ Gun" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="169d-15b8-ae92-e1ec" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="d3f9-4f0e-d07b-497e" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+        <infoLink id="d3f9-4f0e-d07b-497e" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
         <infoLink id="9c4d-2c02-32c7-9bd2" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+        <infoLink id="6ddc-0b79-3a34-9d47" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0c4c-abcc-f61d-6091" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="ea24-85d6-087b-b449" name="Organ Gun" hidden="false" collective="false" defaultSelectionEntryId="5ce2-813d-737b-0cec">
+      <selectionEntries>
+        <selectionEntry id="a8cb-28aa-e1df-2c9a" name="Organ Gun" hidden="false" collective="false" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3405-c909-9270-4c10" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0198-e0be-de71-020e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6df7-ac57-c6b9-2cdf" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a589-77d4-0b38-ae36" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="5ce2-813d-737b-0cec" name="Organ Gun" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b283-f69d-8986-f827" name="Organ Gun" hidden="false" targetId="a0f0-e080-e08b-fd51" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="60.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+          <infoLinks>
+            <infoLink id="60a6-abdb-b93e-a068" name="Organ Gun" hidden="false" targetId="a0f0-e080-e08b-fd51" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="60.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="7515-071a-3e23-068c" name="Crew" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="6179-596b-077f-b4fe" name="Dwarf Crew" hidden="false" collective="false" type="model">

--- a/Elves.cat
+++ b/Elves.cat
@@ -18,7 +18,11 @@
     <entryLink id="7251-4d26-5d58-723d" name="Elven Stone Thrower [93 pts]" hidden="false" collective="false" targetId="1f4e-7ddd-0923-cd17" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="9a7d-1a27-895a-cd53" name="Elven Lord [108 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="9a7d-1a27-895a-cd53" name="Elven Lord" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="7a4b-235b-44e9-6462" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+        <infoLink id="dce4-f0a3-1e03-baf6" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="fe12-55e3-e0ff-330f" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="f3cc-6c74-5912-cf0b" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -75,7 +79,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f96b-0673-f3a8-40ef" name="Elven Lord Tough Level" hidden="false" collective="false" defaultSelectionEntryId="17d5-d186-c9fd-71b3">
+        <selectionEntryGroup id="f96b-0673-f3a8-40ef" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="17d5-d186-c9fd-71b3">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c01-28d2-5281-a5f9" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5d4-bee1-ff6a-b7b2" type="min"/>
@@ -101,7 +105,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1814-0429-79f7-f269" name="Elven Lord Wound Level" hidden="false" collective="false" defaultSelectionEntryId="e587-65fb-7726-6348">
+        <selectionEntryGroup id="1814-0429-79f7-f269" name="Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="e587-65fb-7726-6348">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc72-cea0-9a39-64f7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad9e-f725-99ec-4d7f" type="max"/>
@@ -127,15 +131,15 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="90fd-9021-7d14-405b" name="Models" hidden="false" collective="false" defaultSelectionEntryId="830e-351d-3f3d-9b8b">
+        <selectionEntryGroup id="90fd-9021-7d14-405b" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="830e-351d-3f3d-9b8b">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e519-c12f-3be0-7c63" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29a4-5f23-fa9d-9c9a" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="830e-351d-3f3d-9b8b" name="Elven Lord in Light Armour" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="830e-351d-3f3d-9b8b" name="Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="4b86-5d22-2620-771e" name="Elven Lord in Light Armour" hidden="false" collective="false" defaultSelectionEntryId="e502-1e68-4df8-6f06">
+                <selectionEntryGroup id="4b86-5d22-2620-771e" name="Choose 2 to 4" hidden="false" collective="false" defaultSelectionEntryId="e502-1e68-4df8-6f06">
                   <selectionEntries>
                     <selectionEntry id="e502-1e68-4df8-6f06" name="Elven Lord" hidden="false" collective="false" type="model">
                       <constraints>
@@ -144,8 +148,6 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="9fe9-12b0-300c-21dd" name="Elven Lord in Light Armour" hidden="false" targetId="1cc4-0d0e-ce09-a45d" type="profile"/>
-                        <infoLink id="62c3-df95-4370-cd3d" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                        <infoLink id="e839-d022-f54c-a48b" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="74.0"/>
@@ -173,9 +175,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8af0-6cac-e8d4-77e7" name="Elven Lord in Spangly Armour" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8af0-6cac-e8d4-77e7" name="Spangly Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="06fd-40a3-ac78-df8d" name="Elven Lord in Spangly Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="06fd-40a3-ac78-df8d" name="Choose 2 to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="9268-1c58-104c-cfc2" name="Elven Lord" hidden="false" collective="false" type="model">
                       <constraints>
@@ -183,8 +185,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b617-7200-8a42-c507" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="b43f-052f-38cc-089a" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                        <infoLink id="d53b-e73e-ee0d-bb1e" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
                         <infoLink id="ebda-9236-7104-acbe" name="Elven Lord in Spangly Armour" hidden="false" targetId="be1c-5f56-619b-ce42" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -215,77 +215,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="eeca-196d-b507-b565" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85e2-52f2-e4e9-35ca" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="b292-37bb-58c7-5919" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="df8f-2c2f-f08b-090a" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="fdcd-6dbb-bce5-8672" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5461-0e09-04b3-76c3" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="eaa6-34e8-00f5-a551" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="842c-30fc-f00f-5431" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="483c-9564-26b4-8a72" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ab31-4489-de32-1427" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="22ad-5cfb-c2cd-dd74" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="36ae-406b-ec61-41fe" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="05a5-8d47-94e8-b6c5" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b89b-c4a1-cf1e-92f1" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5aa7-4f4b-d873-75c6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="3cc3-b157-b005-f9cb" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6139-671e-382a-6303" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -294,6 +227,8 @@
     <selectionEntry id="b9d6-982d-12a3-da4d" name="Mounted Elven Lord [128 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="ad12-724b-5c6c-031d" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+        <infoLink id="5c5d-85a4-eeb0-9eb9" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+        <infoLink id="873a-a281-97f3-729c" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c08a-6a09-c86d-df30" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
@@ -306,7 +241,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be8d-1bf3-2f5d-e30d" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="d33e-ff08-1d88-c302" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d33e-ff08-1d88-c302" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="14a4-a342-0df5-a083" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
@@ -358,7 +293,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8c07-9616-1890-37b9" name="Models" hidden="false" collective="false" defaultSelectionEntryId="f689-95ae-efdf-47e5">
+        <selectionEntryGroup id="8c07-9616-1890-37b9" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="f689-95ae-efdf-47e5">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0f5-5cee-d010-fbe5" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c06e-8ff9-48a0-c166" type="min"/>
@@ -366,7 +301,7 @@
           <selectionEntries>
             <selectionEntry id="f689-95ae-efdf-47e5" name="Elven Lord in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="9c5f-9957-4759-efa2" name="Elven Lord in Light Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="9c5f-9957-4759-efa2" name="Choose 2 to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="d543-b182-836d-6bd7" name="Elven Lord" hidden="false" collective="false" type="model">
                       <constraints>
@@ -374,8 +309,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4ac-171f-6152-f75b" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="81c0-93cd-8dc2-ba3a" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                        <infoLink id="f695-4eb3-e782-39e8" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
                         <infoLink id="0768-f44b-c2a5-bf99" name="Mounted Elven Lord in Light Armour" hidden="false" targetId="5851-df8f-b744-e7fb" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -406,7 +339,7 @@
             </selectionEntry>
             <selectionEntry id="90c7-df4d-caca-17e5" name="Elven Lord in Spangly Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="3b20-b9ce-75c2-9c0e" name="Elven Lord in Spangly Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="3b20-b9ce-75c2-9c0e" name="Choose 2 to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="c684-674a-371b-b744" name="Elven Lord" hidden="false" collective="false" type="model">
                       <constraints>
@@ -414,8 +347,6 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2a2-7501-478e-008e" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="f6e9-a8a1-d822-c53b" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                        <infoLink id="721e-ef43-e9ad-78a4" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
                         <infoLink id="df53-39c8-f28d-cc44" name="Mounted Elven Lord in Spangly Armour" hidden="false" targetId="3279-9bce-ac9a-c354" type="profile"/>
                       </infoLinks>
                       <costs>
@@ -446,7 +377,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f098-c078-0d67-fc2d" name="Elven Lord Wound Level" hidden="false" collective="false" defaultSelectionEntryId="df9a-2a84-3601-6826">
+        <selectionEntryGroup id="f098-c078-0d67-fc2d" name="Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="df9a-2a84-3601-6826">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94c5-aca8-2c3d-1ffe" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8ba-ea38-a524-c2b8" type="max"/>
@@ -472,7 +403,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a28d-363d-fac5-03d6" name="Elven Lord Tough Level" hidden="false" collective="false" defaultSelectionEntryId="46c4-ca40-d458-2ac2">
+        <selectionEntryGroup id="a28d-363d-fac5-03d6" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="46c4-ca40-d458-2ac2">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2442-388e-9a0f-6ba4" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="813a-cf16-6d9b-3947" type="min"/>
@@ -525,83 +456,16 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6bdd-423b-bb93-0265" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c26b-fd53-b6b7-cc75" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="e116-6a94-cfc7-ee2e" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="fcf7-7e4f-0b3b-cbe0" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d98f-55d4-8de6-7890" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="64c0-f7c3-ddd7-d135" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="cc22-3b2a-dabb-a51b" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="deb3-d38f-e626-56e3" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5598-126b-0127-c9c2" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d447-f0a9-3900-af9f" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7055-2bf9-ef34-9f9c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="3ba7-aef5-d3c0-4f1a" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="44e0-87db-a938-fa18" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7240-831a-a405-70a8" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6e74-2c59-ce90-66fd" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0612-cd27-ddaf-e9d7" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="16d3-955e-148a-36cb" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a7d7-31cb-d9da-ee08" name="Elven Hero [77 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="a7d7-31cb-d9da-ee08" name="Elven Hero" hidden="false" collective="false" type="unit">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e244-973a-aa3a-3a44" type="max"/>
       </constraints>
@@ -629,7 +493,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3394-97d0-79a7-5e5f" name="Elven Hero Tough Level" hidden="false" collective="false" defaultSelectionEntryId="0208-d959-9570-377b">
+        <selectionEntryGroup id="3394-97d0-79a7-5e5f" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="0208-d959-9570-377b">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d482-daac-6b76-8dea" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84ff-b5cf-327f-b25c" type="min"/>
@@ -655,7 +519,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9351-4ffc-f681-494e" name="Elven Hero Wound Level" hidden="false" collective="false" defaultSelectionEntryId="68c2-4d7d-3e1c-ec6c">
+        <selectionEntryGroup id="9351-4ffc-f681-494e" name="Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="68c2-4d7d-3e1c-ec6c">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1c0-147e-a884-f5a3" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09c7-8ca0-9c3c-253a" type="max"/>
@@ -725,7 +589,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5e95-1d30-1fb8-f658" name="Models" hidden="false" collective="false" defaultSelectionEntryId="d0c6-e076-96b7-0e3b">
+        <selectionEntryGroup id="5e95-1d30-1fb8-f658" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="d0c6-e076-96b7-0e3b">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6070-f99b-54ff-cafc" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd36-c8ae-d9e2-2c39" type="min"/>
@@ -751,77 +615,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="7888-7a08-0df7-c0bc" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39e8-12be-fdf4-ee37" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="75c9-20da-72ee-7971" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="59b0-184f-8384-4613" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="93c3-ada6-5c63-3293" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1a7e-9218-ba4e-949a" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="24d7-c222-2ee0-5b3e" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="de72-59fe-fb91-004c" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2412-7ac2-bc62-e733" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5342-222b-e11b-e5d1" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="50fd-b515-6764-b3ad" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="3e9c-5cfd-e39c-6b5c" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8683-aa9b-882f-49d7" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a33c-562e-05c2-5d3c" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3028-8858-380c-e959" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e2fe-2021-25c0-4997" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a96b-f5da-0c1f-8b34" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -856,7 +653,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="10a0-ef6c-6249-f44d" name="Elven Hero Tough Level" hidden="false" collective="false" defaultSelectionEntryId="1fed-0de8-ece0-c5dc">
+        <selectionEntryGroup id="10a0-ef6c-6249-f44d" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="1fed-0de8-ece0-c5dc">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b1d-7504-4c04-d7d2" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc7f-e274-9e35-76db" type="min"/>
@@ -882,7 +679,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6ebc-dbe2-0b7d-4d24" name="Elven Hero Wound Level" hidden="false" collective="false" defaultSelectionEntryId="1db1-91e4-5078-e051">
+        <selectionEntryGroup id="6ebc-dbe2-0b7d-4d24" name="Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="1db1-91e4-5078-e051">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa2f-44a2-9e34-874f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a2e-3ef5-729c-ebf9" type="max"/>
@@ -923,7 +720,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a72-06dc-744a-55d0" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6db6-1f59-7777-2291" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6db6-1f59-7777-2291" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="8bfe-4da1-6604-466f" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
@@ -952,7 +749,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f1f1-db5f-4d71-11d0" name="Models" hidden="false" collective="false" defaultSelectionEntryId="9b7a-e8bd-17a6-a210">
+        <selectionEntryGroup id="f1f1-db5f-4d71-11d0" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="9b7a-e8bd-17a6-a210">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2378-3058-cdfc-75b5" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9385-d77e-6347-2d75" type="min"/>
@@ -995,106 +792,40 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="030d-bbaa-39ab-2abf" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="024d-6056-42de-fc24" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="6aae-2f74-7b6a-2619" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9412-0530-dc28-665a" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="15c0-f02e-301f-32fa" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e461-42dd-8158-cb45" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6ec8-75ab-f29f-701f" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d495-e774-7d69-c0b9" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f7e4-3d5f-0037-c3fb" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e2ed-1a7f-8a95-7f30" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="60c1-2a21-767b-98bd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="dd08-401a-5d95-3761" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="85f7-506e-7238-7494" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="2e55-965b-f984-88ab" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b704-c98a-3d08-9a90" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="88d1-41e3-0ff6-702b" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8b19-6918-183f-dafc" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2852-dd57-1bd8-8981" name="Elven Mage [62 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="2852-dd57-1bd8-8981" name="Elven Mage" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="025d-2608-491b-91cb" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="5cfe-635b-7ac6-df25" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="2194-6a48-821c-a892" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="9c90-69ef-2acd-f2bd" name="Mage" hidden="false" collective="false" defaultSelectionEntryId="ca73-d528-0417-6678">
+      <selectionEntries>
+        <selectionEntry id="c839-905e-f9ab-71fa" name="Mage" hidden="false" collective="false" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b123-eeb0-0572-f704" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d61-945e-3ef4-7337" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07bf-0a29-e422-7253" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed35-7ae6-12bd-4eea" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="ca73-d528-0417-6678" name="Mage" hidden="false" collective="false" type="model">
-              <infoLinks>
-                <infoLink id="94ca-0532-93c7-9d56" name="Elven Mage" hidden="false" targetId="f5ee-5ad7-bba8-e818" type="profile"/>
-                <infoLink id="865a-77a6-5ef7-ac2d" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="62.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+          <infoLinks>
+            <infoLink id="49dd-7ae5-7238-8852" name="Elven Mage" hidden="false" targetId="f5ee-5ad7-bba8-e818" type="profile"/>
+            <infoLink id="00ac-2778-cb84-8193" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="62.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="fcf0-a6fc-f18d-f707" name="Magic Level" hidden="false" collective="false" defaultSelectionEntryId="c840-fcf6-2779-732c">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="885e-9c02-e07e-746b" type="max"/>
@@ -1130,22 +861,26 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="eff1-46c3-0b1a-9a77" name="Apprentice or Daemons" hidden="false" collective="false">
+        <selectionEntryGroup id="eff1-46c3-0b1a-9a77" name="Apprentices or Daemons" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89ba-9b24-6a03-8674" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="2c65-048f-8b9d-2fd8" name="Apprentices" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="d7df-fa24-fbe8-153d" name="Apprentices" hidden="false" collective="false">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="561d-f095-4177-358a" type="max"/>
-                  </constraints>
+                <selectionEntryGroup id="d7df-fa24-fbe8-153d" name="Choose up to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="b302-9427-951b-f6f2" name="Apprentices" hidden="false" collective="false" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c17b-fd4d-d9a8-6539" type="max"/>
+                      </constraints>
                       <infoLinks>
                         <infoLink id="5d7a-2a89-21f5-0505" name="Apprentice Mages" hidden="false" targetId="8b3f-6ab4-f829-ca12" type="profile"/>
                       </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
@@ -1157,16 +892,20 @@
             </selectionEntry>
             <selectionEntry id="5ab3-a080-aba5-cce5" name="Daemons" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="5161-f662-da6e-5d2f" name="Daemons" hidden="false" collective="false">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be64-0584-6670-d598" type="max"/>
-                  </constraints>
+                <selectionEntryGroup id="5161-f662-da6e-5d2f" name="Choose up to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="7938-d90e-9009-0eba" name="Daemons" hidden="false" collective="false" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bdd-1356-e632-571b" type="max"/>
+                      </constraints>
                       <infoLinks>
                         <infoLink id="8752-53b9-f6bc-194b" name="Bound Daemons" hidden="false" targetId="346d-0141-da49-eecd" type="profile"/>
                         <infoLink id="0ed9-8203-2a84-c32c" name="Spirit" hidden="false" targetId="78d3-886d-5fc6-bac4" type="rule"/>
                       </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
@@ -1178,15 +917,19 @@
             </selectionEntry>
             <selectionEntry id="6d71-8895-ddae-7aec" name="Apprentices in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="7912-948c-8cfc-7f08" name="Apprentices in Light Armour" hidden="false" collective="false">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9aab-4f56-7c10-909a" type="max"/>
-                  </constraints>
+                <selectionEntryGroup id="7912-948c-8cfc-7f08" name="Choose up to 4" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="c959-b271-1868-5678" name="Apprentices in Light Armour" hidden="false" collective="false" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6710-70cb-f1be-33d7" type="max"/>
+                      </constraints>
                       <infoLinks>
                         <infoLink id="43c8-d5fb-e2cb-6132" name="Apprentice Mages in Light Armour" hidden="false" targetId="034b-d422-ccfe-63ca" type="profile"/>
                       </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
@@ -1198,7 +941,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ba5e-373b-fab6-c2b3" name="Mage Tough Level" hidden="false" collective="false" defaultSelectionEntryId="cbbb-2a42-a2ea-8cf8">
+        <selectionEntryGroup id="ba5e-373b-fab6-c2b3" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="cbbb-2a42-a2ea-8cf8">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba26-4cf7-8323-7d28" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97b0-1f6e-fe8a-5b24" type="min"/>
@@ -1546,83 +1289,16 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5456-66f8-254b-51af" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5eaa-71d4-c330-4dd7" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="d313-071d-9285-c8f5" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="2389-5e7d-3aa0-4a01" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7895-db08-6665-d0ab" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="94a7-297f-9bf5-7b04" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="abc5-24c8-c0f9-ca21" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="56f7-1144-257d-a81d" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8ed6-d4b4-cccc-4081" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="12f0-fcfa-58a2-6b96" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="affa-f390-4df4-969c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d5d8-2179-5db8-c3d8" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0421-f681-4d4d-16c2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e896-62c0-0c6f-d7ff" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0ad8-f128-5f6d-7b01" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7c61-20f1-4e90-d20a" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9c3b-1bdc-2216-ac8f" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="aa6f-d68a-6c78-68f8" name="Elven Guard [95 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="aa6f-d68a-6c78-68f8" name="Elven Guard" hidden="false" collective="false" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93a3-be59-ab8f-615c" type="max"/>
       </constraints>
@@ -1698,7 +1374,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1a64-3eff-f1ea-2944" name="Models" hidden="false" collective="false" defaultSelectionEntryId="1ab1-bbb8-7e49-3caf">
+        <selectionEntryGroup id="1a64-3eff-f1ea-2944" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="1ab1-bbb8-7e49-3caf">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5d5-ec5a-a7de-a3f6" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41b0-ce68-a7ea-d96c" type="min"/>
@@ -1706,7 +1382,7 @@
           <selectionEntries>
             <selectionEntry id="1ab1-bbb8-7e49-3caf" name="Elven Guard in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="6b04-320e-befa-0df2" name="Elven Guard in Light Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="6b04-320e-befa-0df2" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="0f03-e521-ad66-f250" name="Elven Guard Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1742,9 +1418,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0cd4-ce20-a380-2188" name="Elven Guard in Spangly Armour [+4 pts per model]" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0cd4-ce20-a380-2188" name="Elven Guard in Spangly Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="312a-03c1-59ff-12c9" name="Elven Guard in Spangly Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="312a-03c1-59ff-12c9" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="775e-3430-c8c5-d95f" name="Elven Guard" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1788,7 +1464,10 @@
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="badc-3155-f998-0995" name="Elven Warriors [95 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="badc-3155-f998-0995" name="Elven Warriors" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="5bc4-9c26-bc22-3761" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="0610-b28c-232c-fdbf" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1801,7 +1480,7 @@
           <selectionEntries>
             <selectionEntry id="0004-72ab-dcde-9f61" name="Sword" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="e76a-041c-2b96-0382" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="e76a-041c-2b96-0382" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1844,7 +1523,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c73e-9028-1487-b7d5" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="c73e-9028-1487-b7d5" name="Choose 4 to 9" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="e40e-f13a-125f-83ab" name="Elven Warrior Leader" hidden="false" collective="false" type="model">
               <constraints>
@@ -1852,8 +1531,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5137-f88a-e361-1041" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="0d80-9d12-0b81-e72d" name="Elven Warrior Leader" hidden="false" targetId="b1f7-05ac-5731-deb0" type="profile"/>
-                <infoLink id="9ef9-26b0-5843-656b" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+                <infoLink id="2603-33e3-64ca-f543" name="Elven Warrior Leader" hidden="false" targetId="b1f7-05ac-5731-deb0" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
@@ -1881,7 +1559,7 @@
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d269-784b-2037-0b91" name="Elven Archers [105 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d269-784b-2037-0b91" name="Elven Archers" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="2fc8-e344-7e1f-6e56" name="Longbow" hidden="false" targetId="d4c8-3ef2-18de-85c0" type="profile"/>
         <infoLink id="850e-39cc-2c51-d09f" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
@@ -1907,15 +1585,15 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4bff-7136-464a-3286" name="Models" hidden="false" collective="false" defaultSelectionEntryId="529c-68ca-ca82-da56">
+        <selectionEntryGroup id="4bff-7136-464a-3286" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="529c-68ca-ca82-da56">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bb2-e4ef-ba2d-4619" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6aa-b30a-fded-a9a4" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="529c-68ca-ca82-da56" name="Elven Archers" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="529c-68ca-ca82-da56" name="Elven Archers (no armour)" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="3612-0303-08a4-acf0" name="Elven Archers" hidden="false" collective="false">
+                <selectionEntryGroup id="3612-0303-08a4-acf0" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="2d17-1e4b-0f77-8881" name="Elven Archer Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1951,9 +1629,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a9a4-ecc6-9246-0d6a" name="Elven Archers in Light Armour [+2 pts per model]" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a9a4-ecc6-9246-0d6a" name="Elven Archers in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="41b3-da22-5692-7062" name="Elven Archers in Light Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="41b3-da22-5692-7062" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="b30d-0dda-7d63-2855" name="Elven Archers" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1997,7 +1675,7 @@
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5d83-e361-70c9-499c" name="Elven Rangers [141 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5d83-e361-70c9-499c" name="Elven Rangers" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="7046-634b-20d8-5ebd" name="Woodsman" hidden="false" targetId="e1f3-7817-0e4e-5cb9" type="rule"/>
         <infoLink id="da64-a1cf-d3a1-adc8" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
@@ -2024,7 +1702,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="90ee-9740-2aa1-adad" name="Models" hidden="false" collective="false" defaultSelectionEntryId="0e32-0a10-d5bd-571e">
+        <selectionEntryGroup id="90ee-9740-2aa1-adad" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="0e32-0a10-d5bd-571e">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78cc-b4d3-c9fc-0d28" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7cf-e017-f7eb-d128" type="min"/>
@@ -2032,7 +1710,7 @@
           <selectionEntries>
             <selectionEntry id="0e32-0a10-d5bd-571e" name="Elven Rangers in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="6a05-be98-0d09-2193" name="Elven Rangers in Light Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="6a05-be98-0d09-2193" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="5e2d-c948-2e98-3c48" name="Elven Ranger Leader" hidden="false" collective="false" type="model">
                       <constraints>
@@ -2068,9 +1746,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0f8f-189e-a46d-d71d" name="Elven Rangers in Spangly Armour [+4 pts per model]" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0f8f-189e-a46d-d71d" name="Elven Rangers in Spangly Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="26d0-d89e-2da9-a2c5" name="Elven Rangers in Spangly Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="26d0-d89e-2da9-a2c5" name="Choose 4 to 9" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="3658-22f1-2a6c-9f70" name="Elven Rangers" hidden="false" collective="false" type="model">
                       <constraints>
@@ -2114,7 +1792,7 @@
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="39cd-09b5-a58e-b4fa" name="Elven Cavalry [79 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="39cd-09b5-a58e-b4fa" name="Elven Cavalry" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="ffc9-c443-ae86-28bd" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
         <infoLink id="8457-a642-ed5a-18f2" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
@@ -2211,7 +1889,7 @@
           <selectionEntries>
             <selectionEntry id="bb28-fde5-671d-b66e" name="Replace Horse with Enchanted Steeds" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="8">
+                <modifier type="increment" field="points" value="8.0">
                   <repeats>
                     <repeat field="selections" scope="39cd-09b5-a58e-b4fa" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -2228,13 +1906,13 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e1a5-f785-cd57-cade" name="models" hidden="false" collective="false" defaultSelectionEntryId="33eb-342b-afe5-1ece">
+        <selectionEntryGroup id="e1a5-f785-cd57-cade" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="33eb-342b-afe5-1ece">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4571-1128-7869-b53a" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5135-bbb9-2a01-1e23" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="33eb-342b-afe5-1ece" name="Cavalry in No Armour" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="33eb-342b-afe5-1ece" name="No Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntries>
                 <selectionEntry id="2a42-58fd-9d98-00f4" name="Elven Cavalry Leader" hidden="false" collective="false" type="model">
                   <constraints>
@@ -2270,7 +1948,7 @@
             </selectionEntry>
             <selectionEntry id="6212-14ad-16ae-6763" name="Cavalry in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntries>
-                <selectionEntry id="b109-0438-e27d-bb2b" name="Elven Cavalry" hidden="false" collective="false" type="model">
+                <selectionEntry id="b109-0438-e27d-bb2b" name="Elven Cavalry in Light Armour" hidden="false" collective="false" type="model">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f593-15da-47c6-e595" type="min"/>
                     <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57f5-a549-9b48-76eb" type="max"/>
@@ -2283,7 +1961,7 @@
                     <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="422e-b0c5-2157-57d3" name="Elven Cavalry Leader" hidden="false" collective="false" type="model">
+                <selectionEntry id="422e-b0c5-2157-57d3" name="Elven Cavalry Leader in Light Armour" hidden="false" collective="false" type="model">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="551c-1640-b12c-f239" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca6d-a875-544c-f043" type="max"/>
@@ -2304,7 +1982,7 @@
             </selectionEntry>
             <selectionEntry id="a933-0dce-4e3c-3edd" name="Cavalry in Spangly Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntries>
-                <selectionEntry id="9d57-b335-b35d-9faf" name="Elven Cavalry" hidden="false" collective="false" type="model">
+                <selectionEntry id="9d57-b335-b35d-9faf" name="Elven Cavalry in Spangly Armour" hidden="false" collective="false" type="model">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fb4-200b-46a3-1e3d" type="min"/>
                     <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11da-29af-04f4-dc04" type="max"/>
@@ -2317,7 +1995,7 @@
                     <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="cbf4-98eb-637b-9bc5" name="Elven Cavalry Leader" hidden="false" collective="false" type="model">
+                <selectionEntry id="cbf4-98eb-637b-9bc5" name="Elven Cavalry Leader in Spangly Armour" hidden="false" collective="false" type="model">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c944-82b1-e974-cd25" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f978-806e-c599-c5e8" type="max"/>
@@ -2344,11 +2022,12 @@
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="52d3-bc0e-f380-0876" name="Elven Knights [104 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="52d3-bc0e-f380-0876" name="Elven Knights" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="e6ac-8a00-4ef4-20c1" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
         <infoLink id="9fd5-3c7c-26b2-c868" name="Haughty Disdain" hidden="false" targetId="6a8d-ef1b-6f78-e15c" type="rule"/>
         <infoLink id="9c26-38d7-76e8-b35d" name="Lance" hidden="false" targetId="e601-dcfc-7485-2164" type="profile"/>
+        <infoLink id="dd71-d06d-d2f2-9b05" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="55fa-e2ff-5e63-a5ea" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
@@ -2378,23 +2057,22 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="de47-eccb-fe2a-be46" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="de47-eccb-fe2a-be46" name="Choose 2 to 4" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="4d99-ad68-a06b-a7a0" name="Elven Knight Leader" hidden="false" collective="false" type="model">
+            <selectionEntry id="4d99-ad68-a06b-a7a0" name="Elven Knight Leader in Spangly Armour" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4b0-c9cc-d7b4-73a7" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46b3-7066-2f28-c54e" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="cb18-9c0d-d99f-1f83" name="Elven Knight Leader in Spangly Armour" hidden="false" targetId="3623-40b3-6d75-71aa" type="profile"/>
-                <infoLink id="f6d9-3ed3-8eab-eb67" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="48.0"/>
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="804c-4773-facd-9fcc" name="Elven Knights" hidden="false" collective="false" type="model">
+            <selectionEntry id="804c-4773-facd-9fcc" name="Elven Knights in Spangly Armour" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1af-7258-f69a-1e17" type="min"/>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb2c-d2e2-e88c-f733" type="max"/>
@@ -2415,28 +2093,28 @@
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d3d2-c832-23e1-9cb7" name="Giant Eagle [143 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d3d2-c832-23e1-9cb7" name="Giant Eagle" hidden="false" collective="false" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb05-afc1-ad4b-09a8" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="8cbc-73e8-57c5-aea5" name="Rock dropped by Eagle" hidden="false" targetId="c44d-adb8-ec8a-3dd4" type="profile"/>
+        <infoLink id="e178-dab9-6764-fac4" name="Fast 10" hidden="false" targetId="0034-82ae-f695-d446" type="rule"/>
+        <infoLink id="6702-d09f-6f54-4253" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+        <infoLink id="9f82-2c9b-d05a-b300" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="e4de-bf19-746c-deed" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bf49-17b0-2e60-7c69" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="8136-c92e-85f7-aed7" name="Giant Eagle with rocks" hidden="false" collective="false" type="model">
+        <selectionEntry id="8136-c92e-85f7-aed7" name="Giant Eagle with Rocks" hidden="false" collective="false" type="model">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e61-5dcf-7321-5a6e" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d066-99d9-fa97-9ebf" type="max"/>
           </constraints>
           <infoLinks>
             <infoLink id="63e7-ae40-471f-c7b2" name="Giant Eagle" hidden="false" targetId="40ac-4e12-eb5a-b9cb" type="profile"/>
-            <infoLink id="8665-2863-2327-9dac" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-            <infoLink id="9ee1-e93a-af9f-692a" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
-            <infoLink id="b1f7-3c0f-e84d-8ac6" name="Fast 10" hidden="false" targetId="0034-82ae-f695-d446" type="rule"/>
-            <infoLink id="0ee2-652c-3e84-121b" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="143.0"/>
@@ -2449,12 +2127,13 @@
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d7a0-4612-9a6d-2215" name="Elven Chariot [116 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="d7a0-4612-9a6d-2215" name="Elven Chariot" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="4160-5acc-9299-adcf" name="Longbow" hidden="false" targetId="d4c8-3ef2-18de-85c0" type="profile"/>
         <infoLink id="a314-015c-3b45-ef0e" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="a966-0876-2483-1f63" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
         <infoLink id="32d6-3eb5-6bee-cffc" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+        <infoLink id="6844-3434-9a15-00d4" name="Haughty Disdain" hidden="false" targetId="6a8d-ef1b-6f78-e15c" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bd78-5943-05d3-e559" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
@@ -2492,7 +2171,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="2f7a-c462-7a0a-da14" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="2f88-7d0d-ef0e-d11d">
+        <selectionEntryGroup id="2f7a-c462-7a0a-da14" name="Choose 2 to 4" hidden="false" collective="false" defaultSelectionEntryId="2f88-7d0d-ef0e-d11d">
           <selectionEntries>
             <selectionEntry id="2f88-7d0d-ef0e-d11d" name="Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -2501,7 +2180,6 @@
               </constraints>
               <infoLinks>
                 <infoLink id="d162-3d14-dff1-82eb" name="Elven Chariot Crew" hidden="false" targetId="7ef5-9e8f-90d8-3d74" type="profile"/>
-                <infoLink id="1bbf-f7f1-2ed0-4343" name="Haughty Disdain" hidden="false" targetId="6a8d-ef1b-6f78-e15c" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
@@ -2567,12 +2245,17 @@
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="555c-7461-6e9a-8467" name="Elven Bolt Thrower [93 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="555c-7461-6e9a-8467" name="Elven Bolt Thrower" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="4962-3aff-2e17-063e" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="5352-26d9-eb7d-8a25" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="3303-a206-80cd-f8f1" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="e441-50b4-417c-8922" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4871-68ee-157e-b6ee" name="Crew" hidden="false" collective="false">
+        <selectionEntryGroup id="4871-68ee-157e-b6ee" name="Choose 3 to 5" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="087c-7214-ea58-1922" name="Crew with Swords" hidden="false" collective="false" type="model">
               <constraints>
@@ -2580,10 +2263,7 @@
                 <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c47f-e0bd-c9bb-5e4a" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="347e-7ac7-c1eb-3e8d" name="Elven Crew with Bolt-throwing engine" hidden="false" targetId="6672-7f43-13f4-1423" type="profile"/>
-                <infoLink id="13ec-dcc6-6753-72e3" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="7d4d-d1b8-2d2f-160f" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
-                <infoLink id="2e54-ce32-81f0-8b97" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="347e-7ac7-c1eb-3e8d" name="Elven Crew with Bolt-throwing engine and swords" hidden="false" targetId="6672-7f43-13f4-1423" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
@@ -2625,12 +2305,18 @@
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1f4e-7ddd-0923-cd17" name="Elven Stone Thrower [105 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="1f4e-7ddd-0923-cd17" name="Elven Stone Thrower" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="c52f-1dc2-d4c5-139d" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="3a01-a9e9-2053-0a11" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="0e11-62d7-6848-53c4" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+        <infoLink id="3cc3-ff21-d2c3-3bc3" name="Overhead" hidden="false" targetId="7751-622a-b896-4874" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="baf1-a29c-e2e1-46da" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f25f-055a-0c25-8665" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="a689-5480-723f-dd49">
+        <selectionEntryGroup id="f25f-055a-0c25-8665" name="Choose 3 to 5" hidden="false" collective="false" defaultSelectionEntryId="a689-5480-723f-dd49">
           <selectionEntries>
             <selectionEntry id="a689-5480-723f-dd49" name="Crew with Swords" hidden="false" collective="false" type="model">
               <constraints>
@@ -2638,9 +2324,6 @@
                 <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de5d-7554-10d3-a091" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="93df-72c4-d3b2-e983" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="6382-e186-427f-d74a" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
-                <infoLink id="75f0-f12a-b297-2e5e" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
                 <infoLink id="0d40-3627-ba35-6029" name="Elven Crew with Stone-throwing engine and swords" hidden="false" targetId="ab3d-0678-c0ec-10f0" type="profile"/>
               </infoLinks>
               <costs>
@@ -2655,9 +2338,6 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1caf-e7d4-cb86-c24d" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="684a-8e31-c359-d149" type="min"/>
           </constraints>
-          <infoLinks>
-            <infoLink id="7009-3e41-6111-43fa" name="Overhead" hidden="false" targetId="7751-622a-b896-4874" type="rule"/>
-          </infoLinks>
           <selectionEntries>
             <selectionEntry id="4108-2a0e-5434-146b" name="Small Stone Thrower" hidden="false" collective="false" type="upgrade">
               <infoLinks>

--- a/Elves.cat
+++ b/Elves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="fe3c-0690-8599-2c5a" name="Elves" revision="1" battleScribeVersion="2.02" authorName="the3dwaragmer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="fe3c-0690-8599-2c5a" name="Elves" revision="2" battleScribeVersion="2.02" authorName="the3dwaragmer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="f9fe-8a78-d73c-6467" name="Elven Lord" hidden="false" collective="false" targetId="9a7d-1a27-895a-cd53" type="selectionEntry"/>
     <entryLink id="806f-cefb-1bbc-16ba" name="Mounted Elven Lord" hidden="false" collective="false" targetId="b9d6-982d-12a3-da4d" type="selectionEntry"/>
@@ -19,6 +19,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="9a7d-1a27-895a-cd53" name="Elven Lord [108 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="fe12-55e3-e0ff-330f" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="f3cc-6c74-5912-cf0b" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -36,6 +39,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5ce-bd0d-9ffb-876f" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -44,6 +48,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f92-2628-6609-c9aa" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -52,6 +57,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -67,6 +73,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -83,6 +90,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f8ae-b91f-590a-7c2b" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -91,6 +99,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -107,6 +116,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="111c-d14e-6a91-733f" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -115,6 +125,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -141,6 +152,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="74.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="7d39-e268-cac6-3d83" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -153,6 +165,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -160,6 +173,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8af0-6cac-e8d4-77e7" name="Elven Lord in Spangly Armour" hidden="false" collective="false" type="upgrade">
@@ -178,6 +192,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="89.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="35e1-bb12-c48e-988f" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -190,6 +205,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -197,6 +213,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -212,6 +229,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fdcd-6dbb-bce5-8672" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -220,6 +238,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eaa6-34e8-00f5-a551" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -228,6 +247,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="483c-9564-26b4-8a72" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -236,6 +256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="22ad-5cfb-c2cd-dd74" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -244,6 +265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="05a5-8d47-94e8-b6c5" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -252,6 +274,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5aa7-4f4b-d873-75c6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -260,6 +283,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -267,9 +291,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b9d6-982d-12a3-da4d" name="Mounted Elven Lord [128 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="ae31-dfa0-3fde-3b87" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -290,6 +318,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b597-0aed-39a6-8f28" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -298,6 +327,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="82b8-2a75-6f1f-05e3" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -313,6 +343,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -328,6 +359,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -354,6 +386,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="82.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a28d-36dc-d687-1b8f" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -366,6 +399,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -373,6 +407,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90c7-df4d-caca-17e5" name="Elven Lord in Spangly Armour" hidden="false" collective="false" type="upgrade">
@@ -391,6 +426,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="97.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="7df7-ebf0-5514-88a3" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -403,6 +439,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -410,6 +447,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -426,6 +464,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7653-0ad0-3578-b9ad" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -434,6 +473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -450,6 +490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eb9e-3d69-a6aa-f295" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -458,6 +499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -484,6 +526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -499,6 +542,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d98f-55d4-8de6-7890" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -507,6 +551,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cc22-3b2a-dabb-a51b" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -515,6 +560,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5598-126b-0127-c9c2" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -523,6 +569,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7055-2bf9-ef34-9f9c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -531,6 +578,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44e0-87db-a938-fa18" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -539,6 +587,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e74-2c59-ce90-66fd" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -547,6 +596,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -554,9 +604,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a7d7-31cb-d9da-ee08" name="Elven Hero [77 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e244-973a-aa3a-3a44" type="max"/>
       </constraints>
@@ -579,6 +633,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -595,6 +650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0208-d959-9570-377b" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -603,6 +659,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -619,6 +676,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="685c-4a2f-b93e-452c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -627,6 +685,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e0a9-88cd-8f1e-0f48" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -635,6 +694,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -651,6 +711,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cde6-39de-1497-420a" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -659,6 +720,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="045d-1f45-8468-6271" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -667,6 +729,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -683,6 +746,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="77.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="942a-a907-5881-6da2" name="Elven Hero in Spangly Armour" hidden="false" collective="false" type="model">
@@ -691,6 +755,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="92.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -706,6 +771,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="93c3-ada6-5c63-3293" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -714,6 +780,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="24d7-c222-2ee0-5b3e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -722,6 +789,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2412-7ac2-bc62-e733" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -730,6 +798,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="50fd-b515-6764-b3ad" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -738,6 +807,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8683-aa9b-882f-49d7" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -746,6 +816,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3028-8858-380c-e959" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -754,6 +825,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -761,9 +833,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5416-8391-045e-6c54" name="Mounted Elven Hero [87 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fb2-3f4d-1dd6-609b" type="max"/>
       </constraints>
@@ -787,6 +863,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -803,6 +880,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1fed-0de8-ece0-c5dc" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -811,6 +889,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -827,6 +906,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02e7-e496-5a99-fdb8" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -835,6 +915,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3bdc-677e-6e9e-2c2b" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -843,6 +924,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -859,6 +941,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f574-f339-258e-0fe4" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -867,6 +950,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f458-8145-ed13-bd25" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -875,6 +959,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -891,6 +976,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="87.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffef-d41b-c9bd-b9eb" name="Elven Hero in Spangly Armour" hidden="false" collective="false" type="model">
@@ -899,6 +985,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="102.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -915,6 +1002,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -930,6 +1018,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15c0-f02e-301f-32fa" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -938,6 +1027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ec8-75ab-f29f-701f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -946,6 +1036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f7e4-3d5f-0037-c3fb" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -954,6 +1045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="60c1-2a21-767b-98bd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -962,6 +1054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="85f7-506e-7238-7494" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -970,6 +1063,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b704-c98a-3d08-9a90" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -978,6 +1072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -985,9 +1080,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2852-dd57-1bd8-8981" name="Elven Mage [62 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5cfe-635b-7ac6-df25" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="2194-6a48-821c-a892" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
@@ -1006,6 +1105,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1019,16 +1119,19 @@
             <selectionEntry id="c840-fcf6-2779-732c" name="Magic Level 1" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="128e-b58a-49db-8d8c" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd3f-9eb6-53de-0d24" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1051,6 +1154,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1fe6-b9f2-3f8b-ff96" name="Apprentices in Light Armour" hidden="false" collective="false" type="model">
@@ -1062,6 +1166,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1069,6 +1174,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ab3-a080-aba5-cce5" name="Daemons" hidden="false" collective="false" type="upgrade">
@@ -1085,6 +1191,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1092,6 +1199,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1108,6 +1216,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9165-7289-0e76-9d89" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1116,6 +1225,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1131,6 +1241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1147,6 +1258,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d67-08e8-8987-2d32" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1155,6 +1267,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e160-d6b2-7dda-db7b" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1163,6 +1276,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89f8-f18f-7b8a-5fbc" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1171,6 +1285,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ea48-7be2-2b8b-cb42" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1179,6 +1294,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b45f-2990-e201-b123" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1187,6 +1303,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad30-e0af-5d6b-d325" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1195,6 +1312,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d03-783d-93e0-39ec" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1203,6 +1321,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5bef-245a-a81b-fc0c" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1211,6 +1330,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="35f9-c6dd-d666-10d2" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1219,6 +1339,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e6de-aa4d-6796-8ce4" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1227,6 +1348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="79ac-2480-7ea8-9011" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1235,6 +1357,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eca0-3d73-e3b3-fcee" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1243,6 +1366,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d604-be1b-c53e-cc0c" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1251,6 +1375,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1266,6 +1391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7959-1486-daa3-4b49" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1277,6 +1403,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5fdb-17e4-ddc3-cc50" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1288,6 +1415,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b3d-3780-d660-94e9" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1299,6 +1427,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c25d-1013-4a1d-f1b7" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1310,6 +1439,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="654f-6b95-a2c8-536a" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1321,6 +1451,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e930-48f2-73a8-e2af" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1332,6 +1463,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3ae-6c35-f605-08dd" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1343,6 +1475,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="455f-f936-d77d-64ba" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1354,6 +1487,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a49-0760-f980-7b25" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1365,6 +1499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1c6d-bdb8-3909-5d61" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1376,6 +1511,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="932b-eca5-18ee-8dc0" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1387,6 +1523,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3e1d-1433-1c0f-4eb4" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1398,6 +1535,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b8f7-9ab0-6f8a-cafa" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1409,6 +1547,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1424,6 +1563,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7895-db08-6665-d0ab" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1432,6 +1572,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="abc5-24c8-c0f9-ca21" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1440,6 +1581,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8ed6-d4b4-cccc-4081" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1448,6 +1590,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="affa-f390-4df4-969c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1456,6 +1599,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0421-f681-4d4d-16c2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1464,6 +1608,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ad8-f128-5f6d-7b01" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1472,6 +1617,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1479,9 +1625,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aa6f-d68a-6c78-68f8" name="Elven Guard [95 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="ec30-f907-96cd-64fe" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
@@ -1500,6 +1650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1516,6 +1667,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e99-be7e-b83a-aaf5" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1524,6 +1676,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1546,6 +1699,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1570,6 +1724,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3f5b-444c-f1e7-5875" name="Elven Guard" hidden="false" collective="false" type="model">
@@ -1582,6 +1737,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1589,6 +1745,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0cd4-ce20-a380-2188" name="Elven Guard in Spangly Armour [+4 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1605,6 +1762,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="268b-535b-9120-39f2" name="Elven Guard Leader" hidden="false" collective="false" type="model">
@@ -1617,6 +1775,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1624,6 +1783,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1631,9 +1791,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="badc-3155-f998-0995" name="Elven Warriors [95 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="0610-b28c-232c-fdbf" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1650,6 +1814,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="79c0-f546-f1d0-0963" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1658,6 +1823,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f16-46c1-7f8f-a78d" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1666,6 +1832,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1681,6 +1848,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1697,6 +1865,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="daca-77a5-1a28-7eb8" name="Elven Warriors" hidden="false" collective="false" type="model">
@@ -1709,6 +1878,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1716,9 +1886,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d269-784b-2037-0b91" name="Elven Archers [105 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2fc8-e344-7e1f-6e56" name="Longbow" hidden="false" targetId="d4c8-3ef2-18de-85c0" type="profile"/>
         <infoLink id="850e-39cc-2c51-d09f" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
@@ -1739,6 +1913,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1763,6 +1938,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="38f8-5e00-0fdb-910b" name="Elven Archers" hidden="false" collective="false" type="model">
@@ -1775,6 +1951,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1782,6 +1959,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9a4-ecc6-9246-0d6a" name="Elven Archers in Light Armour [+2 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1798,6 +1976,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0502-fdea-edd0-763e" name="Elven Archer Leader" hidden="false" collective="false" type="model">
@@ -1810,6 +1989,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1817,6 +1997,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1824,9 +2005,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5d83-e361-70c9-499c" name="Elven Rangers [141 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="7046-634b-20d8-5ebd" name="Woodsman" hidden="false" targetId="e1f3-7817-0e4e-5cb9" type="rule"/>
         <infoLink id="da64-a1cf-d3a1-adc8" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
@@ -1848,6 +2033,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1872,6 +2058,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="36.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5230-bf49-1dcd-5443" name="Elven Rangers" hidden="false" collective="false" type="model">
@@ -1884,6 +2071,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1891,6 +2079,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f8f-189e-a46d-d71d" name="Elven Rangers in Spangly Armour [+4 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1907,6 +2096,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2fb9-dd34-6e54-c95e" name="Elven Ranger Leader" hidden="false" collective="false" type="model">
@@ -1919,6 +2109,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="40.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1926,6 +2117,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1933,9 +2125,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="39cd-09b5-a58e-b4fa" name="Elven Cavalry [79 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="ffc9-c443-ae86-28bd" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
         <infoLink id="8457-a642-ed5a-18f2" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
@@ -1955,6 +2151,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1971,6 +2168,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c205-30ae-4952-6105" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1979,6 +2177,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d546-1d97-27c2-9f4d" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -1994,6 +2193,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2016,6 +2216,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2039,6 +2240,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2061,6 +2263,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="33.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a880-6a8b-3651-2a12" name="Elven Cavalry" hidden="false" collective="false" type="model">
@@ -2073,11 +2276,13 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="23.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6212-14ad-16ae-6763" name="Cavalry in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2092,6 +2297,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="25.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="422e-b0c5-2157-57d3" name="Elven Cavalry Leader" hidden="false" collective="false" type="model">
@@ -2104,11 +2310,13 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="35.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a933-0dce-4e3c-3edd" name="Cavalry in Spangly Armour" hidden="false" collective="false" type="upgrade">
@@ -2123,6 +2331,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="29.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cbf4-98eb-637b-9bc5" name="Elven Cavalry Leader" hidden="false" collective="false" type="model">
@@ -2135,11 +2344,13 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="39.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2147,9 +2358,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="52d3-bc0e-f380-0876" name="Elven Knights [104 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="e6ac-8a00-4ef4-20c1" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
         <infoLink id="9fd5-3c7c-26b2-c868" name="Haughty Disdain" hidden="false" targetId="6a8d-ef1b-6f78-e15c" type="rule"/>
@@ -2178,6 +2393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2195,6 +2411,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="48.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="804c-4773-facd-9fcc" name="Elven Knights" hidden="false" collective="false" type="model">
@@ -2207,6 +2424,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2214,9 +2432,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d3d2-c832-23e1-9cb7" name="Giant Eagle [143 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="8cbc-73e8-57c5-aea5" name="Rock dropped by Eagle" hidden="false" targetId="c44d-adb8-ec8a-3dd4" type="profile"/>
       </infoLinks>
@@ -2239,6 +2461,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="143.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2255,6 +2478,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2262,9 +2486,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d7a0-4612-9a6d-2215" name="Elven Chariot [116 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="4160-5acc-9299-adcf" name="Longbow" hidden="false" targetId="d4c8-3ef2-18de-85c0" type="profile"/>
       </infoLinks>
@@ -2284,6 +2512,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="98.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2300,6 +2529,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2317,6 +2547,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2333,6 +2564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3bbc-1eac-4b59-d875" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2341,6 +2573,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f286-0f44-3008-dfb4" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2349,6 +2582,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2364,6 +2598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2371,9 +2606,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="555c-7461-6e9a-8467" name="Elven Bolt Thrower [93 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="e441-50b4-417c-8922" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2393,6 +2632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2409,6 +2649,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c226-9114-8dbb-c8aa" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2418,6 +2659,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2425,9 +2667,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1f4e-7ddd-0923-cd17" name="Elven Stone Thrower [105 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="baf1-a29c-e2e1-46da" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2447,6 +2693,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2463,6 +2710,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1bf9-67e1-1641-80e4" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -2471,6 +2719,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2478,6 +2727,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Elves.cat
+++ b/Elves.cat
@@ -36,7 +36,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5ce-bd0d-9ffb-876f" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -45,7 +45,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f92-2628-6609-c9aa" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -54,7 +54,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -70,7 +70,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -87,7 +87,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f8ae-b91f-590a-7c2b" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -96,7 +96,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -113,7 +113,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="111c-d14e-6a91-733f" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -122,7 +122,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -149,7 +149,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="74.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="7d39-e268-cac6-3d83" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -162,7 +162,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -170,7 +170,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8af0-6cac-e8d4-77e7" name="Elven Lord in Spangly Armour" hidden="false" collective="false" type="upgrade">
@@ -189,7 +189,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="89.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="35e1-bb12-c48e-988f" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -202,7 +202,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -210,7 +210,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -226,7 +226,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fdcd-6dbb-bce5-8672" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -235,7 +235,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eaa6-34e8-00f5-a551" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -244,7 +244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="483c-9564-26b4-8a72" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -253,7 +253,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="22ad-5cfb-c2cd-dd74" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -262,7 +262,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="05a5-8d47-94e8-b6c5" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -271,7 +271,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5aa7-4f4b-d873-75c6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -280,7 +280,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -288,12 +288,12 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b9d6-982d-12a3-da4d" name="Mounted Elven Lord [128 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="ae31-dfa0-3fde-3b87" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="ad12-724b-5c6c-031d" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c08a-6a09-c86d-df30" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
@@ -312,7 +312,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b597-0aed-39a6-8f28" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -321,7 +321,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="82b8-2a75-6f1f-05e3" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -337,7 +337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -353,7 +353,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -380,7 +380,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="82.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a28d-36dc-d687-1b8f" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -393,7 +393,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -401,7 +401,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90c7-df4d-caca-17e5" name="Elven Lord in Spangly Armour" hidden="false" collective="false" type="upgrade">
@@ -420,7 +420,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="97.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="7df7-ebf0-5514-88a3" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -433,7 +433,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -441,7 +441,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -458,7 +458,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7653-0ad0-3578-b9ad" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -467,7 +467,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -484,7 +484,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eb9e-3d69-a6aa-f295" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -493,7 +493,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -520,7 +520,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -536,7 +536,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d98f-55d4-8de6-7890" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -545,7 +545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cc22-3b2a-dabb-a51b" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -554,7 +554,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5598-126b-0127-c9c2" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -563,7 +563,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7055-2bf9-ef34-9f9c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -572,7 +572,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44e0-87db-a938-fa18" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -581,7 +581,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e74-2c59-ce90-66fd" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -590,7 +590,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -598,7 +598,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a7d7-31cb-d9da-ee08" name="Elven Hero [77 pts]" hidden="false" collective="false" type="unit">
@@ -624,7 +624,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -641,7 +641,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0208-d959-9570-377b" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -650,7 +650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -667,7 +667,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="685c-4a2f-b93e-452c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -676,7 +676,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e0a9-88cd-8f1e-0f48" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -685,7 +685,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -702,7 +702,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cde6-39de-1497-420a" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -711,7 +711,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="045d-1f45-8468-6271" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -720,7 +720,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -737,7 +737,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="77.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="942a-a907-5881-6da2" name="Elven Hero in Spangly Armour" hidden="false" collective="false" type="model">
@@ -746,7 +746,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="92.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -762,7 +762,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="93c3-ada6-5c63-3293" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -771,7 +771,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="24d7-c222-2ee0-5b3e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -780,7 +780,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2412-7ac2-bc62-e733" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -789,7 +789,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="50fd-b515-6764-b3ad" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -798,7 +798,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8683-aa9b-882f-49d7" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -807,7 +807,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3028-8858-380c-e959" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -816,7 +816,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -824,7 +824,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5416-8391-045e-6c54" name="Mounted Elven Hero [87 pts]" hidden="false" collective="false" type="unit">
@@ -833,7 +833,7 @@
       </constraints>
       <infoLinks>
         <infoLink id="fe07-cbbd-e94b-2dfe" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
-        <infoLink id="156e-0b65-5fe7-c3ff" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="99a4-bc42-a02a-a67f" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="7e9d-2e53-bbaf-0e1a" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="false"/>
@@ -851,7 +851,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -868,7 +868,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1fed-0de8-ece0-c5dc" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -877,7 +877,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -894,7 +894,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02e7-e496-5a99-fdb8" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -903,7 +903,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3bdc-677e-6e9e-2c2b" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -912,7 +912,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -929,7 +929,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f574-f339-258e-0fe4" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -938,7 +938,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f458-8145-ed13-bd25" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -947,7 +947,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -964,7 +964,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="87.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffef-d41b-c9bd-b9eb" name="Elven Hero in Spangly Armour" hidden="false" collective="false" type="model">
@@ -973,7 +973,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="102.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -990,7 +990,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1006,7 +1006,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15c0-f02e-301f-32fa" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1015,7 +1015,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ec8-75ab-f29f-701f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1024,7 +1024,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f7e4-3d5f-0037-c3fb" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1033,7 +1033,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="60c1-2a21-767b-98bd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1042,7 +1042,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="85f7-506e-7238-7494" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1051,7 +1051,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b704-c98a-3d08-9a90" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1060,7 +1060,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1068,7 +1068,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2852-dd57-1bd8-8981" name="Elven Mage [62 pts]" hidden="false" collective="false" type="unit">
@@ -1090,7 +1090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1102,21 +1102,30 @@
           </constraints>
           <selectionEntries>
             <selectionEntry id="c840-fcf6-2779-732c" name="Magic Level 1" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="3ab9-2a3e-4a24-7f63" name="Magic Level 1" hidden="false" targetId="90e2-5b2c-1fc8-0e8c" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="128e-b58a-49db-8d8c" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="ce81-da78-f031-3a93" name="Magic Level 2" hidden="false" targetId="4a91-87e6-88c5-5e1d" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd3f-9eb6-53de-0d24" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="cd2f-b878-a527-dea7" name="Magic Level 3" hidden="false" targetId="2e1b-4169-af1f-71e5" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1126,65 +1135,65 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89ba-9b24-6a03-8674" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="70ca-11c2-4458-8eb7" name="Apprentices" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2c65-048f-8b9d-2fd8" name="Apprentices" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="cad0-8073-67c6-914b" name="Apprentices" hidden="false" collective="false" defaultSelectionEntryId="8af4-6c49-7294-2583">
+                <selectionEntryGroup id="d7df-fa24-fbe8-153d" name="Apprentices" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="561d-f095-4177-358a" type="max"/>
+                  </constraints>
                   <selectionEntries>
-                    <selectionEntry id="8af4-6c49-7294-2583" name="Apprentices" hidden="false" collective="false" type="model">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fc9-4449-bc66-7ed9" type="max"/>
-                      </constraints>
+                    <selectionEntry id="b302-9427-951b-f6f2" name="Apprentices" hidden="false" collective="false" type="upgrade">
                       <infoLinks>
-                        <infoLink id="a0eb-8345-edf1-b0ad" name="Apprentice Mages" hidden="false" targetId="8b3f-6ab4-f829-ca12" type="profile"/>
+                        <infoLink id="5d7a-2a89-21f5-0505" name="Apprentice Mages" hidden="false" targetId="8b3f-6ab4-f829-ca12" type="profile"/>
                       </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="1fe6-b9f2-3f8b-ff96" name="Apprentices in Light Armour" hidden="false" collective="false" type="model">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd38-b328-b231-9ec0" type="max"/>
-                      </constraints>
-                      <infoLinks>
-                        <infoLink id="6eae-22cc-db3c-c230" name="Apprentice Mages in Light Armour" hidden="false" targetId="034b-d422-ccfe-63ca" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ab3-a080-aba5-cce5" name="Daemons" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="08c6-310a-0ead-c23c" name="Daemons" hidden="false" collective="false">
+                <selectionEntryGroup id="5161-f662-da6e-5d2f" name="Daemons" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be64-0584-6670-d598" type="max"/>
+                  </constraints>
                   <selectionEntries>
-                    <selectionEntry id="af87-3126-93a2-27d6" name="Daemons" hidden="false" collective="false" type="model">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d961-ac04-37ae-af76" type="max"/>
-                      </constraints>
+                    <selectionEntry id="7938-d90e-9009-0eba" name="Daemons" hidden="false" collective="false" type="upgrade">
                       <infoLinks>
-                        <infoLink id="bb64-cb4b-bc8f-938c" name="Bound Daemons" hidden="false" targetId="346d-0141-da49-eecd" type="profile"/>
-                        <infoLink id="fb9e-d773-48af-df14" name="Spirit" hidden="false" targetId="78d3-886d-5fc6-bac4" type="rule"/>
+                        <infoLink id="8752-53b9-f6bc-194b" name="Bound Daemons" hidden="false" targetId="346d-0141-da49-eecd" type="profile"/>
+                        <infoLink id="0ed9-8203-2a84-c32c" name="Spirit" hidden="false" targetId="78d3-886d-5fc6-bac4" type="rule"/>
                       </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6d71-8895-ddae-7aec" name="Apprentices in Light Armour" hidden="false" collective="false" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="7912-948c-8cfc-7f08" name="Apprentices in Light Armour" hidden="false" collective="false">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9aab-4f56-7c10-909a" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="c959-b271-1868-5678" name="Apprentices in Light Armour" hidden="false" collective="false" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="43c8-d5fb-e2cb-6132" name="Apprentice Mages in Light Armour" hidden="false" targetId="034b-d422-ccfe-63ca" type="profile"/>
+                      </infoLinks>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1201,7 +1210,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9165-7289-0e76-9d89" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1210,7 +1219,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1226,7 +1235,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1243,7 +1252,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d67-08e8-8987-2d32" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1252,7 +1261,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e160-d6b2-7dda-db7b" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1261,7 +1270,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89f8-f18f-7b8a-5fbc" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1270,7 +1279,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ea48-7be2-2b8b-cb42" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1279,7 +1288,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b45f-2990-e201-b123" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1288,7 +1297,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad30-e0af-5d6b-d325" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1297,7 +1306,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d03-783d-93e0-39ec" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1306,7 +1315,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5bef-245a-a81b-fc0c" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1315,7 +1324,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="35f9-c6dd-d666-10d2" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1324,7 +1333,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e6de-aa4d-6796-8ce4" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1333,7 +1342,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="79ac-2480-7ea8-9011" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1342,7 +1351,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eca0-3d73-e3b3-fcee" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1351,7 +1360,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d604-be1b-c53e-cc0c" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1360,7 +1369,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1376,7 +1385,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7959-1486-daa3-4b49" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1388,7 +1397,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5fdb-17e4-ddc3-cc50" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1400,7 +1409,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b3d-3780-d660-94e9" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1412,7 +1421,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c25d-1013-4a1d-f1b7" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1424,7 +1433,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="654f-6b95-a2c8-536a" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1436,7 +1445,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e930-48f2-73a8-e2af" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1448,7 +1457,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3ae-6c35-f605-08dd" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1460,7 +1469,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="455f-f936-d77d-64ba" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1472,7 +1481,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a49-0760-f980-7b25" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1484,7 +1493,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1c6d-bdb8-3909-5d61" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1496,7 +1505,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="932b-eca5-18ee-8dc0" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1508,7 +1517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3e1d-1433-1c0f-4eb4" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1520,7 +1529,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b8f7-9ab0-6f8a-cafa" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1532,7 +1541,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1548,7 +1557,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7895-db08-6665-d0ab" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1557,7 +1566,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="abc5-24c8-c0f9-ca21" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1566,7 +1575,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8ed6-d4b4-cccc-4081" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1575,7 +1584,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="affa-f390-4df4-969c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1584,7 +1593,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0421-f681-4d4d-16c2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1593,7 +1602,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ad8-f128-5f6d-7b01" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1602,7 +1611,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1610,10 +1619,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aa6f-d68a-6c78-68f8" name="Elven Guard [95 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93a3-be59-ab8f-615c" type="max"/>
+      </constraints>
       <infoLinks>
         <infoLink id="ec30-f907-96cd-64fe" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
@@ -1632,7 +1644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1649,7 +1661,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e99-be7e-b83a-aaf5" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1658,7 +1670,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1681,7 +1693,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1706,7 +1718,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3f5b-444c-f1e7-5875" name="Elven Guard" hidden="false" collective="false" type="model">
@@ -1719,7 +1731,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1727,7 +1739,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0cd4-ce20-a380-2188" name="Elven Guard in Spangly Armour [+4 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1744,7 +1756,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="268b-535b-9120-39f2" name="Elven Guard Leader" hidden="false" collective="false" type="model">
@@ -1757,7 +1769,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1765,7 +1777,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1773,7 +1785,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="badc-3155-f998-0995" name="Elven Warriors [95 pts]" hidden="false" collective="false" type="unit">
@@ -1793,7 +1805,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="79c0-f546-f1d0-0963" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1802,7 +1814,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f16-46c1-7f8f-a78d" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1811,7 +1823,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1827,7 +1839,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1841,10 +1853,11 @@
               </constraints>
               <infoLinks>
                 <infoLink id="0d80-9d12-0b81-e72d" name="Elven Warrior Leader" hidden="false" targetId="b1f7-05ac-5731-deb0" type="profile"/>
+                <infoLink id="9ef9-26b0-5843-656b" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="daca-77a5-1a28-7eb8" name="Elven Warriors" hidden="false" collective="false" type="model">
@@ -1857,7 +1870,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1865,7 +1878,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d269-784b-2037-0b91" name="Elven Archers [105 pts]" hidden="false" collective="false" type="unit">
@@ -1889,7 +1902,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1914,7 +1927,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="38f8-5e00-0fdb-910b" name="Elven Archers" hidden="false" collective="false" type="model">
@@ -1927,7 +1940,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1935,7 +1948,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9a4-ecc6-9246-0d6a" name="Elven Archers in Light Armour [+2 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1952,7 +1965,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0502-fdea-edd0-763e" name="Elven Archer Leader" hidden="false" collective="false" type="model">
@@ -1965,7 +1978,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1973,7 +1986,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1981,7 +1994,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5d83-e361-70c9-499c" name="Elven Rangers [141 pts]" hidden="false" collective="false" type="unit">
@@ -2006,7 +2019,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2031,7 +2044,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="36.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5230-bf49-1dcd-5443" name="Elven Rangers" hidden="false" collective="false" type="model">
@@ -2044,7 +2057,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2052,7 +2065,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f8f-189e-a46d-d71d" name="Elven Rangers in Spangly Armour [+4 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -2069,7 +2082,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2fb9-dd34-6e54-c95e" name="Elven Ranger Leader" hidden="false" collective="false" type="model">
@@ -2082,7 +2095,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="40.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2090,7 +2103,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2098,12 +2111,12 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="39cd-09b5-a58e-b4fa" name="Elven Cavalry [79 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="ffc9-c443-ae86-28bd" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="ffc9-c443-ae86-28bd" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
         <infoLink id="8457-a642-ed5a-18f2" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
@@ -2121,7 +2134,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2138,7 +2151,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c205-30ae-4952-6105" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2147,7 +2160,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d546-1d97-27c2-9f4d" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -2163,7 +2176,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2186,7 +2199,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2210,7 +2223,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2233,7 +2246,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="33.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a880-6a8b-3651-2a12" name="Elven Cavalry" hidden="false" collective="false" type="model">
@@ -2246,13 +2259,13 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="23.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6212-14ad-16ae-6763" name="Cavalry in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2267,7 +2280,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="25.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="422e-b0c5-2157-57d3" name="Elven Cavalry Leader" hidden="false" collective="false" type="model">
@@ -2280,13 +2293,13 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="35.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a933-0dce-4e3c-3edd" name="Cavalry in Spangly Armour" hidden="false" collective="false" type="upgrade">
@@ -2301,7 +2314,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="29.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cbf4-98eb-637b-9bc5" name="Elven Cavalry Leader" hidden="false" collective="false" type="model">
@@ -2314,13 +2327,13 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="39.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2328,12 +2341,12 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="52d3-bc0e-f380-0876" name="Elven Knights [104 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="e6ac-8a00-4ef4-20c1" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="e6ac-8a00-4ef4-20c1" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
         <infoLink id="9fd5-3c7c-26b2-c868" name="Haughty Disdain" hidden="false" targetId="6a8d-ef1b-6f78-e15c" type="rule"/>
         <infoLink id="9c26-38d7-76e8-b35d" name="Lance" hidden="false" targetId="e601-dcfc-7485-2164" type="profile"/>
       </infoLinks>
@@ -2360,7 +2373,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2378,7 +2391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="48.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="804c-4773-facd-9fcc" name="Elven Knights" hidden="false" collective="false" type="model">
@@ -2391,7 +2404,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2399,85 +2412,69 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d3d2-c832-23e1-9cb7" name="Giant Eagle [143 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb05-afc1-ad4b-09a8" type="max"/>
+      </constraints>
       <infoLinks>
         <infoLink id="8cbc-73e8-57c5-aea5" name="Rock dropped by Eagle" hidden="false" targetId="c44d-adb8-ec8a-3dd4" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bf49-17b0-2e60-7c69" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="47ee-c60b-d65b-6323" name="Models" hidden="false" collective="false" defaultSelectionEntryId="829c-8967-2fa5-5e96">
-          <selectionEntries>
-            <selectionEntry id="829c-8967-2fa5-5e96" name="Giant Eagle with rocks" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1de-3551-b751-0da6" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a106-0619-398e-c06e" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="a886-7c57-7bce-7ce0" name="Giant Eagle" hidden="false" targetId="40ac-4e12-eb5a-b9cb" type="profile"/>
-                <infoLink id="f140-0611-0553-d13f" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="b017-4eda-ee7b-16c2" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
-                <infoLink id="d8a2-d4b4-437d-1edd" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="143.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="2ca2-4cc6-bd50-0780" name="Wound Level" hidden="false" collective="false" defaultSelectionEntryId="1096-3af3-4d1f-9b9c">
+      <selectionEntries>
+        <selectionEntry id="8136-c92e-85f7-aed7" name="Giant Eagle with rocks" hidden="false" collective="false" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57a7-c728-5e86-0632" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c9b-f722-4280-9740" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e61-5dcf-7321-5a6e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d066-99d9-fa97-9ebf" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="1096-3af3-4d1f-9b9c" name="Wound" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="fbcd-b424-60c5-632e" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+          <infoLinks>
+            <infoLink id="63e7-ae40-471f-c7b2" name="Giant Eagle" hidden="false" targetId="40ac-4e12-eb5a-b9cb" type="profile"/>
+            <infoLink id="8665-2863-2327-9dac" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+            <infoLink id="9ee1-e93a-af9f-692a" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
+            <infoLink id="b1f7-3c0f-e84d-8ac6" name="Fast 10" hidden="false" targetId="0034-82ae-f695-d446" type="rule"/>
+            <infoLink id="0ee2-652c-3e84-121b" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="143.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d7a0-4612-9a6d-2215" name="Elven Chariot [116 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="4160-5acc-9299-adcf" name="Longbow" hidden="false" targetId="d4c8-3ef2-18de-85c0" type="profile"/>
+        <infoLink id="a314-015c-3b45-ef0e" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="a966-0876-2483-1f63" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+        <infoLink id="32d6-3eb5-6bee-cffc" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bd78-5943-05d3-e559" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4a29-7542-f36f-050c" name="Elven Chariot" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a245-58e5-b893-f5bf" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43ec-439e-acf3-5749" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="a498-9aaa-f40f-647d" name="Elven Chariot with crew, pulled by 2 horses" hidden="false" targetId="2699-e8ed-8105-cf1a" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="98.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="194d-1b99-0625-9743" name="Chariot" hidden="false" collective="false" defaultSelectionEntryId="2c1c-6b48-da8f-5532">
-          <selectionEntries>
-            <selectionEntry id="2c1c-6b48-da8f-5532" name="Elven Chariot" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11c1-b031-b565-0f2d" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f74-06b2-9fba-7df0" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="e33b-c351-60dd-2277" name="Elven Chariot with crew, pulled by 2 horses" hidden="false" targetId="2699-e8ed-8105-cf1a" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="98.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
         <selectionEntryGroup id="74ea-5e6b-7c05-28af" name="Enchanted Steeds" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddc1-89ff-b1d3-bb11" type="max"/>
@@ -2490,7 +2487,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2508,7 +2505,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2525,7 +2522,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3bbc-1eac-4b59-d875" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2534,7 +2531,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f286-0f44-3008-dfb4" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2543,7 +2540,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2559,7 +2556,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2567,7 +2564,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="555c-7461-6e9a-8467" name="Elven Bolt Thrower [93 pts]" hidden="false" collective="false" type="unit">
@@ -2585,12 +2582,12 @@
               <infoLinks>
                 <infoLink id="347e-7ac7-c1eb-3e8d" name="Elven Crew with Bolt-throwing engine" hidden="false" targetId="6672-7f43-13f4-1423" type="profile"/>
                 <infoLink id="13ec-dcc6-6753-72e3" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="7d4d-d1b8-2d2f-160f" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+                <infoLink id="7d4d-d1b8-2d2f-160f" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
                 <infoLink id="2e54-ce32-81f0-8b97" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2607,7 +2604,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c226-9114-8dbb-c8aa" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2617,7 +2614,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2625,7 +2622,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1f4e-7ddd-0923-cd17" name="Elven Stone Thrower [105 pts]" hidden="false" collective="false" type="unit">
@@ -2642,13 +2639,13 @@
               </constraints>
               <infoLinks>
                 <infoLink id="93df-72c4-d3b2-e983" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="6382-e186-427f-d74a" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+                <infoLink id="6382-e186-427f-d74a" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
                 <infoLink id="75f0-f12a-b297-2e5e" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
                 <infoLink id="0d40-3627-ba35-6029" name="Elven Crew with Stone-throwing engine and swords" hidden="false" targetId="ab3d-0678-c0ec-10f0" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2658,6 +2655,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1caf-e7d4-cb86-c24d" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="684a-8e31-c359-d149" type="min"/>
           </constraints>
+          <infoLinks>
+            <infoLink id="7009-3e41-6111-43fa" name="Overhead" hidden="false" targetId="7751-622a-b896-4874" type="rule"/>
+          </infoLinks>
           <selectionEntries>
             <selectionEntry id="4108-2a0e-5434-146b" name="Small Stone Thrower" hidden="false" collective="false" type="upgrade">
               <infoLinks>
@@ -2665,7 +2665,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1bf9-67e1-1641-80e4" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -2674,7 +2674,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2682,7 +2682,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Elves.cat
+++ b/Elves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="fe3c-0690-8599-2c5a" name="Elves" revision="2" battleScribeVersion="2.02" authorName="the3dwaragmer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="fe3c-0690-8599-2c5a" name="Elves" revision="3" battleScribeVersion="2.02" authorName="the3dwaragmer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="f9fe-8a78-d73c-6467" name="Elven Lord" hidden="false" collective="false" targetId="9a7d-1a27-895a-cd53" type="selectionEntry"/>
     <entryLink id="806f-cefb-1bbc-16ba" name="Mounted Elven Lord" hidden="false" collective="false" targetId="b9d6-982d-12a3-da4d" type="selectionEntry"/>
@@ -19,9 +19,6 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="9a7d-1a27-895a-cd53" name="Elven Lord [108 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="fe12-55e3-e0ff-330f" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="f3cc-6c74-5912-cf0b" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -39,7 +36,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5ce-bd0d-9ffb-876f" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -48,7 +45,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f92-2628-6609-c9aa" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -57,7 +54,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -73,7 +70,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -90,7 +87,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f8ae-b91f-590a-7c2b" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -99,7 +96,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -116,7 +113,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="111c-d14e-6a91-733f" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -125,7 +122,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -152,7 +149,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="74.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="7d39-e268-cac6-3d83" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -165,7 +162,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -173,7 +170,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8af0-6cac-e8d4-77e7" name="Elven Lord in Spangly Armour" hidden="false" collective="false" type="upgrade">
@@ -192,7 +189,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="89.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="35e1-bb12-c48e-988f" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -205,7 +202,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -213,7 +210,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -229,7 +226,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fdcd-6dbb-bce5-8672" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -238,7 +235,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eaa6-34e8-00f5-a551" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -247,7 +244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="483c-9564-26b4-8a72" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -256,7 +253,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="22ad-5cfb-c2cd-dd74" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -265,7 +262,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="05a5-8d47-94e8-b6c5" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -274,7 +271,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5aa7-4f4b-d873-75c6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -283,7 +280,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -291,13 +288,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b9d6-982d-12a3-da4d" name="Mounted Elven Lord [128 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="ae31-dfa0-3fde-3b87" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -318,7 +312,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b597-0aed-39a6-8f28" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -327,7 +321,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="82b8-2a75-6f1f-05e3" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -343,7 +337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -359,7 +353,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -386,7 +380,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="82.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a28d-36dc-d687-1b8f" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -399,7 +393,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -407,7 +401,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90c7-df4d-caca-17e5" name="Elven Lord in Spangly Armour" hidden="false" collective="false" type="upgrade">
@@ -426,7 +420,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="97.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="7df7-ebf0-5514-88a3" name="Elven Bodyguard " hidden="false" collective="false" type="model">
@@ -439,7 +433,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -447,7 +441,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -464,7 +458,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7653-0ad0-3578-b9ad" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -473,7 +467,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -490,7 +484,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eb9e-3d69-a6aa-f295" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -499,7 +493,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -526,7 +520,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -542,7 +536,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d98f-55d4-8de6-7890" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -551,7 +545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cc22-3b2a-dabb-a51b" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -560,7 +554,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5598-126b-0127-c9c2" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -569,7 +563,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7055-2bf9-ef34-9f9c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -578,7 +572,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44e0-87db-a938-fa18" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -587,7 +581,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e74-2c59-ce90-66fd" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -596,7 +590,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -604,13 +598,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a7d7-31cb-d9da-ee08" name="Elven Hero [77 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e244-973a-aa3a-3a44" type="max"/>
       </constraints>
@@ -633,7 +624,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -650,7 +641,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0208-d959-9570-377b" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -659,7 +650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -676,7 +667,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="685c-4a2f-b93e-452c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -685,7 +676,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e0a9-88cd-8f1e-0f48" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -694,7 +685,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -711,7 +702,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cde6-39de-1497-420a" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -720,7 +711,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="045d-1f45-8468-6271" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -729,7 +720,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -746,7 +737,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="77.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="942a-a907-5881-6da2" name="Elven Hero in Spangly Armour" hidden="false" collective="false" type="model">
@@ -755,7 +746,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="92.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -771,7 +762,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="93c3-ada6-5c63-3293" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -780,7 +771,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="24d7-c222-2ee0-5b3e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -789,7 +780,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2412-7ac2-bc62-e733" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -798,7 +789,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="50fd-b515-6764-b3ad" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -807,7 +798,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8683-aa9b-882f-49d7" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -816,7 +807,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3028-8858-380c-e959" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -825,7 +816,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -833,13 +824,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5416-8391-045e-6c54" name="Mounted Elven Hero [87 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fb2-3f4d-1dd6-609b" type="max"/>
       </constraints>
@@ -863,7 +851,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -880,7 +868,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1fed-0de8-ece0-c5dc" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -889,7 +877,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -906,7 +894,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02e7-e496-5a99-fdb8" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -915,7 +903,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3bdc-677e-6e9e-2c2b" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -924,7 +912,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -941,7 +929,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f574-f339-258e-0fe4" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -950,7 +938,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f458-8145-ed13-bd25" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -959,7 +947,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -976,7 +964,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="87.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffef-d41b-c9bd-b9eb" name="Elven Hero in Spangly Armour" hidden="false" collective="false" type="model">
@@ -985,7 +973,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="102.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1002,7 +990,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1018,7 +1006,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15c0-f02e-301f-32fa" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1027,7 +1015,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ec8-75ab-f29f-701f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1036,7 +1024,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f7e4-3d5f-0037-c3fb" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1045,7 +1033,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="60c1-2a21-767b-98bd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1054,7 +1042,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="85f7-506e-7238-7494" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1063,7 +1051,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b704-c98a-3d08-9a90" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1072,7 +1060,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1080,13 +1068,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2852-dd57-1bd8-8981" name="Elven Mage [62 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="5cfe-635b-7ac6-df25" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="2194-6a48-821c-a892" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
@@ -1105,7 +1090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1119,19 +1104,19 @@
             <selectionEntry id="c840-fcf6-2779-732c" name="Magic Level 1" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="128e-b58a-49db-8d8c" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd3f-9eb6-53de-0d24" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1154,7 +1139,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1fe6-b9f2-3f8b-ff96" name="Apprentices in Light Armour" hidden="false" collective="false" type="model">
@@ -1166,7 +1151,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1174,7 +1159,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5ab3-a080-aba5-cce5" name="Daemons" hidden="false" collective="false" type="upgrade">
@@ -1191,7 +1176,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1199,7 +1184,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1216,7 +1201,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9165-7289-0e76-9d89" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1225,7 +1210,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1241,7 +1226,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1258,7 +1243,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d67-08e8-8987-2d32" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1267,7 +1252,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e160-d6b2-7dda-db7b" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1276,7 +1261,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89f8-f18f-7b8a-5fbc" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1285,7 +1270,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ea48-7be2-2b8b-cb42" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1294,7 +1279,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b45f-2990-e201-b123" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1303,7 +1288,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad30-e0af-5d6b-d325" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1312,7 +1297,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d03-783d-93e0-39ec" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1321,7 +1306,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5bef-245a-a81b-fc0c" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1330,7 +1315,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="35f9-c6dd-d666-10d2" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1339,7 +1324,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e6de-aa4d-6796-8ce4" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1348,7 +1333,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="79ac-2480-7ea8-9011" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1357,7 +1342,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eca0-3d73-e3b3-fcee" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1366,7 +1351,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d604-be1b-c53e-cc0c" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1375,7 +1360,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1391,7 +1376,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7959-1486-daa3-4b49" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1403,7 +1388,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5fdb-17e4-ddc3-cc50" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1415,7 +1400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b3d-3780-d660-94e9" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1427,7 +1412,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c25d-1013-4a1d-f1b7" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1439,7 +1424,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="654f-6b95-a2c8-536a" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1451,7 +1436,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e930-48f2-73a8-e2af" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1463,7 +1448,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3ae-6c35-f605-08dd" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1475,7 +1460,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="455f-f936-d77d-64ba" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1487,7 +1472,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a49-0760-f980-7b25" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1499,7 +1484,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1c6d-bdb8-3909-5d61" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1511,7 +1496,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="932b-eca5-18ee-8dc0" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1523,7 +1508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3e1d-1433-1c0f-4eb4" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1535,7 +1520,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b8f7-9ab0-6f8a-cafa" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1547,7 +1532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1563,7 +1548,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7895-db08-6665-d0ab" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1572,7 +1557,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="abc5-24c8-c0f9-ca21" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1581,7 +1566,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8ed6-d4b4-cccc-4081" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1590,7 +1575,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="affa-f390-4df4-969c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1599,7 +1584,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0421-f681-4d4d-16c2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1608,7 +1593,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ad8-f128-5f6d-7b01" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1617,7 +1602,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1625,15 +1610,12 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aa6f-d68a-6c78-68f8" name="Elven Guard [95 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
-        <infoLink id="ec30-f907-96cd-64fe" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="ec30-f907-96cd-64fe" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="295a-2e56-9b16-6892" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -1650,7 +1632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1667,7 +1649,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e99-be7e-b83a-aaf5" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1676,7 +1658,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1699,7 +1681,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1724,7 +1706,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3f5b-444c-f1e7-5875" name="Elven Guard" hidden="false" collective="false" type="model">
@@ -1737,7 +1719,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1745,7 +1727,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0cd4-ce20-a380-2188" name="Elven Guard in Spangly Armour [+4 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1762,7 +1744,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="268b-535b-9120-39f2" name="Elven Guard Leader" hidden="false" collective="false" type="model">
@@ -1775,7 +1757,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1783,7 +1765,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1791,13 +1773,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="badc-3155-f998-0995" name="Elven Warriors [95 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="0610-b28c-232c-fdbf" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1814,7 +1793,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="79c0-f546-f1d0-0963" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1823,7 +1802,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f16-46c1-7f8f-a78d" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1832,7 +1811,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1848,7 +1827,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1865,7 +1844,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="daca-77a5-1a28-7eb8" name="Elven Warriors" hidden="false" collective="false" type="model">
@@ -1878,7 +1857,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1886,16 +1865,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d269-784b-2037-0b91" name="Elven Archers [105 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="2fc8-e344-7e1f-6e56" name="Longbow" hidden="false" targetId="d4c8-3ef2-18de-85c0" type="profile"/>
-        <infoLink id="850e-39cc-2c51-d09f" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="850e-39cc-2c51-d09f" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="97ae-bec3-7d32-81ff" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
       <categoryLinks>
@@ -1913,7 +1889,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1938,7 +1914,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="38f8-5e00-0fdb-910b" name="Elven Archers" hidden="false" collective="false" type="model">
@@ -1951,7 +1927,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1959,7 +1935,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9a4-ecc6-9246-0d6a" name="Elven Archers in Light Armour [+2 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1976,7 +1952,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0502-fdea-edd0-763e" name="Elven Archer Leader" hidden="false" collective="false" type="model">
@@ -1989,7 +1965,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1997,7 +1973,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2005,13 +1981,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5d83-e361-70c9-499c" name="Elven Rangers [141 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="7046-634b-20d8-5ebd" name="Woodsman" hidden="false" targetId="e1f3-7817-0e4e-5cb9" type="rule"/>
         <infoLink id="da64-a1cf-d3a1-adc8" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
@@ -2033,7 +2006,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2058,7 +2031,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="36.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5230-bf49-1dcd-5443" name="Elven Rangers" hidden="false" collective="false" type="model">
@@ -2071,7 +2044,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2079,7 +2052,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f8f-189e-a46d-d71d" name="Elven Rangers in Spangly Armour [+4 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -2096,7 +2069,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2fb9-dd34-6e54-c95e" name="Elven Ranger Leader" hidden="false" collective="false" type="model">
@@ -2109,7 +2082,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="40.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2117,7 +2090,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2125,16 +2098,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="39cd-09b5-a58e-b4fa" name="Elven Cavalry [79 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="ffc9-c443-ae86-28bd" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-        <infoLink id="8457-a642-ed5a-18f2" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="8457-a642-ed5a-18f2" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="823d-c92b-25d3-c438" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
@@ -2151,7 +2121,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2168,7 +2138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c205-30ae-4952-6105" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2177,7 +2147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d546-1d97-27c2-9f4d" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -2193,7 +2163,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2216,7 +2186,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2240,7 +2210,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2263,7 +2233,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="33.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="a880-6a8b-3651-2a12" name="Elven Cavalry" hidden="false" collective="false" type="model">
@@ -2276,13 +2246,13 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="23.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6212-14ad-16ae-6763" name="Cavalry in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2297,7 +2267,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="25.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="422e-b0c5-2157-57d3" name="Elven Cavalry Leader" hidden="false" collective="false" type="model">
@@ -2310,13 +2280,13 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="35.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a933-0dce-4e3c-3edd" name="Cavalry in Spangly Armour" hidden="false" collective="false" type="upgrade">
@@ -2331,7 +2301,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="29.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="cbf4-98eb-637b-9bc5" name="Elven Cavalry Leader" hidden="false" collective="false" type="model">
@@ -2344,13 +2314,13 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="39.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2358,13 +2328,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="52d3-bc0e-f380-0876" name="Elven Knights [104 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="e6ac-8a00-4ef4-20c1" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
         <infoLink id="9fd5-3c7c-26b2-c868" name="Haughty Disdain" hidden="false" targetId="6a8d-ef1b-6f78-e15c" type="rule"/>
@@ -2393,7 +2360,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2411,7 +2378,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="48.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="804c-4773-facd-9fcc" name="Elven Knights" hidden="false" collective="false" type="model">
@@ -2424,7 +2391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2432,13 +2399,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d3d2-c832-23e1-9cb7" name="Giant Eagle [143 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="8cbc-73e8-57c5-aea5" name="Rock dropped by Eagle" hidden="false" targetId="c44d-adb8-ec8a-3dd4" type="profile"/>
       </infoLinks>
@@ -2461,7 +2425,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="143.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2478,7 +2442,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2486,13 +2450,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d7a0-4612-9a6d-2215" name="Elven Chariot [116 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="4160-5acc-9299-adcf" name="Longbow" hidden="false" targetId="d4c8-3ef2-18de-85c0" type="profile"/>
       </infoLinks>
@@ -2512,7 +2473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="98.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2529,7 +2490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2547,7 +2508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2564,7 +2525,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3bbc-1eac-4b59-d875" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2573,7 +2534,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f286-0f44-3008-dfb4" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2582,7 +2543,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2598,7 +2559,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2606,13 +2567,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="555c-7461-6e9a-8467" name="Elven Bolt Thrower [93 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="e441-50b4-417c-8922" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2632,7 +2590,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2649,7 +2607,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c226-9114-8dbb-c8aa" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2659,7 +2617,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2667,13 +2625,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1f4e-7ddd-0923-cd17" name="Elven Stone Thrower [105 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="baf1-a29c-e2e1-46da" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2693,7 +2648,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2710,7 +2665,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1bf9-67e1-1641-80e4" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -2719,7 +2674,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2727,7 +2682,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Gnolls.cat
+++ b/Gnolls.cat
@@ -59,7 +59,7 @@
           <selectionEntries>
             <selectionEntry id="b87a-0f66-9882-c686" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="7b43-6632-47cb-1380" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="7b43-6632-47cb-1380" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -419,7 +419,7 @@
             </selectionEntry>
             <selectionEntry id="902f-c5bd-d344-31ed" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="234a-13a2-bbb8-66e2" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="234a-13a2-bbb8-66e2" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -842,7 +842,7 @@
           <selectionEntries>
             <selectionEntry id="e18d-45bc-8bea-96df" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="4116-ec89-e0fe-02ec" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="4116-ec89-e0fe-02ec" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1151,7 +1151,7 @@
             </selectionEntry>
             <selectionEntry id="e402-bd7c-d214-dac4" name="Axes" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="dbb8-4a3a-ca67-caa5" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="dbb8-4a3a-ca67-caa5" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1269,7 +1269,7 @@
           <selectionEntries>
             <selectionEntry id="f1bb-1942-efc1-9066" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="2833-3ac8-c09d-817e" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="2833-3ac8-c09d-817e" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1377,7 +1377,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="109d-275f-3a1d-cdaf" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="109d-275f-3a1d-cdaf" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1502,7 +1502,7 @@
           <selectionEntries>
             <selectionEntry id="727b-a143-5c34-b10a" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="ca52-2b60-4c71-ba0e" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="ca52-2b60-4c71-ba0e" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1668,7 +1668,7 @@
           <selectionEntries>
             <selectionEntry id="552e-f0e6-5dfd-0763" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="ddfb-b9fc-bf25-115a" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="ddfb-b9fc-bf25-115a" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1787,7 +1787,7 @@
             </selectionEntry>
             <selectionEntry id="a8d0-463b-c291-3395" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="cb53-104c-9caf-5ad4" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="cb53-104c-9caf-5ad4" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2008,7 +2008,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="4374-2f7c-c901-0a49" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="4374-2f7c-c901-0a49" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>

--- a/Gnolls.cat
+++ b/Gnolls.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6f32-651f-4105-5375" name="Gnolls" revision="1" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwaragmer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6f32-651f-4105-5375" name="Gnolls" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwaragmer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="c253-a1f4-cc5a-aa3d" name="Gnoll Chieftain [110 pts]" hidden="false" collective="false" targetId="ceea-205a-5863-8f33" type="selectionEntry"/>
     <entryLink id="4be6-0544-f612-81bd" name="Gnoll Shaman [66 pts]" hidden="false" collective="false" targetId="98e7-400a-37ff-3d3e" type="selectionEntry"/>
@@ -14,6 +14,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="ceea-205a-5863-8f33" name="Gnoll Chieftain [112 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="bf1b-12ca-08b1-43f5" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="27b6-e12b-c05e-78c2" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -32,6 +35,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="78.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d88-393c-df81-60ee" name="Gnoll Guard" hidden="false" collective="false" type="model">
@@ -44,6 +48,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -60,6 +65,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="909a-c84a-8c9b-ff93" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -68,6 +74,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7188-f700-ba7d-9b95" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -76,6 +83,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="37bc-ac49-ae68-f04f" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -84,6 +92,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88f8-1f67-852f-893a" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -92,6 +101,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="94eb-ddc2-d8c6-cbef" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -100,6 +110,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9823-d87b-a4de-8886" name="Morning Stars" hidden="false" collective="false" type="upgrade">
@@ -108,6 +119,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -124,6 +136,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2a21-5c35-794f-7009" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -132,6 +145,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5183-13f1-799a-eac1" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -140,6 +154,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -156,6 +171,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e50-17d9-7f11-5bc1" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -164,6 +180,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -179,6 +196,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="abc5-4ad8-6735-2988" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -187,6 +205,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e42a-95d8-d875-5683" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -195,6 +214,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="520f-e9ce-25c5-f7ca" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -203,6 +223,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55d7-0c31-e693-ed74" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -211,6 +232,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db72-f5da-527b-f765" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -219,6 +241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83cb-0aa0-639a-4ca5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -227,6 +250,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -234,9 +258,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="98e7-400a-37ff-3d3e" name="Gnoll Shaman [66 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="2646-bfeb-96bd-705a" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
         <categoryLink id="9b57-d316-be08-f09d" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -254,6 +282,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88a3-c66a-d580-4dfd" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -262,6 +291,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cdc5-5f88-ce65-6b13" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -270,6 +300,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -286,6 +317,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebee-1d13-4f8d-851c" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -294,6 +326,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -317,6 +350,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -324,6 +358,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1cfb-4578-c6a7-5726" name="Animal Spirits" hidden="false" collective="false" type="upgrade">
@@ -339,6 +374,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -346,6 +382,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -363,6 +400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="66.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -379,6 +417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="902f-c5bd-d344-31ed" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -387,6 +426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -402,6 +442,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c1a9-63fe-d1ba-ed48" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -413,6 +454,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d01-e748-d7ff-457b" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -424,6 +466,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6051-bb02-40a2-5107" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -435,6 +478,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1cb8-14ce-536a-f757" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -446,6 +490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5910-dbc8-18dc-0da4" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -457,6 +502,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="09b7-f33f-21fa-d97d" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -468,6 +514,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="80da-bce8-6fbb-71cc" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -479,6 +526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d81-5cfb-e4d5-38da" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -490,6 +538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1ae9-d269-7fd1-2307" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -501,6 +550,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a280-d673-22d9-35d1" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -512,6 +562,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="46f4-32bc-72b0-24c8" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -523,6 +574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90c0-9072-6ac8-4d3c" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -534,6 +586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1aca-e801-89fb-88fb" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -545,6 +598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -561,6 +615,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58f9-0626-51bb-345e" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -569,6 +624,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="06c4-0a29-a563-b87b" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -577,6 +633,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1360-383e-2681-04ed" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -585,6 +642,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c42f-1a42-7281-0b84" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -593,6 +651,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fdc1-0f95-08b3-6173" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -601,6 +660,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7236-6e02-bc9d-dc2a" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -609,6 +669,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a32e-b23f-a3d0-38bc" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -617,6 +678,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3182-b341-91c9-7b1e" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -625,6 +687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="492c-2af5-42a0-43df" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -633,6 +696,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9420-ee2e-eb84-d43b" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -641,6 +705,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02f4-dcc9-0644-d994" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -649,6 +714,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e69e-ea4b-d376-62b2" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -657,6 +723,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4aab-9e9e-3ce2-926b" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -665,6 +732,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -680,6 +748,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9af-7629-68df-f517" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -688,6 +757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9bdd-efa3-f4c4-8d97" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -696,6 +766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="379f-93c1-ff65-4f4c" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -704,6 +775,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6fdf-abac-4dc1-f696" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -712,6 +784,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c138-04e4-7077-451b" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -720,6 +793,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95d8-1dbb-4339-0ca6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -728,6 +802,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -735,9 +810,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="808f-7316-9868-4ba3" name="Gnoll Champion [83 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9443-1d62-6a77-9955" name="New CategoryLink" hidden="false" targetId="warrior command unit" primary="true"/>
       </categoryLinks>
@@ -754,6 +833,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="946b-5665-067b-cc59" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -762,6 +842,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66e6-3339-3e70-af50" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -770,6 +851,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="691d-b4f8-dc43-8ebd" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -778,6 +860,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ef5a-c3ed-b2a2-4b12" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -786,6 +869,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d7f-422f-c1ef-d2fa" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -794,6 +878,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2da9-eaa5-4d3f-4e68" name="Morning Stars" hidden="false" collective="false" type="upgrade">
@@ -802,6 +887,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -818,6 +904,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e241-3f9a-9ee0-a464" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -826,6 +913,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ddb3-b5c3-a6ce-4d62" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -834,6 +922,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -850,6 +939,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="512a-4340-62cd-c9f6" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -858,6 +948,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -875,6 +966,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="83.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -890,6 +982,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b04f-63c1-c77e-99b5" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -898,6 +991,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e2d-084f-9f76-333c" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -906,6 +1000,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dda6-e8a6-263e-1a64" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -914,6 +1009,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2d69-0f2e-9b87-0cbd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -922,6 +1018,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="74d0-dcb4-4aa9-9946" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -930,6 +1027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2763-559e-c84d-92af" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -938,6 +1036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -945,9 +1044,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6738-54c4-3339-67af" name="Gnoll Warriors [77 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="8c87-2f5f-d3b2-5d1a" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
@@ -975,6 +1078,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8043-fef9-3226-bac8" name="Gnoll Warrior" hidden="false" collective="false" type="model">
@@ -987,6 +1091,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -994,6 +1099,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18af-0d2f-84fc-08b4" name="Gnoll Warriors in Light Armour [+2 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1010,6 +1116,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3fe2-6f8b-8a31-58e8" name="Gnoll Pack master" hidden="false" collective="false" type="model">
@@ -1022,6 +1129,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1029,6 +1137,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1045,6 +1154,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e402-bd7c-d214-dac4" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1053,6 +1163,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1060,9 +1171,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4970-7f8f-b173-60cf" name="Gnoll Guard [87 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="4acb-c343-9343-9fd1" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1087,6 +1202,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="76e2-979e-5e12-56fe" name="Gnoll Guard" hidden="false" collective="false" type="model">
@@ -1099,6 +1215,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1106,6 +1223,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b053-c308-a8f5-451a" name="Gnoll Guard in Light Armour [+2 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1122,6 +1240,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4cad-b484-6ecd-2d11" name="Gnoll Pack master" hidden="false" collective="false" type="model">
@@ -1134,6 +1253,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1141,6 +1261,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1157,6 +1278,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4747-ae97-54f5-3a5c" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1165,6 +1287,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9367-280a-f0a9-aea9" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1173,6 +1296,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51e3-155f-e08b-ead3" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1181,6 +1305,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f34-e0d1-71da-d756" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -1189,6 +1314,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee28-b3ca-57bd-67cd" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -1197,6 +1323,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29e7-8bb3-2d76-6ae1" name="Morning Stars" hidden="false" collective="false" type="upgrade">
@@ -1205,6 +1332,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51a7-935e-cbc2-872f" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1220,6 +1348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1227,9 +1356,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="eb98-a54f-3cfe-1329" name="Gnoll Archers [82 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="41af-00a0-f106-8f1a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1253,6 +1386,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91d7-e459-79b2-eda6" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1268,6 +1402,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bce1-3949-1e74-e111" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -1276,6 +1411,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1292,6 +1428,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2eb2-f842-c886-81ec" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -1307,6 +1444,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1323,6 +1461,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="26.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6bd6-13ff-71c8-5795" name="Gnoll Archer" hidden="false" collective="false" type="model">
@@ -1335,6 +1474,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1342,15 +1482,19 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2efe-475b-9097-0f86" name="Gnoll Scouts [92 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac55-996f-1043-c14f" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="8527-bca2-aa85-90e1" name="Stealthy" hidden="false" targetId="dcb2-de55-1fca-e0a8" type="rule"/>
-        <infoLink id="0b52-2bd1-a1ef-d905" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+        <infoLink id="0b52-2bd1-a1ef-d905" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="32fa-7089-bcf5-5720" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -1368,6 +1512,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa91-c694-f200-caf7" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1376,6 +1521,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1398,6 +1544,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1413,6 +1560,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1430,6 +1578,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bdeb-67b3-2105-4bd6" name="Gnoll Scouts" hidden="false" collective="false" type="model">
@@ -1442,6 +1591,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1449,12 +1599,16 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ca29-8d81-164c-ae92" name="Gnoll Trackers [104 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="3315-3013-c1cf-2f2a" name="Woodsman" hidden="false" targetId="e1f3-7817-0e4e-5cb9" type="rule"/>
-        <infoLink id="41ee-98c8-c61b-62c0" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+        <infoLink id="41ee-98c8-c61b-62c0" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
         <infoLink id="cd2c-8a3a-a961-7158" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
@@ -1475,6 +1629,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="19.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1494,6 +1649,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b2e-69c8-a5e4-ad90" name="Gnoll Tracker in Light Armour" hidden="false" collective="false" type="model">
@@ -1505,6 +1661,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1521,6 +1678,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="586b-8d39-193a-e3ea" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1529,6 +1687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b805-05a3-0fd1-f26f" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1537,6 +1696,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5259-ad59-4326-704e" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -1545,6 +1705,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="69df-296f-2c6f-0d40" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -1553,6 +1714,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2efc-1d5d-384b-a8b0" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -1561,6 +1723,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e408-9f77-4bdb-f5cd" name="Morning Star" hidden="false" collective="false" type="upgrade">
@@ -1569,6 +1732,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1576,9 +1740,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="43b2-a0f2-3dbd-dee6" name="Gnoll Chariot [100 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="ad20-1194-af32-8961" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
       </categoryLinks>
@@ -1595,6 +1763,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6d5-6214-25e2-7067" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1603,6 +1772,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a8d0-463b-c291-3395" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1611,6 +1781,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1633,6 +1804,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1127-1604-6894-47b4" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -1648,6 +1820,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1663,6 +1836,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1679,6 +1853,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1694,11 +1869,12 @@
                 <infoLink id="86b7-2dac-0f1f-9fbc" name="Gnoll Chariot with crew, pulled by two hyenas" hidden="false" targetId="00bd-e5d9-8f1b-ae6c" type="profile"/>
                 <infoLink id="dd88-f20b-71f5-2ebb" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                 <infoLink id="8313-5e66-7d93-40ab" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
-                <infoLink id="e59d-67ce-7302-f6b9" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                <infoLink id="e59d-67ce-7302-f6b9" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
                 <infoLink id="6bfc-0076-9d39-d731" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="90.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1721,6 +1897,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1728,9 +1905,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ef5a-8658-be88-159f" name="Gnoll Stone Thrower [96 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="e068-e6ce-1eaa-f2d2" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -1757,6 +1938,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1764,6 +1946,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="108a-641c-0f3d-922c" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1782,6 +1965,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1789,6 +1973,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1805,6 +1990,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78bf-7696-bbdd-7078" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -1813,6 +1999,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1836,6 +2023,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e3ed-b852-70b3-0d00" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1851,6 +2039,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15b9-e903-91b5-26d8" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -1859,6 +2048,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1866,6 +2056,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Gnolls.cat
+++ b/Gnolls.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6f32-651f-4105-5375" name="Gnolls" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwaragmer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6f32-651f-4105-5375" name="Gnolls" revision="3" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwaragmer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="c253-a1f4-cc5a-aa3d" name="Gnoll Chieftain [110 pts]" hidden="false" collective="false" targetId="ceea-205a-5863-8f33" type="selectionEntry"/>
     <entryLink id="4be6-0544-f612-81bd" name="Gnoll Shaman [66 pts]" hidden="false" collective="false" targetId="98e7-400a-37ff-3d3e" type="selectionEntry"/>
@@ -14,9 +14,6 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="ceea-205a-5863-8f33" name="Gnoll Chieftain [112 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="bf1b-12ca-08b1-43f5" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="27b6-e12b-c05e-78c2" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -35,7 +32,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="78.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d88-393c-df81-60ee" name="Gnoll Guard" hidden="false" collective="false" type="model">
@@ -48,7 +45,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -65,7 +62,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="909a-c84a-8c9b-ff93" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -74,7 +71,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7188-f700-ba7d-9b95" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -83,7 +80,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="37bc-ac49-ae68-f04f" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -92,7 +89,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88f8-1f67-852f-893a" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -101,7 +98,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="94eb-ddc2-d8c6-cbef" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -110,7 +107,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9823-d87b-a4de-8886" name="Morning Stars" hidden="false" collective="false" type="upgrade">
@@ -119,7 +116,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -136,7 +133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2a21-5c35-794f-7009" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -145,7 +142,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5183-13f1-799a-eac1" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -154,7 +151,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -171,7 +168,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e50-17d9-7f11-5bc1" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -180,7 +177,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -196,7 +193,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="abc5-4ad8-6735-2988" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -205,7 +202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e42a-95d8-d875-5683" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -214,7 +211,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="520f-e9ce-25c5-f7ca" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -223,7 +220,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55d7-0c31-e693-ed74" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -232,7 +229,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db72-f5da-527b-f765" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -241,7 +238,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83cb-0aa0-639a-4ca5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -250,7 +247,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -258,13 +255,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="98e7-400a-37ff-3d3e" name="Gnoll Shaman [66 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="2646-bfeb-96bd-705a" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
         <categoryLink id="9b57-d316-be08-f09d" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -282,7 +276,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88a3-c66a-d580-4dfd" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -291,7 +285,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cdc5-5f88-ce65-6b13" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -300,7 +294,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -317,7 +311,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebee-1d13-4f8d-851c" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -326,7 +320,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -350,7 +344,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -358,7 +352,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1cfb-4578-c6a7-5726" name="Animal Spirits" hidden="false" collective="false" type="upgrade">
@@ -374,7 +368,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -382,7 +376,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -400,7 +394,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="66.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -417,7 +411,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="902f-c5bd-d344-31ed" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -426,7 +420,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -442,7 +436,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c1a9-63fe-d1ba-ed48" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -454,7 +448,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d01-e748-d7ff-457b" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -466,7 +460,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6051-bb02-40a2-5107" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -478,7 +472,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1cb8-14ce-536a-f757" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -490,7 +484,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5910-dbc8-18dc-0da4" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -502,7 +496,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="09b7-f33f-21fa-d97d" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -514,7 +508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="80da-bce8-6fbb-71cc" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -526,7 +520,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d81-5cfb-e4d5-38da" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -538,7 +532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1ae9-d269-7fd1-2307" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -550,7 +544,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a280-d673-22d9-35d1" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -562,7 +556,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="46f4-32bc-72b0-24c8" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -574,7 +568,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90c0-9072-6ac8-4d3c" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -586,7 +580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1aca-e801-89fb-88fb" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -598,7 +592,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -615,7 +609,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58f9-0626-51bb-345e" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -624,7 +618,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="06c4-0a29-a563-b87b" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -633,7 +627,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1360-383e-2681-04ed" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -642,7 +636,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c42f-1a42-7281-0b84" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -651,7 +645,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fdc1-0f95-08b3-6173" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -660,7 +654,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7236-6e02-bc9d-dc2a" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -669,7 +663,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a32e-b23f-a3d0-38bc" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -678,7 +672,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3182-b341-91c9-7b1e" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -687,7 +681,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="492c-2af5-42a0-43df" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -696,7 +690,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9420-ee2e-eb84-d43b" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -705,7 +699,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02f4-dcc9-0644-d994" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -714,7 +708,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e69e-ea4b-d376-62b2" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -723,7 +717,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4aab-9e9e-3ce2-926b" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -732,7 +726,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -748,7 +742,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9af-7629-68df-f517" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -757,7 +751,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9bdd-efa3-f4c4-8d97" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -766,7 +760,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="379f-93c1-ff65-4f4c" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -775,7 +769,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6fdf-abac-4dc1-f696" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -784,7 +778,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c138-04e4-7077-451b" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -793,7 +787,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95d8-1dbb-4339-0ca6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -802,7 +796,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -810,13 +804,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="808f-7316-9868-4ba3" name="Gnoll Champion [83 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="9443-1d62-6a77-9955" name="New CategoryLink" hidden="false" targetId="warrior command unit" primary="true"/>
       </categoryLinks>
@@ -833,7 +824,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="946b-5665-067b-cc59" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -842,7 +833,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66e6-3339-3e70-af50" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -851,7 +842,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="691d-b4f8-dc43-8ebd" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -860,7 +851,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ef5a-c3ed-b2a2-4b12" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -869,7 +860,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d7f-422f-c1ef-d2fa" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -878,7 +869,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2da9-eaa5-4d3f-4e68" name="Morning Stars" hidden="false" collective="false" type="upgrade">
@@ -887,7 +878,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -904,7 +895,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e241-3f9a-9ee0-a464" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -913,7 +904,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ddb3-b5c3-a6ce-4d62" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -922,7 +913,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -939,7 +930,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="512a-4340-62cd-c9f6" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -948,7 +939,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -966,7 +957,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="83.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -982,7 +973,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b04f-63c1-c77e-99b5" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -991,7 +982,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e2d-084f-9f76-333c" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1000,7 +991,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dda6-e8a6-263e-1a64" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1009,7 +1000,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2d69-0f2e-9b87-0cbd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1018,7 +1009,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="74d0-dcb4-4aa9-9946" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1027,7 +1018,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2763-559e-c84d-92af" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1036,7 +1027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1044,15 +1035,12 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6738-54c4-3339-67af" name="Gnoll Warriors [77 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
-        <infoLink id="8c87-2f5f-d3b2-5d1a" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="8c87-2f5f-d3b2-5d1a" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5f47-23cf-7b87-db59" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -1078,7 +1066,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8043-fef9-3226-bac8" name="Gnoll Warrior" hidden="false" collective="false" type="model">
@@ -1091,7 +1079,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1099,7 +1087,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18af-0d2f-84fc-08b4" name="Gnoll Warriors in Light Armour [+2 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1116,7 +1104,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3fe2-6f8b-8a31-58e8" name="Gnoll Pack master" hidden="false" collective="false" type="model">
@@ -1129,7 +1117,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1137,7 +1125,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1154,7 +1142,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e402-bd7c-d214-dac4" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1163,7 +1151,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1171,13 +1159,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4970-7f8f-b173-60cf" name="Gnoll Guard [87 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="4acb-c343-9343-9fd1" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1202,7 +1187,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="76e2-979e-5e12-56fe" name="Gnoll Guard" hidden="false" collective="false" type="model">
@@ -1215,7 +1200,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1223,7 +1208,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b053-c308-a8f5-451a" name="Gnoll Guard in Light Armour [+2 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1240,7 +1225,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4cad-b484-6ecd-2d11" name="Gnoll Pack master" hidden="false" collective="false" type="model">
@@ -1253,7 +1238,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1261,7 +1246,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1278,7 +1263,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4747-ae97-54f5-3a5c" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1287,7 +1272,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9367-280a-f0a9-aea9" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1296,7 +1281,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51e3-155f-e08b-ead3" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1305,7 +1290,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f34-e0d1-71da-d756" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -1314,7 +1299,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee28-b3ca-57bd-67cd" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -1323,7 +1308,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29e7-8bb3-2d76-6ae1" name="Morning Stars" hidden="false" collective="false" type="upgrade">
@@ -1332,7 +1317,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51a7-935e-cbc2-872f" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1348,7 +1333,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1356,13 +1341,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="eb98-a54f-3cfe-1329" name="Gnoll Archers [82 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="41af-00a0-f106-8f1a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1386,7 +1368,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91d7-e459-79b2-eda6" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1402,7 +1384,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bce1-3949-1e74-e111" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -1411,7 +1393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1428,7 +1410,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2eb2-f842-c886-81ec" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -1444,7 +1426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1461,7 +1443,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="26.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6bd6-13ff-71c8-5795" name="Gnoll Archer" hidden="false" collective="false" type="model">
@@ -1474,7 +1456,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1482,13 +1464,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2efe-475b-9097-0f86" name="Gnoll Scouts [92 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac55-996f-1043-c14f" type="max"/>
       </constraints>
@@ -1512,7 +1491,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa91-c694-f200-caf7" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1521,7 +1500,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1544,7 +1523,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1560,7 +1539,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1578,7 +1557,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bdeb-67b3-2105-4bd6" name="Gnoll Scouts" hidden="false" collective="false" type="model">
@@ -1591,7 +1570,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1599,13 +1578,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ca29-8d81-164c-ae92" name="Gnoll Trackers [104 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="3315-3013-c1cf-2f2a" name="Woodsman" hidden="false" targetId="e1f3-7817-0e4e-5cb9" type="rule"/>
         <infoLink id="41ee-98c8-c61b-62c0" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
@@ -1629,7 +1605,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="19.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1649,7 +1625,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b2e-69c8-a5e4-ad90" name="Gnoll Tracker in Light Armour" hidden="false" collective="false" type="model">
@@ -1661,7 +1637,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1678,7 +1654,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="586b-8d39-193a-e3ea" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1687,7 +1663,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b805-05a3-0fd1-f26f" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1696,7 +1672,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5259-ad59-4326-704e" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -1705,7 +1681,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="69df-296f-2c6f-0d40" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -1714,7 +1690,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2efc-1d5d-384b-a8b0" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -1723,7 +1699,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e408-9f77-4bdb-f5cd" name="Morning Star" hidden="false" collective="false" type="upgrade">
@@ -1732,7 +1708,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1740,13 +1716,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="43b2-a0f2-3dbd-dee6" name="Gnoll Chariot [100 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="ad20-1194-af32-8961" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
       </categoryLinks>
@@ -1763,7 +1736,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6d5-6214-25e2-7067" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1772,7 +1745,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a8d0-463b-c291-3395" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1781,7 +1754,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1804,7 +1777,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1127-1604-6894-47b4" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -1820,7 +1793,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1836,7 +1809,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1853,7 +1826,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1874,7 +1847,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="90.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1897,7 +1870,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1905,13 +1878,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ef5a-8658-be88-159f" name="Gnoll Stone Thrower [96 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="e068-e6ce-1eaa-f2d2" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -1938,7 +1908,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1946,7 +1916,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="108a-641c-0f3d-922c" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1965,7 +1935,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1973,7 +1943,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1990,7 +1960,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78bf-7696-bbdd-7078" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -1999,7 +1969,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2023,7 +1993,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e3ed-b852-70b3-0d00" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2039,7 +2009,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15b9-e903-91b5-26d8" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -2048,7 +2018,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2056,7 +2026,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Gnolls.cat
+++ b/Gnolls.cat
@@ -29,10 +29,11 @@
               <infoLinks>
                 <infoLink id="9c8c-2c9c-e286-e89f" name="Gnoll Chieftain" hidden="false" targetId="9793-1b53-df3d-0e5d" type="profile"/>
                 <infoLink id="4dd7-7a11-c880-a0aa" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+                <infoLink id="06cc-fc3d-10eb-8807" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="78.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d88-393c-df81-60ee" name="Gnoll Guard" hidden="false" collective="false" type="model">
@@ -45,7 +46,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -62,7 +63,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="909a-c84a-8c9b-ff93" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -71,7 +72,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7188-f700-ba7d-9b95" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -80,7 +81,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="37bc-ac49-ae68-f04f" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -89,7 +90,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88f8-1f67-852f-893a" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -98,7 +99,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="94eb-ddc2-d8c6-cbef" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -107,7 +108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9823-d87b-a4de-8886" name="Morning Stars" hidden="false" collective="false" type="upgrade">
@@ -116,7 +117,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -133,7 +134,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2a21-5c35-794f-7009" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -142,7 +143,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5183-13f1-799a-eac1" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -151,7 +152,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -168,7 +169,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e50-17d9-7f11-5bc1" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -177,7 +178,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -193,7 +194,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="abc5-4ad8-6735-2988" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -202,7 +203,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e42a-95d8-d875-5683" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -211,7 +212,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="520f-e9ce-25c5-f7ca" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -220,7 +221,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55d7-0c31-e693-ed74" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -229,7 +230,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db72-f5da-527b-f765" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -238,7 +239,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83cb-0aa0-639a-4ca5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -247,7 +248,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -255,7 +256,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="98e7-400a-37ff-3d3e" name="Gnoll Shaman [66 pts]" hidden="false" collective="false" type="unit">
@@ -276,7 +277,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88a3-c66a-d580-4dfd" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -285,7 +286,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cdc5-5f88-ce65-6b13" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -294,7 +295,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -311,7 +312,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebee-1d13-4f8d-851c" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -320,7 +321,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -341,10 +342,11 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="6013-968d-7242-6871" name="Totem Beasts: (Dogs, Wolves or Hyenas)" hidden="false" targetId="c9df-b218-c23e-491c" type="profile"/>
+                        <infoLink id="1ef3-0184-4620-c7ac" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -352,7 +354,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1cfb-4578-c6a7-5726" name="Animal Spirits" hidden="false" collective="false" type="upgrade">
@@ -365,10 +367,11 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="cee1-ba57-e899-336b" name="Animal Spirit Guide or Familiar" hidden="false" targetId="4887-6844-9b46-966c" type="profile"/>
+                        <infoLink id="82c5-1378-43e8-4ca9" name="Spirit" hidden="false" targetId="78d3-886d-5fc6-bac4" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -376,7 +379,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -394,7 +397,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="66.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -411,7 +414,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="902f-c5bd-d344-31ed" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -420,7 +423,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -436,7 +439,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c1a9-63fe-d1ba-ed48" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -448,7 +451,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d01-e748-d7ff-457b" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -460,7 +463,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6051-bb02-40a2-5107" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -472,7 +475,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1cb8-14ce-536a-f757" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -484,7 +487,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5910-dbc8-18dc-0da4" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -496,7 +499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="09b7-f33f-21fa-d97d" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -508,7 +511,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="80da-bce8-6fbb-71cc" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -520,7 +523,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d81-5cfb-e4d5-38da" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -532,7 +535,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1ae9-d269-7fd1-2307" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -544,7 +547,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a280-d673-22d9-35d1" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -556,7 +559,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="46f4-32bc-72b0-24c8" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -568,7 +571,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90c0-9072-6ac8-4d3c" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -580,7 +583,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1aca-e801-89fb-88fb" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -592,7 +595,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -609,7 +612,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58f9-0626-51bb-345e" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -618,7 +621,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="06c4-0a29-a563-b87b" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -627,7 +630,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1360-383e-2681-04ed" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -636,7 +639,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c42f-1a42-7281-0b84" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -645,7 +648,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fdc1-0f95-08b3-6173" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -654,7 +657,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7236-6e02-bc9d-dc2a" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -663,7 +666,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a32e-b23f-a3d0-38bc" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -672,7 +675,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3182-b341-91c9-7b1e" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -681,7 +684,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="492c-2af5-42a0-43df" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -690,7 +693,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9420-ee2e-eb84-d43b" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -699,7 +702,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02f4-dcc9-0644-d994" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -708,7 +711,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e69e-ea4b-d376-62b2" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -717,7 +720,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4aab-9e9e-3ce2-926b" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -726,7 +729,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -742,7 +745,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9af-7629-68df-f517" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -751,7 +754,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9bdd-efa3-f4c4-8d97" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -760,7 +763,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="379f-93c1-ff65-4f4c" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -769,7 +772,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6fdf-abac-4dc1-f696" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -778,7 +781,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c138-04e4-7077-451b" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -787,7 +790,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95d8-1dbb-4339-0ca6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -796,7 +799,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -804,13 +807,32 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="808f-7316-9868-4ba3" name="Gnoll Champion [83 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cce9-5bf5-b2ef-7166" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="9443-1d62-6a77-9955" name="New CategoryLink" hidden="false" targetId="warrior command unit" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b55c-778b-da2e-ebd1" name="Champion" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd45-c46c-3427-753b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="815a-07e5-9226-271f" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b596-2b31-2119-5c42" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
+            <infoLink id="99a8-16b2-fd9e-e5f9" name="Gnoll Champion" hidden="false" targetId="fbf6-44a5-1372-9ef4" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="83.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="f4ba-a2a7-95f1-f72c" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="e18d-45bc-8bea-96df">
           <constraints>
@@ -824,7 +846,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="946b-5665-067b-cc59" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -833,7 +855,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66e6-3339-3e70-af50" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -842,7 +864,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="691d-b4f8-dc43-8ebd" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -851,7 +873,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ef5a-c3ed-b2a2-4b12" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -860,7 +882,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7d7f-422f-c1ef-d2fa" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -869,7 +891,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2da9-eaa5-4d3f-4e68" name="Morning Stars" hidden="false" collective="false" type="upgrade">
@@ -878,7 +900,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -895,7 +917,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e241-3f9a-9ee0-a464" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -904,7 +926,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ddb3-b5c3-a6ce-4d62" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -913,7 +935,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -930,7 +952,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="512a-4340-62cd-c9f6" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -939,25 +961,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="e2b7-8895-97bd-7a97" name="Champion" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="261c-1d26-1ac8-f41e" name="Champion" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b71-dea9-8c1a-66a3" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="316c-e114-7c4c-5bd0" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="6a94-76d5-efdf-1858" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
-                <infoLink id="4a83-a70b-641d-9f6d" name="Gnoll Champion" hidden="false" targetId="fbf6-44a5-1372-9ef4" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="83.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -973,7 +977,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b04f-63c1-c77e-99b5" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -982,7 +986,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e2d-084f-9f76-333c" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -991,7 +995,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dda6-e8a6-263e-1a64" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1000,7 +1004,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2d69-0f2e-9b87-0cbd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1009,7 +1013,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="74d0-dcb4-4aa9-9946" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1018,7 +1022,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2763-559e-c84d-92af" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1027,7 +1031,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1035,7 +1039,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6738-54c4-3339-67af" name="Gnoll Warriors [77 pts]" hidden="false" collective="false" type="unit">
@@ -1066,7 +1070,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8043-fef9-3226-bac8" name="Gnoll Warrior" hidden="false" collective="false" type="model">
@@ -1079,7 +1083,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1087,7 +1091,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18af-0d2f-84fc-08b4" name="Gnoll Warriors in Light Armour [+2 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1104,7 +1108,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3fe2-6f8b-8a31-58e8" name="Gnoll Pack master" hidden="false" collective="false" type="model">
@@ -1117,7 +1121,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1125,7 +1129,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1142,7 +1146,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e402-bd7c-d214-dac4" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1151,7 +1155,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1159,10 +1163,16 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4970-7f8f-b173-60cf" name="Gnoll Guard [87 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76fc-c744-3132-28ff" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="46d6-3c19-95e3-5577" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="4acb-c343-9343-9fd1" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1187,7 +1197,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="76e2-979e-5e12-56fe" name="Gnoll Guard" hidden="false" collective="false" type="model">
@@ -1200,7 +1210,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1208,7 +1218,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b053-c308-a8f5-451a" name="Gnoll Guard in Light Armour [+2 pts per model]" hidden="false" collective="false" type="upgrade">
@@ -1225,7 +1235,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4cad-b484-6ecd-2d11" name="Gnoll Pack master" hidden="false" collective="false" type="model">
@@ -1238,7 +1248,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1246,7 +1256,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1263,7 +1273,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4747-ae97-54f5-3a5c" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1272,7 +1282,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9367-280a-f0a9-aea9" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1281,7 +1291,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51e3-155f-e08b-ead3" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1290,7 +1300,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f34-e0d1-71da-d756" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -1299,7 +1309,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee28-b3ca-57bd-67cd" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -1308,7 +1318,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29e7-8bb3-2d76-6ae1" name="Morning Stars" hidden="false" collective="false" type="upgrade">
@@ -1317,7 +1327,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51a7-935e-cbc2-872f" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1333,7 +1343,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1341,10 +1351,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="eb98-a54f-3cfe-1329" name="Gnoll Archers [82 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="ed57-49f6-2414-5f2d" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="41af-00a0-f106-8f1a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1368,7 +1381,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91d7-e459-79b2-eda6" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1384,7 +1397,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bce1-3949-1e74-e111" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -1393,7 +1406,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1410,7 +1423,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2eb2-f842-c886-81ec" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -1423,10 +1436,11 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="3215-f944-8502-e4bc" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
+                <infoLink id="ec12-456a-100b-b2c9" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1443,7 +1457,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="26.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6bd6-13ff-71c8-5795" name="Gnoll Archer" hidden="false" collective="false" type="model">
@@ -1456,7 +1470,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1464,12 +1478,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2efe-475b-9097-0f86" name="Gnoll Scouts [92 pts]" hidden="false" collective="false" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac55-996f-1043-c14f" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ef1-1083-b816-6a3f" type="max"/>
       </constraints>
       <infoLinks>
         <infoLink id="8527-bca2-aa85-90e1" name="Stealthy" hidden="false" targetId="dcb2-de55-1fca-e0a8" type="rule"/>
@@ -1491,7 +1506,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa91-c694-f200-caf7" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1500,7 +1515,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1523,7 +1538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1539,7 +1554,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1557,7 +1572,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bdeb-67b3-2105-4bd6" name="Gnoll Scouts" hidden="false" collective="false" type="model">
@@ -1570,7 +1585,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1578,10 +1593,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ca29-8d81-164c-ae92" name="Gnoll Trackers [104 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30a3-c211-11c6-fc3b" type="max"/>
+      </constraints>
       <infoLinks>
         <infoLink id="3315-3013-c1cf-2f2a" name="Woodsman" hidden="false" targetId="e1f3-7817-0e4e-5cb9" type="rule"/>
         <infoLink id="41ee-98c8-c61b-62c0" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
@@ -1605,7 +1623,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="19.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1625,7 +1643,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b2e-69c8-a5e4-ad90" name="Gnoll Tracker in Light Armour" hidden="false" collective="false" type="model">
@@ -1637,7 +1655,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1654,7 +1672,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="586b-8d39-193a-e3ea" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1663,7 +1681,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b805-05a3-0fd1-f26f" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1672,7 +1690,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5259-ad59-4326-704e" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -1681,7 +1699,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="69df-296f-2c6f-0d40" name="Flails" hidden="false" collective="false" type="upgrade">
@@ -1690,7 +1708,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2efc-1d5d-384b-a8b0" name="Chainmaces" hidden="false" collective="false" type="upgrade">
@@ -1699,7 +1717,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e408-9f77-4bdb-f5cd" name="Morning Star" hidden="false" collective="false" type="upgrade">
@@ -1708,7 +1726,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1716,13 +1734,32 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="43b2-a0f2-3dbd-dee6" name="Gnoll Chariot [100 pts]" hidden="false" collective="false" type="unit">
       <categoryLinks>
         <categoryLink id="ad20-1194-af32-8961" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="50af-3ed3-0f9c-4e7c" name="Chariot" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="332e-9278-a3e3-c032" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c951-a8b7-9895-d9c6" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="dfc5-3197-2ec2-ccb0" name="Gnoll Chariot with crew, pulled by two hyenas" hidden="false" targetId="00bd-e5d9-8f1b-ae6c" type="profile"/>
+            <infoLink id="622e-13cf-4e13-d8ce" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+            <infoLink id="8beb-aedd-2161-4d41" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
+            <infoLink id="162a-1cb1-4e1e-79d0" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
+            <infoLink id="3d29-1e22-3f5d-64a7" name="Hyenas (Chariot)" hidden="false" targetId="742e-af86-0f8b-7eeb" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="90.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="ae5a-d70d-1e26-6c79" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="a8d0-463b-c291-3395">
           <constraints>
@@ -1736,7 +1773,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6d5-6214-25e2-7067" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1745,7 +1782,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a8d0-463b-c291-3395" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1754,7 +1791,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1777,12 +1814,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1127-1604-6894-47b4" name="Crossbows" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="3">
+                <modifier type="increment" field="points" value="3.0">
                   <repeats>
                     <repeat field="selections" scope="43b2-a0f2-3dbd-dee6" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -1790,10 +1827,11 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="6086-d037-ee59-a10e" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
+                <infoLink id="27bf-29c3-f410-4cb7" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1809,7 +1847,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1826,28 +1864,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="d9cb-7be2-5e30-5cf3" name="Chariot" hidden="false" collective="false" defaultSelectionEntryId="ce67-e47d-8c79-dc2b">
-          <selectionEntries>
-            <selectionEntry id="ce67-e47d-8c79-dc2b" name="Chariot" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="599b-f5d1-80ab-a917" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f89f-3011-4df2-7c9e" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="86b7-2dac-0f1f-9fbc" name="Gnoll Chariot with crew, pulled by two hyenas" hidden="false" targetId="00bd-e5d9-8f1b-ae6c" type="profile"/>
-                <infoLink id="dd88-f20b-71f5-2ebb" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                <infoLink id="8313-5e66-7d93-40ab" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
-                <infoLink id="e59d-67ce-7302-f6b9" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
-                <infoLink id="6bfc-0076-9d39-d731" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="90.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1870,7 +1887,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1878,10 +1895,16 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ef5a-8658-be88-159f" name="Gnoll Stone Thrower [96 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="7cb0-1205-777b-6dce" name="Overhead" hidden="false" targetId="7751-622a-b896-4874" type="rule"/>
+        <infoLink id="1e9b-1cf6-1076-96d0" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="674d-d5ce-09cd-e993" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="a661-a352-037d-e727" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="e068-e6ce-1eaa-f2d2" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -1902,13 +1925,11 @@
                         <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fae0-002b-9e39-48a4" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="8c28-5488-7a73-df85" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                        <infoLink id="317b-9c70-c2f0-2f72" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
                         <infoLink id="9201-1c83-7454-fa46" name="Gnoll Crew with Stone Throwing Engine" hidden="false" targetId="abdf-b90c-fbf2-4937" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1916,7 +1937,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="108a-641c-0f3d-922c" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1929,13 +1950,11 @@
                         <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30bb-e4be-a4a2-f59d" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="8bc1-3a45-0e62-08b0" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                        <infoLink id="66b3-c661-ab87-920e" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
                         <infoLink id="ce6f-8704-7963-50b2" name="Gnoll Crew in Light Armour with Stone Throwing Engine" hidden="false" targetId="ec9a-9dfc-762d-815b" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1943,7 +1962,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1960,7 +1979,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78bf-7696-bbdd-7078" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -1969,7 +1988,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1993,7 +2012,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e3ed-b852-70b3-0d00" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2009,7 +2028,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15b9-e903-91b5-26d8" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -2018,7 +2037,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2026,7 +2045,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -2105,7 +2124,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="873b-5700-5316-fa97" name="Gnoll Warrior Pack Master in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2116,7 +2135,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="4080-8c63-fb84-470d" name="Gnoll Warrior" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2149,7 +2168,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="6990-4892-a408-4ac8" name="Gnoll Guard" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2171,7 +2190,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="af02-6c91-8f59-fd7e" name="Gnoll Guard in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2193,7 +2212,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="646e-86a2-8eeb-b1cf" name="Gnoll Archer" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2215,7 +2234,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Rapid Sprint, Stealthy</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Rapid Sprint, Stealthy</characteristic>
       </characteristics>
     </profile>
     <profile id="8349-3729-0b8c-0a4d" name="Gnoll Scout" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2237,7 +2256,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Rapid Sprint, Woodsmen</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Rapid Sprint, Woodsmen</characteristic>
       </characteristics>
     </profile>
     <profile id="2d48-c654-5b01-9db6" name="Gnoll Tracker in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2248,7 +2267,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Rapid Sprint, Woodsmen</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Rapid Sprint, Woodsmen</characteristic>
       </characteristics>
     </profile>
     <profile id="f5b8-87b9-2bad-532a" name="Hyenas" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">

--- a/Gnolls.cat
+++ b/Gnolls.cat
@@ -51,22 +51,13 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ac43-e4f0-4d76-38b0" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="b87a-0f66-9882-c686">
+        <selectionEntryGroup id="ac43-e4f0-4d76-38b0" name="Weapons" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c93e-a96b-a22e-ee5f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a5c-8338-bc00-8dd9" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="b87a-0f66-9882-c686" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7b43-6632-47cb-1380" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="909a-c84a-8c9b-ff93" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="909a-c84a-8c9b-ff93" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="71da-c4bc-c5c8-356a" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
@@ -183,83 +174,19 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ef73-3fb4-f274-12da" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1508-c12c-6ca7-4cb4" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="0eb2-bbe9-eb05-820d" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="2de3-c841-29d9-d9dd" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="abc5-4ad8-6735-2988" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="3fe1-3a25-bcc2-55f4" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e42a-95d8-d875-5683" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="835f-d005-5f9e-55b1" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="520f-e9ce-25c5-f7ca" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b7bf-35a5-f4a1-a664" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="55d7-0c31-e693-ed74" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="087e-3518-a76e-1d15" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="db72-f5da-527b-f765" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="45bc-3dd2-fe76-bd51" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="83cb-0aa0-639a-4ca5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4b9a-22ab-d20d-a733" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e2c4-44c5-f17e-8b3b" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="98e7-400a-37ff-3d3e" name="Gnoll Shaman [66 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="78db-c240-7024-594a" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="2646-bfeb-96bd-705a" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
         <categoryLink id="9b57-d316-be08-f09d" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -397,32 +324,6 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="66.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="10a5-f725-8c94-e70a" name="Shaman Weapon" hidden="false" collective="false" defaultSelectionEntryId="2e17-f224-a059-6b21">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c7f-dbe2-da02-fcef" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b275-73d8-c571-261e" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="2e17-f224-a059-6b21" name="Sword" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bd96-48b4-0692-dd38" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="902f-c5bd-d344-31ed" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="234a-13a2-bbb8-66e2" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -734,77 +635,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="12ee-97d5-fb4e-6ab7" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b034-1193-d53d-d589" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="c3a4-bf18-337e-9972" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5410-9712-1a87-3631" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a9af-7629-68df-f517" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="3d4c-f6c8-4528-1005" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9bdd-efa3-f4c4-8d97" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="39eb-4183-e592-faea" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="379f-93c1-ff65-4f4c" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="21fb-58be-d629-e7ec" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6fdf-abac-4dc1-f696" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="368c-7e7a-4b84-d874" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c138-04e4-7077-451b" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0696-27d8-b1a3-eced" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="95d8-1dbb-4339-0ca6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="775c-87e1-5dfb-6488" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="75fd-4513-3a77-995c" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -834,22 +668,13 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f4ba-a2a7-95f1-f72c" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="e18d-45bc-8bea-96df">
+        <selectionEntryGroup id="f4ba-a2a7-95f1-f72c" name="Weapons" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b61f-e408-8767-5eaf" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89b6-8458-c1d0-35de" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="e18d-45bc-8bea-96df" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4116-ec89-e0fe-02ec" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="946b-5665-067b-cc59" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="946b-5665-067b-cc59" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="d5ea-03f2-4450-c4f7" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
@@ -966,77 +791,10 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="fa7d-ab72-6123-d695" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bed-cca7-3f05-00b5" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="3313-3a3d-d117-bb5c" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b1af-c76e-2a79-980e" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b04f-63c1-c77e-99b5" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="03ee-797a-7061-1019" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0e2d-084f-9f76-333c" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9ac2-07b7-db30-21b5" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="dda6-e8a6-263e-1a64" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d4bf-f5d3-8b82-1523" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2d69-0f2e-9b87-0cbd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="eeb8-803d-8b40-bf8d" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="74d0-dcb4-4aa9-9946" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ec59-3a44-03a8-2874" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2763-559e-c84d-92af" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="cb13-31be-f9f2-1c82" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4e06-cf0c-41cb-3182" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name=" order dice" typeId="orderDice" value="1.0"/>
@@ -1045,6 +803,7 @@
     <selectionEntry id="6738-54c4-3339-67af" name="Gnoll Warriors [77 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="8c87-2f5f-d3b2-5d1a" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="f3b3-1f02-a822-030e" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5f47-23cf-7b87-db59" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -1127,32 +886,6 @@
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="cfe4-3c91-6e77-356b" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="339c-1cd1-83e9-9a27">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0084-a74d-7da5-a74d" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b82-de94-9451-745c" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="339c-1cd1-83e9-9a27" name="Swords" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9639-ce06-cd57-ef99" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e402-bd7c-d214-dac4" name="Axes" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="dbb8-4a3a-ca67-caa5" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
@@ -1267,16 +1000,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ee6-ec94-f81c-cb69" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f1bb-1942-efc1-9066" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="2833-3ac8-c09d-817e" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4747-ae97-54f5-3a5c" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4747-ae97-54f5-3a5c" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="4dc4-a929-2385-931c" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
@@ -1362,38 +1086,22 @@
         <categoryLink id="41af-00a0-f106-8f1a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4942-6121-7c25-609f" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="bce1-3949-1e74-e111">
+        <selectionEntryGroup id="4942-6121-7c25-609f" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="bce1-3949-1e74-e111">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4823-7345-91fc-702c" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7de-d32d-b44a-bc54" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="794e-b15e-cbac-9cd6" name="Axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="794e-b15e-cbac-9cd6" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="eb98-a54f-3cfe-1329" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="109d-275f-3a1d-cdaf" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="91d7-e459-79b2-eda6" name="Sword" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="1">
-                  <repeats>
-                    <repeat field="selections" scope="eb98-a54f-3cfe-1329" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="8810-46f1-ed78-23db" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="109d-275f-3a1d-cdaf" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1489,37 +1197,12 @@
       <infoLinks>
         <infoLink id="8527-bca2-aa85-90e1" name="Stealthy" hidden="false" targetId="dcb2-de55-1fca-e0a8" type="rule"/>
         <infoLink id="0b52-2bd1-a1ef-d905" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
+        <infoLink id="02f5-6312-f3bc-ee8c" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="32fa-7089-bcf5-5720" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b5bb-5b92-b9fd-6899" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="aa91-c694-f200-caf7">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d237-d367-c2ee-3641" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0784-96ff-9847-d975" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="727b-a143-5c34-b10a" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ca52-2b60-4c71-ba0e" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="aa91-c694-f200-caf7" name="Sword" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bf5b-403e-2700-3b25" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
         <selectionEntryGroup id="81f9-0f34-fbe4-1c4d" name="Ranged Weapon" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1b0-d01c-d9de-75f6" type="max"/>
@@ -1660,22 +1343,13 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5047-e03e-9b84-a95e" name="Tracker Weapon" hidden="false" collective="false" defaultSelectionEntryId="552e-f0e6-5dfd-0763">
+        <selectionEntryGroup id="5047-e03e-9b84-a95e" name="Tracker Weapon" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ef6-9d45-02b8-29d3" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0de2-6ae0-856a-6d67" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="552e-f0e6-5dfd-0763" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ddfb-b9fc-bf25-115a" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="586b-8d39-193a-e3ea" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="586b-8d39-193a-e3ea" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="c280-d0df-049d-938b" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
@@ -1761,13 +1435,13 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ae5a-d70d-1e26-6c79" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="a8d0-463b-c291-3395">
+        <selectionEntryGroup id="ae5a-d70d-1e26-6c79" name="HtH Weapons" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c956-9377-62ed-f5e7" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4671-304b-6961-efbc" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="68b1-bb90-af3b-de09" name="Swords" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="68b1-bb90-af3b-de09" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="5fa7-8ec4-2e5e-e6e2" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
@@ -1779,15 +1453,6 @@
             <selectionEntry id="f6d5-6214-25e2-7067" name="Spears" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="c3ed-aa70-8ffb-5bf3" name="Spear" hidden="false" targetId="c79a-48d1-9b48-2c68" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a8d0-463b-c291-3395" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="cb53-104c-9caf-5ad4" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1993,29 +1658,13 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="07dd-0160-ec8d-bbd1" name="Crew HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="15b9-e903-91b5-26d8">
+        <selectionEntryGroup id="07dd-0160-ec8d-bbd1" name="Crew HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="15b9-e903-91b5-26d8">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7619-c841-a408-e3c9" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5e3-f11e-db90-d066" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6786-b220-b645-4987" name="Axe" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="1">
-                  <repeats>
-                    <repeat field="selections" scope="ef5a-8658-be88-159f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="4374-2f7c-c901-0a49" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e3ed-b852-70b3-0d00" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e3ed-b852-70b3-0d00" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
@@ -2058,7 +1707,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 3xHTH, Wound X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="f86a-75e0-29d1-15cd" name="Gnoll Guard" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2091,7 +1740,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">5</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Savage, 1xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Savage, 1xHtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="4887-6844-9b46-966c" name="Animal Spirit Guide or Familiar" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2102,7 +1751,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">3</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Spirit, 1xHTH SV1, Exchange of Missiles SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Spirit, 1xHtH SV1, Exchange of Missiles SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="fbf6-44a5-1372-9ef4" name="Gnoll Champion" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2113,7 +1762,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHTH, Wound X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="de12-c096-bf3f-0512" name="Gnoll Warrior Pack Master" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2278,7 +1927,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">5</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHTH SV1, Savage, Rapid Sprint, Woodsmen</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHtH SV1, Savage, Rapid Sprint, Woodsmen</characteristic>
       </characteristics>
     </profile>
     <profile id="00bd-e5d9-8f1b-ae6c" name="Gnoll Chariot with crew, pulled by two hyenas" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2311,7 +1960,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="abdf-b90c-fbf2-4937" name="Gnoll Crew with Stone Throwing Engine" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">

--- a/Goblins.cat
+++ b/Goblins.cat
@@ -84,18 +84,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="041b-5f59-5c51-6a0e" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3a1d-5ff2-0340-cd6f" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3a1d-5ff2-0340-cd6f" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="efb5-f0a2-4986-cf3f" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="dd12-7d02-fb2b-7c52" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="f390-cd03-efa4-7839" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -268,24 +259,15 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="319f-55c8-c778-997d" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="f8ad-2a61-dc09-3fab">
+        <selectionEntryGroup id="319f-55c8-c778-997d" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="f8ad-2a61-dc09-3fab">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b974-1858-8263-5df2" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efc7-b764-904d-83cc" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f8ad-2a61-dc09-3fab" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f8ad-2a61-dc09-3fab" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="13f1-7410-b479-b983" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c571-82a5-3ee9-af1d" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7824-b2d3-726c-f460" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -528,6 +510,9 @@
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a01d-10ea-25e9-6527" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="a188-7a75-92b8-0202" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="e954-1e32-2e99-7d17" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
         <categoryLink id="6651-2528-d49c-91a4" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1004,18 +989,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a9f-4ea6-df07-4dec" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="062e-0241-6225-8f4f" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="062e-0241-6225-8f4f" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="1033-44f2-48a4-57cd" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="286a-ea49-46c1-7f63" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b86a-7aaf-332f-8a68" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="1033-44f2-48a4-57cd" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1058,7 +1034,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9036-5662-7d32-5837" name="Models" hidden="false" collective="false" defaultSelectionEntryId="6fc2-b21d-66c8-1024">
+        <selectionEntryGroup id="9036-5662-7d32-5837" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="6fc2-b21d-66c8-1024">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0461-1d20-daba-826b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7521-f3ee-b232-3705" type="min"/>
@@ -1192,18 +1168,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb6e-3f26-61d6-829c" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f986-e545-4759-53df" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f986-e545-4759-53df" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="618c-9d47-c8e1-5779" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c194-43f5-df69-277a" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1bfd-051a-74a3-9166" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1335,7 +1302,7 @@
         <categoryLink id="5258-48cf-2412-63d5" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a3a2-fa8b-adf4-edc5" name="Models" hidden="false" collective="false" defaultSelectionEntryId="f33b-a347-403d-b1c9">
+        <selectionEntryGroup id="a3a2-fa8b-adf4-edc5" name="Choose 3 to 5" hidden="false" collective="false" defaultSelectionEntryId="f33b-a347-403d-b1c9">
           <selectionEntries>
             <selectionEntry id="f33b-a347-403d-b1c9" name="Whirling Dervishes" hidden="false" collective="false" type="model">
               <constraints>
@@ -1369,12 +1336,12 @@
         <categoryLink id="01d5-4467-aab1-1f84" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b472-dcfa-5096-b0f4" name="Dire Wolves" hidden="false" collective="false">
+        <selectionEntryGroup id="b472-dcfa-5096-b0f4" name="Dire Wolves Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c111-faf3-3a51-6679" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="11af-2414-4a94-dc4b" name="Mount unit on Dire Wolves increasing Wolf to 2XHTH SV1" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="11af-2414-4a94-dc4b" name="Mount unit on Dire Wolves increasing Wolf to 2XHtH SV1" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="6.0">
                   <repeats>
@@ -1389,7 +1356,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e862-2ec2-6b7b-1ad9" name="Models" hidden="false" collective="false" defaultSelectionEntryId="4305-93da-2a9f-46be">
+        <selectionEntryGroup id="e862-2ec2-6b7b-1ad9" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="4305-93da-2a9f-46be">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f945-2673-5d1d-d410" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae46-bb56-772f-76cf" type="max"/>
@@ -1496,24 +1463,15 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3c1c-c668-83c5-6453" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="f217-8b22-ba6f-cdb9">
+        <selectionEntryGroup id="3c1c-c668-83c5-6453" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="f217-8b22-ba6f-cdb9">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c36-c8a1-77c2-ad91" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31d1-7eb4-2f8d-ca5e" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f217-8b22-ba6f-cdb9" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f217-8b22-ba6f-cdb9" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="1ad0-5ad8-1c6c-28d8" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="aa72-260f-56ae-dfb4" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7f0e-a1a9-47e2-a4bd" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1628,24 +1586,15 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0d45-1860-1cb8-4067" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="105b-a354-3bc0-c023">
+        <selectionEntryGroup id="0d45-1860-1cb8-4067" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="105b-a354-3bc0-c023">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3039-0449-f3a0-9660" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d0f-ff4d-7484-3d1c" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="105b-a354-3bc0-c023" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="105b-a354-3bc0-c023" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="72a9-f829-9a8f-ecf3" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8f70-262a-31ab-09e0" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a9c4-27ba-b15a-2dfb" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1691,7 +1640,7 @@
         <categoryLink id="973d-e14a-ab21-28ee" name="New CategoryLink" hidden="false" targetId="c820-d327-811d-1144" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b8c3-ad64-cb56-8a21" name="Models" hidden="false" collective="false" defaultSelectionEntryId="80a9-74a6-c1f8-c5ac">
+        <selectionEntryGroup id="b8c3-ad64-cb56-8a21" name="Choose 3 to 5" hidden="false" collective="false" defaultSelectionEntryId="80a9-74a6-c1f8-c5ac">
           <selectionEntries>
             <selectionEntry id="80a9-74a6-c1f8-c5ac" name="Goblin Sprog Swarm" hidden="false" collective="false" type="model">
               <constraints>
@@ -1714,9 +1663,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19e0-54ee-1d2d-a25d" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="68f4-6d11-6bea-a385" name="Rocks to throw" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="68f4-6d11-6bea-a385" name="Rocks to Throw" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="6116-5bf2-30da-f941" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -1748,7 +1697,7 @@
         <categoryLink id="5f9d-7ac3-1168-4f0a" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="c95e-e4a4-7112-3477" name="gobble dogs" hidden="false" collective="false" defaultSelectionEntryId="752d-fe00-387f-95a3">
+        <selectionEntryGroup id="c95e-e4a4-7112-3477" name="Choose 4 to 9" hidden="false" collective="false" defaultSelectionEntryId="752d-fe00-387f-95a3">
           <selectionEntries>
             <selectionEntry id="752d-fe00-387f-95a3" name="Gobble Dogs" hidden="false" collective="false" type="model">
               <constraints>
@@ -1765,7 +1714,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="37d3-0db5-f36f-c872" name="pack master" hidden="false" collective="false" defaultSelectionEntryId="46b6-fc8d-a4e3-a7f2">
+        <selectionEntryGroup id="37d3-0db5-f36f-c872" name="Pack Master" hidden="false" collective="false" defaultSelectionEntryId="46b6-fc8d-a4e3-a7f2">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0222-a874-851f-4e1c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2eef-ff8a-288a-5342" type="max"/>
@@ -1797,24 +1746,15 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="de5a-ae9d-037e-4878" name="pack master weapon" hidden="false" collective="false" defaultSelectionEntryId="a56d-1202-b62f-b3de">
+        <selectionEntryGroup id="de5a-ae9d-037e-4878" name="Pack Master Weapon" hidden="false" collective="false" defaultSelectionEntryId="a56d-1202-b62f-b3de">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="847b-1b7f-0659-aa41" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee93-f6e2-49b4-767f" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="a56d-1202-b62f-b3de" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a56d-1202-b62f-b3de" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="ca4c-071a-a507-8bb2" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a7e7-98a3-b32a-fae0" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e5be-b9ec-3f4f-a2f6" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1908,13 +1848,13 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8503-fcf3-e0cc-2615" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="d69b-4a22-6a5c-e9a7">
+        <selectionEntryGroup id="8503-fcf3-e0cc-2615" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="d69b-4a22-6a5c-e9a7">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ca2-a85a-a754-96a1" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7a0-befc-0a65-8bfb" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="d69b-4a22-6a5c-e9a7" name="Goblin Crew" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d69b-4a22-6a5c-e9a7" name="Goblin Crew (no armour)" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
                 <selectionEntryGroup id="e388-f77f-1bb5-53b0" name="Goblin Crew" hidden="false" collective="false">
                   <selectionEntries>
@@ -1981,7 +1921,7 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="af7f-d914-8f2d-524a" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="af7f-d914-8f2d-524a" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
@@ -1991,22 +1931,6 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="f7b7-65b1-fb63-ae59" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="578b-b6a5-e352-748d" name="Axe" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="set" field="points" value="1">
-                  <repeats>
-                    <repeat field="selections" scope="d779-99c9-c589-31fc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="d738-44fd-469b-ee9c" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2031,13 +1955,13 @@
         <categoryLink id="7f88-9dff-4221-3caa" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e9d5-6421-0f43-96ed" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="12d0-d9f2-1dcc-02cb">
+        <selectionEntryGroup id="e9d5-6421-0f43-96ed" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="12d0-d9f2-1dcc-02cb">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95de-2049-257b-f056" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d145-d83a-951f-ba44" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="12d0-d9f2-1dcc-02cb" name="Goblin Crew" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="12d0-d9f2-1dcc-02cb" name="Goblin Crew (no armour)" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
                 <selectionEntryGroup id="cebf-5784-7368-c7fb" name="Goblin Crew" hidden="false" collective="false">
                   <selectionEntries>
@@ -2131,7 +2055,7 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="823a-5d06-2b30-16f8" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="823a-5d06-2b30-16f8" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
@@ -2141,22 +2065,6 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="a523-9d65-fa03-a012" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0007-03c6-6849-4199" name="Axe" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="1">
-                  <repeats>
-                    <repeat field="selections" scope="9096-65fd-09c1-25cc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="8d7e-15c5-812b-6f07" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2187,7 +2095,7 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">4(5)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 3xHTH, Wound X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="3e02-e70a-4b54-238e" name="Goblin Chieftain in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2198,7 +2106,7 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">4(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 3xHTH, Wound X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="9ee7-e759-f818-fdb9" name="Goblin Bodyguard in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2242,7 +2150,7 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[4(5)]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, 3x HTH, [Wound X]</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, 3x HtH, [Wound X]</characteristic>
       </characteristics>
     </profile>
     <profile id="63ec-8a3a-4484-d669" name="Goblin Chariot Crew" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2264,7 +2172,7 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="32aa-2002-3522-661e" name="Dire Wolves" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2275,7 +2183,7 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="02a4-bdbd-5235-fb2f" name="Goblin Chieftain in Medium Armour [on foot]" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2286,7 +2194,7 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[4(6)]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, 3xHTH, [Wound X]</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, 3xHtH, [Wound X]</characteristic>
       </characteristics>
     </profile>
     <profile id="5db7-3f7a-a45a-1524" name="Goblin Shaman" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2319,7 +2227,7 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">5</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Frenzied Charge, 2xHTH SV2</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Frenzied Charge, 2xHtH SV2</characteristic>
       </characteristics>
     </profile>
     <profile id="0a3b-cb7c-dd41-1a9a" name="Goblin Guard Leader in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2451,7 +2359,7 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 6, Rapid Sprint, Wolf 1xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 6, Rapid Sprint, Wolf 1xHtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="ab98-045b-8108-f4e1" name="Goblin Wolf Rider Leader in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2462,7 +2370,7 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 6, Rapid Sprint, Wolf 1xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 6, Rapid Sprint, Wolf 1xHtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="a452-136e-58bc-9ebb" name="Goblin Wolf Rider" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2473,7 +2381,7 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">6</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Rapid Sprint, Wolf 1xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Rapid Sprint, Wolf 1xHtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="420c-045f-442e-9907" name="Goblin Wolf Rider in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2484,7 +2392,7 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">6</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Rapid Sprint, Wolf 1xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Rapid Sprint, Wolf 1xHtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="0906-f514-4c81-85c3" name="Goblin Chariot: crew, pulled by 2 wolves" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2517,10 +2425,10 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Surly, 3xHTH SV0</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Surly, 3xHtH SV0</characteristic>
       </characteristics>
     </profile>
-    <profile id="bdef-5dfc-393a-c889" name="Rock (thrown)" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="bdef-5dfc-393a-c889" name="Rock (thrown)" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -2559,7 +2467,7 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">5</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Frenzied Charge, 2xHTH SV2</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Frenzied Charge, 2xHtH SV2</characteristic>
       </characteristics>
     </profile>
     <profile id="d912-2e11-e1e0-6a84" name="Troll" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2570,7 +2478,7 @@ Must be given run order. On order roll of 10, move randomly.  All shooting hits 
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">4</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 3xHTH SV2, Chunder, Regenerate</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 3xHtH SV2, Chunder, Regenerate</characteristic>
       </characteristics>
     </profile>
     <profile id="f6be-a32d-119c-c81a" name="Goblin Crew with Stone-throwing engine" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">

--- a/Goblins.cat
+++ b/Goblins.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a5f0-ec9e-8401-d5df" name="Goblins" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a5f0-ec9e-8401-d5df" name="Goblins" revision="3" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="7c72-b3c6-5f8f-2aee" name="Goblin Chieftain [59 pts]" hidden="false" collective="false" targetId="9b2e-c57f-ec1e-d70d" type="selectionEntry"/>
     <entryLink id="2ce4-b851-6bc0-7617" name="Goblin Chieftain in Wolf Chariot [151 pts]" hidden="false" collective="false" targetId="6dce-754d-7cff-650c" type="selectionEntry"/>
@@ -18,9 +18,6 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="9b2e-c57f-ec1e-d70d" name="Goblin Chieftain [59 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="684c-00f7-2c9e-845f" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
       </infoLinks>
@@ -41,7 +38,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89d1-0ce8-8631-6724" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -50,7 +47,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -67,7 +64,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6eef-8ef2-f81e-4fe2" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -76,7 +73,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -93,7 +90,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd12-7d02-fb2b-7c52" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -102,7 +99,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27e5-5cc3-1cc9-31ef" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -111,7 +108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="009d-9f31-6687-b5da" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -120,7 +117,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="80d6-5260-94ae-9e57" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -129,7 +126,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73bb-d5b8-ef1f-a893" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -138,7 +135,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99a4-20c0-aa8f-68dd" name="Massive Maces" hidden="false" collective="false" type="upgrade">
@@ -147,7 +144,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -172,7 +169,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="41.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="77a5-7c5e-7263-acba" name="Goblin Bodyguard in Light Armour" hidden="false" collective="false" type="model">
@@ -185,7 +182,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -193,7 +190,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="372d-60dc-ff13-7f91" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -210,7 +207,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="51.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="396e-a1a7-1262-db43" name="Goblin Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -220,7 +217,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -228,7 +225,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -244,7 +241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c553-2ca2-2337-3ca8" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -253,7 +250,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b642-2130-c3cc-905e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -262,7 +259,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c5c-9816-1d75-ea85" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -271,7 +268,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="77ff-d53d-723c-f2dc" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -280,7 +277,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="606d-bc15-404e-83a7" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -289,7 +286,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9a13-efd0-27c5-2587" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -298,7 +295,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -306,13 +303,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6dce-754d-7cff-650c" name="Goblin Chieftain in Wolf Chariot [151 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="f1c6-f1e1-48f2-f552" name="Goblin Chariot with Chieftain, pulled by 2 wolves" hidden="false" targetId="0d81-8af5-08c1-ceb5" type="profile"/>
         <infoLink id="b31b-f3de-8e84-b4e3" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -336,7 +330,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -353,7 +347,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c571-82a5-3ee9-af1d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -362,7 +356,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd32-ccce-cccb-3604" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -371,7 +365,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf8b-6fe6-187e-9810" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -380,7 +374,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2590-1570-d5df-4eee" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -389,7 +383,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cc69-6e4e-9ca1-f750" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -398,7 +392,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1aae-fce8-afbc-ea9f" name="Massive Maces" hidden="false" collective="false" type="upgrade">
@@ -407,7 +401,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -430,7 +424,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -447,7 +441,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4738-e2f2-5397-28bf" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -456,7 +450,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -473,7 +467,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a136-b4f1-1307-5df6" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -482,7 +476,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -499,7 +493,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -524,7 +518,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="146.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -532,7 +526,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8697-6dc8-aec9-1d96" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -549,7 +543,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="156.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -557,7 +551,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -574,7 +568,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a0f-ba25-9f29-f0be" name="Dire Wolves" hidden="false" collective="false" type="upgrade">
@@ -583,7 +577,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -599,7 +593,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e3af-972c-2171-16b8" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -608,7 +602,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="beed-9166-0423-47c6" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -617,7 +611,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98a8-c5c7-8738-bd04" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -626,7 +620,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5a3f-c39b-2359-5891" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -635,7 +629,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="801e-7660-3546-a998" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -644,7 +638,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a98c-e1ae-a737-32ec" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -653,7 +647,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -661,13 +655,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9b6c-6957-d526-e7ea" name="Goblin Shaman [52 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a01d-10ea-25e9-6527" type="max"/>
       </constraints>
@@ -688,7 +679,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3df4-abda-254d-2942" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -697,7 +688,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3ce-9aea-4213-57ac" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -706,7 +697,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -723,7 +714,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c74-7420-d7e4-f4a2" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -732,7 +723,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -750,7 +741,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="52.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -774,7 +765,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="7.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -782,7 +773,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0e10-a7e6-7a05-cb74" name="Gobble Dogs" hidden="false" collective="false" type="upgrade">
@@ -799,7 +790,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="16.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -807,7 +798,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -826,7 +817,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="38cb-1368-ca79-cfdd" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -835,7 +826,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3624-d046-4359-4043" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -844,7 +835,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="01a2-3df1-fa23-0413" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -853,7 +844,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df7a-cf5c-7231-ce22" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -862,7 +853,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89e2-0470-6909-08d0" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -871,7 +862,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c07-4aab-ba23-7968" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -880,7 +871,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="11a7-47fe-1457-59a8" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -889,7 +880,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29a0-3721-3779-68c6" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -898,7 +889,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4dcb-dbe7-fedf-8690" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -907,7 +898,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1edb-1d69-93d6-647f" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -916,7 +907,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a745-8305-c14b-b9d6" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -925,7 +916,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2446-a881-881c-312d" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -934,7 +925,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="488c-3cd7-c1ed-f6f5" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -943,7 +934,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -959,7 +950,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e5e6-d09b-0d41-568d" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -971,7 +962,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="473f-be7a-4f8f-1d55" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -983,7 +974,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff38-a0be-5362-7824" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -995,7 +986,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="16d9-d23e-a8fc-7d05" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1007,7 +998,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d56-ffa2-5697-4977" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1019,7 +1010,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6943-4d3c-7930-8237" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1031,7 +1022,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="05ac-455d-4ffe-b766" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1043,7 +1034,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce9d-0ab7-473a-237b" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1055,7 +1046,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="efdb-bbbc-a461-6785" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1067,7 +1058,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7895-145a-9f45-63f4" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1079,7 +1070,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e0a-b41e-e84c-e4e8" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1091,7 +1082,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c76b-447a-d992-73e1" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1103,7 +1094,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4552-4f8a-1e41-813f" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1115,7 +1106,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1131,7 +1122,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebaf-d6b4-1cd7-95de" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1140,7 +1131,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0592-ad61-3898-306a" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1149,7 +1140,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="47e7-024e-09b0-a96c" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1158,7 +1149,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ea52-795c-4c00-73ca" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1167,7 +1158,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b32-0a76-349b-7a45" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1176,7 +1167,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4575-0bb4-df35-676b" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1185,7 +1176,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1193,18 +1184,15 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="edf4-0805-90d6-cb5d" name="Goblin Guard [49 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c981-9d20-788f-5870" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="2c2d-3148-2a27-b906" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="2c2d-3148-2a27-b906" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="9a14-cfc5-1a12-41ee" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -1222,7 +1210,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="286a-ea49-46c1-7f63" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1231,7 +1219,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bca3-60fb-ac29-f47e" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -1240,7 +1228,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83f9-6596-57c9-086e" name="Maces" hidden="false" collective="false" type="upgrade">
@@ -1249,7 +1237,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebcb-6b88-a645-dd7d" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1265,7 +1253,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1290,7 +1278,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="89ea-e8d9-ce94-e742" name="Goblin Guard in Light Armour" hidden="false" collective="false" type="model">
@@ -1303,7 +1291,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1311,7 +1299,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e3e4-db71-b73d-7e2b" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1328,7 +1316,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b966-b009-58c1-6eaa" name="Goblin Guard in Medium Armour" hidden="false" collective="false" type="model">
@@ -1341,7 +1329,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1349,7 +1337,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1357,15 +1345,12 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="58a6-33e4-8a2f-c503" name="Goblin Warriors [47 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
-        <infoLink id="cc8b-e368-dfd6-818e" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="cc8b-e368-dfd6-818e" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bc02-580c-3499-feb2" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -1383,7 +1368,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="19.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9da7-eb54-800b-5442" name="Goblin Warriors" hidden="false" collective="false" type="model">
@@ -1396,7 +1381,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="7.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1413,7 +1398,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c194-43f5-df69-277a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1422,7 +1407,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a5bd-fe5b-3b19-2481" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1431,7 +1416,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1439,15 +1424,12 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c835-bc33-0ef5-7675" name="Goblin Archers [47 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
-        <infoLink id="49e4-0c80-f821-ec0e" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="49e4-0c80-f821-ec0e" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="46d4-aa05-c21a-208d" name="Bow" hidden="false" targetId="95e1-d9f2-8182-5835" type="profile"/>
         <infoLink id="0565-cee0-f9c0-fda5" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
@@ -1475,7 +1457,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2b83-ca48-70fb-7d88" name="Goblin Archers with Bow and Sword or Axe" hidden="false" collective="false" type="model">
@@ -1488,7 +1470,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1496,7 +1478,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0d74-f50e-b097-464a" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1513,7 +1495,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8475-3024-5ba0-6198" name="Goblin Archers in Light Armour with Bow and Sword or Axe" hidden="false" collective="false" type="model">
@@ -1526,7 +1508,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1534,7 +1516,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1542,13 +1524,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="af02-f99a-22b1-78fc" name="Whirling Dervishes [90 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="5258-48cf-2412-63d5" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1566,7 +1545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1574,13 +1553,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d07b-876f-bc12-954b" name="Goblin Wolf Riders [69 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="01d5-4467-aab1-1f84" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
@@ -1600,7 +1576,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1625,7 +1601,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3d06-ffd9-7243-e241" name="Goblin Wolf Riders" hidden="false" collective="false" type="model">
@@ -1638,7 +1614,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1646,7 +1622,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf8b-3e1d-9e60-36a6" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1663,7 +1639,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="33.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0baf-20b4-d706-5d51" name="Goblin Wolf Riders in Light Armour" hidden="false" collective="false" type="model">
@@ -1676,7 +1652,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1684,7 +1660,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1707,7 +1683,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1724,7 +1700,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa72-260f-56ae-dfb4" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1733,7 +1709,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="977b-2093-e683-2cee" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1742,7 +1718,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1750,13 +1726,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="607c-0a91-69c5-0af3" name="Goblin Wolf Chariot [99 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="9f5c-9175-15e7-f2ef" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="57e8-c5d6-eec0-844c" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
@@ -1778,7 +1751,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1795,7 +1768,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="defe-df41-ead1-171e" name="Dire Wolves" hidden="false" collective="false" type="upgrade">
@@ -1804,7 +1777,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1827,7 +1800,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1844,7 +1817,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8f70-262a-31ab-09e0" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1853,7 +1826,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e08c-a28d-b25e-63ff" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1862,7 +1835,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1879,7 +1852,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1896,7 +1869,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="89.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1904,13 +1877,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6116-5bf2-30da-f941" name="Goblin Sprog Swarm [81 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="973d-e14a-ab21-28ee" name="New CategoryLink" hidden="false" targetId="c820-d327-811d-1144" primary="true"/>
       </categoryLinks>
@@ -1928,7 +1898,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1951,7 +1921,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1959,15 +1929,12 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cb00-866a-fe1c-a04c" name="Gobble Dog Pack [83 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
-        <infoLink id="0aa4-14ad-ef36-eed2" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="0aa4-14ad-ef36-eed2" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="bfe1-3535-f4b2-4beb" name="Frenzied Charge" hidden="false" targetId="1c49-276e-425d-0999" type="rule"/>
       </infoLinks>
       <categoryLinks>
@@ -1987,7 +1954,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2007,7 +1974,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="19.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f52d-6826-667d-6e22" name="Pack Master in Medium Armour" hidden="false" collective="false" type="model">
@@ -2019,7 +1986,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2036,7 +2003,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a7e7-98a3-b32a-fae0" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2045,7 +2012,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3205-56ff-059e-6088" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -2054,7 +2021,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2062,13 +2029,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e95e-cc72-7367-c272" name="Trolls [105 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="c519-02a4-fd04-1f53" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="c042-94cb-bb35-1f8e" name="Regenerate" hidden="false" targetId="0a0c-ed4c-9647-4398" type="rule"/>
@@ -2090,7 +2054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2098,13 +2062,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d779-99c9-c589-31fc" name="Goblin Stone Thrower [63 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="a4dc-af09-4456-606c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="3eca-9fbb-655e-f5d6" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2125,7 +2086,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b064-2191-2cb2-5d33" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -2134,7 +2095,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2159,7 +2120,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="3.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2167,7 +2128,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87b7-d89c-b55e-5c9b" name="Goblin Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2184,7 +2145,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2192,7 +2153,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2209,7 +2170,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af7f-d914-8f2d-524a" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2225,7 +2186,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="578b-b6a5-e352-748d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2241,7 +2202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2249,13 +2210,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9096-65fd-09c1-25cc" name="Goblin Bolt Thrower [51 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="2587-b159-79a8-b8fb" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="a66f-4aea-0bb9-3d30" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2284,7 +2242,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="3.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2292,7 +2250,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10c8-9568-04ba-1d07" name="Goblin Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2309,7 +2267,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2317,7 +2275,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2334,7 +2292,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="31db-0295-7487-293d" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2344,7 +2302,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2361,7 +2319,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="823a-5d06-2b30-16f8" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2377,7 +2335,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0007-03c6-6849-4199" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2393,7 +2351,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2401,7 +2359,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Goblins.cat
+++ b/Goblins.cat
@@ -38,7 +38,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89d1-0ce8-8631-6724" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -47,7 +47,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -64,7 +64,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6eef-8ef2-f81e-4fe2" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -73,7 +73,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -90,7 +90,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd12-7d02-fb2b-7c52" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -99,7 +99,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27e5-5cc3-1cc9-31ef" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -108,7 +108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="009d-9f31-6687-b5da" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -117,7 +117,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="80d6-5260-94ae-9e57" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -126,7 +126,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73bb-d5b8-ef1f-a893" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -135,7 +135,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99a4-20c0-aa8f-68dd" name="Massive Maces" hidden="false" collective="false" type="upgrade">
@@ -144,7 +144,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -169,7 +169,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="41.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="77a5-7c5e-7263-acba" name="Goblin Bodyguard in Light Armour" hidden="false" collective="false" type="model">
@@ -182,7 +182,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -190,7 +190,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="372d-60dc-ff13-7f91" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -207,7 +207,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="51.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="396e-a1a7-1262-db43" name="Goblin Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -217,7 +217,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -225,85 +225,18 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="82b5-98cd-1f18-2d3b" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8de6-7704-020b-513d" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="6aee-11f9-51ff-4cdc" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="00b5-c47e-c034-53d0" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c553-2ca2-2337-3ca8" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0ef0-8656-93a9-99f1" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b642-2130-c3cc-905e" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="656b-e232-c042-fa09" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2c5c-9816-1d75-ea85" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="44db-3870-2a07-5234" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="77ff-d53d-723c-f2dc" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7da6-e050-b444-88ba" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="606d-bc15-404e-83a7" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5e22-7228-ab6d-c884" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9a13-efd0-27c5-2587" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="fbae-51bd-d1ae-b0e3" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="eb92-69de-e768-cc81" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6dce-754d-7cff-650c" name="Goblin Chieftain in Wolf Chariot [151 pts]" hidden="false" collective="false" type="unit">
@@ -311,7 +244,7 @@
         <infoLink id="f1c6-f1e1-48f2-f552" name="Goblin Chariot with Chieftain, pulled by 2 wolves" hidden="false" targetId="0d81-8af5-08c1-ceb5" type="profile"/>
         <infoLink id="b31b-f3de-8e84-b4e3" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="cc50-080c-0f4a-d777" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
-        <infoLink id="bff5-f502-493a-a27f" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="bff5-f502-493a-a27f" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
         <infoLink id="5956-6a94-9538-454a" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
       </infoLinks>
       <categoryLinks>
@@ -330,7 +263,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -347,7 +280,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c571-82a5-3ee9-af1d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -356,7 +289,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd32-ccce-cccb-3604" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -365,7 +298,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf8b-6fe6-187e-9810" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -374,7 +307,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2590-1570-d5df-4eee" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -383,7 +316,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cc69-6e4e-9ca1-f750" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -392,7 +325,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1aae-fce8-afbc-ea9f" name="Massive Maces" hidden="false" collective="false" type="upgrade">
@@ -401,7 +334,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -424,7 +357,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -441,7 +374,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4738-e2f2-5397-28bf" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -450,7 +383,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -467,7 +400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a136-b4f1-1307-5df6" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -476,7 +409,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -493,7 +426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -518,7 +451,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="146.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -526,7 +459,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8697-6dc8-aec9-1d96" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -543,7 +476,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="156.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -551,7 +484,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -568,7 +501,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a0f-ba25-9f29-f0be" name="Dire Wolves" hidden="false" collective="false" type="upgrade">
@@ -577,85 +510,18 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="8a1b-fbcb-5f69-3544" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07cd-c7b1-d492-21c1" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="5d5f-12e8-041c-e2d0" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="6006-e71b-cfa1-22b6" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e3af-972c-2171-16b8" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0107-9b5e-7141-3252" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="beed-9166-0423-47c6" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="6d72-9779-7ef5-261a" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="98a8-c5c7-8738-bd04" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="003b-3c66-4eeb-7ad3" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5a3f-c39b-2359-5891" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bc19-bd38-2e78-12b2" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="801e-7660-3546-a998" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="11ce-54e2-055c-12d6" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a98c-e1ae-a737-32ec" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="23c4-05db-1b97-cd29" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a336-1f25-7b15-8c3d" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9b6c-6957-d526-e7ea" name="Goblin Shaman [52 pts]" hidden="false" collective="false" type="unit">
@@ -679,7 +545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3df4-abda-254d-2942" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -688,7 +554,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3ce-9aea-4213-57ac" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -697,7 +563,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -714,7 +580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c74-7420-d7e4-f4a2" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -723,7 +589,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -741,7 +607,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="52.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -762,10 +628,11 @@
                           </constraints>
                           <infoLinks>
                             <infoLink id="d504-abc3-8ca8-53a8" name="Goblin Shamanic Cultist" hidden="false" targetId="ac8a-452e-7c65-a4bd" type="profile"/>
+                            <infoLink id="9807-e1d4-c9aa-4c68" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="7.0"/>
-                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                            <cost name=" order dice" typeId="orderDice" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -773,7 +640,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0e10-a7e6-7a05-cb74" name="Gobble Dogs" hidden="false" collective="false" type="upgrade">
@@ -790,7 +657,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="16.0"/>
-                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                            <cost name=" order dice" typeId="orderDice" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -798,7 +665,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -817,7 +684,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="38cb-1368-ca79-cfdd" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -826,7 +693,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3624-d046-4359-4043" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -835,7 +702,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="01a2-3df1-fa23-0413" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -844,7 +711,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df7a-cf5c-7231-ce22" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -853,7 +720,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89e2-0470-6909-08d0" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -862,7 +729,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c07-4aab-ba23-7968" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -871,7 +738,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="11a7-47fe-1457-59a8" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -880,7 +747,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29a0-3721-3779-68c6" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -889,7 +756,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4dcb-dbe7-fedf-8690" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -898,7 +765,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1edb-1d69-93d6-647f" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -907,7 +774,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a745-8305-c14b-b9d6" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -916,7 +783,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2446-a881-881c-312d" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -925,7 +792,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="488c-3cd7-c1ed-f6f5" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -934,7 +801,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -950,7 +817,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e5e6-d09b-0d41-568d" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -962,7 +829,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="473f-be7a-4f8f-1d55" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -974,7 +841,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff38-a0be-5362-7824" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -986,7 +853,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="16d9-d23e-a8fc-7d05" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -998,7 +865,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d56-ffa2-5697-4977" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1010,7 +877,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6943-4d3c-7930-8237" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1022,7 +889,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="05ac-455d-4ffe-b766" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1034,7 +901,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce9d-0ab7-473a-237b" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1046,7 +913,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="efdb-bbbc-a461-6785" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1058,7 +925,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7895-145a-9f45-63f4" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1070,7 +937,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e0a-b41e-e84c-e4e8" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1082,7 +949,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c76b-447a-d992-73e1" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1094,7 +961,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4552-4f8a-1e41-813f" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1106,85 +973,18 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="09e3-af65-943c-00e4" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf56-82a1-b966-ae3b" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="3b81-2dde-5a22-01b6" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c7ff-08be-d4a3-2a31" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ebaf-d6b4-1cd7-95de" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5da5-8b1f-805f-cd26" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0592-ad61-3898-306a" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1f2a-ce28-ae9d-3cd1" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="47e7-024e-09b0-a96c" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="2af3-acfa-8ce7-9a40" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ea52-795c-4c00-73ca" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e67d-5ff0-5ab9-7c56" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0b32-0a76-349b-7a45" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c133-2888-3e9d-3caf" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4575-0bb4-df35-676b" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a70b-a0cb-4dce-ba33" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="53a5-e5ee-8890-1b30" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="edf4-0805-90d6-cb5d" name="Goblin Guard [49 pts]" hidden="false" collective="false" type="unit">
@@ -1210,7 +1010,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="286a-ea49-46c1-7f63" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1219,7 +1019,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bca3-60fb-ac29-f47e" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -1228,7 +1028,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83f9-6596-57c9-086e" name="Maces" hidden="false" collective="false" type="upgrade">
@@ -1237,7 +1037,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebcb-6b88-a645-dd7d" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1253,7 +1053,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1278,7 +1078,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="89ea-e8d9-ce94-e742" name="Goblin Guard in Light Armour" hidden="false" collective="false" type="model">
@@ -1291,7 +1091,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1299,7 +1099,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e3e4-db71-b73d-7e2b" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1316,7 +1116,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b966-b009-58c1-6eaa" name="Goblin Guard in Medium Armour" hidden="false" collective="false" type="model">
@@ -1329,7 +1129,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1337,7 +1137,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1345,7 +1145,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="58a6-33e4-8a2f-c503" name="Goblin Warriors [47 pts]" hidden="false" collective="false" type="unit">
@@ -1368,7 +1168,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="19.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9da7-eb54-800b-5442" name="Goblin Warriors" hidden="false" collective="false" type="model">
@@ -1381,7 +1181,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="7.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1398,7 +1198,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c194-43f5-df69-277a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1407,7 +1207,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a5bd-fe5b-3b19-2481" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1416,7 +1216,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1424,7 +1224,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c835-bc33-0ef5-7675" name="Goblin Archers [47 pts]" hidden="false" collective="false" type="unit">
@@ -1457,7 +1257,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2b83-ca48-70fb-7d88" name="Goblin Archers with Bow and Sword or Axe" hidden="false" collective="false" type="model">
@@ -1470,7 +1270,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1478,7 +1278,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0d74-f50e-b097-464a" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1495,7 +1295,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8475-3024-5ba0-6198" name="Goblin Archers in Light Armour with Bow and Sword or Axe" hidden="false" collective="false" type="model">
@@ -1508,7 +1308,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1516,7 +1316,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1524,10 +1324,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="af02-f99a-22b1-78fc" name="Whirling Dervishes [90 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed66-ee33-9418-cead" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="5258-48cf-2412-63d5" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1545,7 +1348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1553,10 +1356,15 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d07b-876f-bc12-954b" name="Goblin Wolf Riders [69 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="61a4-5613-186f-b586" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="54cf-9e4f-be92-ec38" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
+        <infoLink id="4862-5119-ca43-fae3" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="01d5-4467-aab1-1f84" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
@@ -1568,7 +1376,7 @@
           <selectionEntries>
             <selectionEntry id="11af-2414-4a94-dc4b" name="Mount unit on Dire Wolves increasing Wolf to 2XHTH SV1" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="6">
+                <modifier type="increment" field="points" value="6.0">
                   <repeats>
                     <repeat field="selections" scope="d07b-876f-bc12-954b" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -1576,7 +1384,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1601,7 +1409,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3d06-ffd9-7243-e241" name="Goblin Wolf Riders" hidden="false" collective="false" type="model">
@@ -1614,7 +1422,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1622,7 +1430,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf8b-3e1d-9e60-36a6" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1639,7 +1447,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="33.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0baf-20b4-d706-5d51" name="Goblin Wolf Riders in Light Armour" hidden="false" collective="false" type="model">
@@ -1652,7 +1460,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1660,7 +1468,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1683,7 +1491,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1700,7 +1508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa72-260f-56ae-dfb4" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1709,7 +1517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="977b-2093-e683-2cee" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1718,7 +1526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1726,19 +1534,34 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="607c-0a91-69c5-0af3" name="Goblin Wolf Chariot [99 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="9f5c-9175-15e7-f2ef" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="57e8-c5d6-eec0-844c" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
-        <infoLink id="8b4e-eb2a-1610-d64c" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="8b4e-eb2a-1610-d64c" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
         <infoLink id="7464-2b60-0154-2082" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ceb1-a0bd-6ee2-5d5f" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="635b-9379-5a52-42cf" name="Chariot" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1882-2ea4-df67-6a3d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e60f-0472-1b96-eb70" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="043d-5c6d-cd24-e4d3" name="Goblin Chariot: crew, pulled by 2 wolves" hidden="false" targetId="0906-f514-4c81-85c3" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="89.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="7640-5200-aa9e-e977" name="Chariot Scythes" hidden="false" collective="false">
           <constraints>
@@ -1751,7 +1574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1768,7 +1591,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="defe-df41-ead1-171e" name="Dire Wolves" hidden="false" collective="false" type="upgrade">
@@ -1777,7 +1600,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1800,7 +1623,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1817,7 +1640,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8f70-262a-31ab-09e0" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1826,7 +1649,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e08c-a28d-b25e-63ff" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1835,7 +1658,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1852,24 +1675,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="e079-72b7-8d5c-f785" name="Chariot" hidden="false" collective="false" defaultSelectionEntryId="ebb3-da84-6556-1161">
-          <selectionEntries>
-            <selectionEntry id="ebb3-da84-6556-1161" name="Chariot" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8761-275f-e43c-8240" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cda-2905-2667-b2c7" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="903d-0226-60ee-473e" name="Goblin Chariot: crew, pulled by 2 wolves" hidden="false" targetId="0906-f514-4c81-85c3" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="89.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1877,7 +1683,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6116-5bf2-30da-f941" name="Goblin Sprog Swarm [81 pts]" hidden="false" collective="false" type="unit">
@@ -1885,7 +1691,7 @@
         <categoryLink id="973d-e14a-ab21-28ee" name="New CategoryLink" hidden="false" targetId="c820-d327-811d-1144" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b8c3-ad64-cb56-8a21" name="models" hidden="false" collective="false" defaultSelectionEntryId="80a9-74a6-c1f8-c5ac">
+        <selectionEntryGroup id="b8c3-ad64-cb56-8a21" name="Models" hidden="false" collective="false" defaultSelectionEntryId="80a9-74a6-c1f8-c5ac">
           <selectionEntries>
             <selectionEntry id="80a9-74a6-c1f8-c5ac" name="Goblin Sprog Swarm" hidden="false" collective="false" type="model">
               <constraints>
@@ -1898,7 +1704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1921,7 +1727,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1929,7 +1735,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cb00-866a-fe1c-a04c" name="Gobble Dog Pack [83 pts]" hidden="false" collective="false" type="unit">
@@ -1954,7 +1760,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1974,7 +1780,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="19.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f52d-6826-667d-6e22" name="Pack Master in Medium Armour" hidden="false" collective="false" type="model">
@@ -1986,7 +1792,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2003,7 +1809,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a7e7-98a3-b32a-fae0" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2012,7 +1818,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3205-56ff-059e-6088" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -2021,7 +1827,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2029,7 +1835,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e95e-cc72-7367-c272" name="Trolls [105 pts]" hidden="false" collective="false" type="unit">
@@ -2054,7 +1860,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2062,13 +1868,15 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d779-99c9-c589-31fc" name="Goblin Stone Thrower [63 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="a4dc-af09-4456-606c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="3eca-9fbb-655e-f5d6" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+        <infoLink id="3eca-9fbb-655e-f5d6" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="5b59-2a29-333c-8820" name="Overhead" hidden="false" targetId="7751-622a-b896-4874" type="rule"/>
+        <infoLink id="9479-50b0-4918-b910" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f329-a9cd-f3d3-1e84" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
@@ -2086,7 +1894,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b064-2191-2cb2-5d33" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -2095,7 +1903,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2120,7 +1928,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="3.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2128,7 +1936,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87b7-d89c-b55e-5c9b" name="Goblin Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2145,7 +1953,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2153,7 +1961,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2170,7 +1978,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af7f-d914-8f2d-524a" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2186,7 +1994,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="578b-b6a5-e352-748d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2202,7 +2010,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2210,13 +2018,14 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9096-65fd-09c1-25cc" name="Goblin Bolt Thrower [51 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="2587-b159-79a8-b8fb" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="a66f-4aea-0bb9-3d30" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+        <infoLink id="a66f-4aea-0bb9-3d30" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="d1a3-cf97-9b6b-f0dc" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="7f88-9dff-4221-3caa" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
@@ -2242,7 +2051,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="3.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2250,7 +2059,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10c8-9568-04ba-1d07" name="Goblin Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2267,7 +2076,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2275,7 +2084,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2292,7 +2101,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="31db-0295-7487-293d" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2302,7 +2111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2319,7 +2128,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="823a-5d06-2b30-16f8" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2335,7 +2144,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0007-03c6-6849-4199" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2351,7 +2160,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2359,7 +2168,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Goblins.cat
+++ b/Goblins.cat
@@ -95,7 +95,7 @@
             </selectionEntry>
             <selectionEntry id="dd12-7d02-fb2b-7c52" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="f390-cd03-efa4-7839" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="f390-cd03-efa4-7839" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -285,7 +285,7 @@
             </selectionEntry>
             <selectionEntry id="c571-82a5-3ee9-af1d" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="7824-b2d3-726c-f460" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="7824-b2d3-726c-f460" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -628,7 +628,7 @@
                           </constraints>
                           <infoLinks>
                             <infoLink id="d504-abc3-8ca8-53a8" name="Goblin Shamanic Cultist" hidden="false" targetId="ac8a-452e-7c65-a4bd" type="profile"/>
-                            <infoLink id="9807-e1d4-c9aa-4c68" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                            <infoLink id="9807-e1d4-c9aa-4c68" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="7.0"/>
@@ -1015,7 +1015,7 @@
             </selectionEntry>
             <selectionEntry id="286a-ea49-46c1-7f63" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="b86a-7aaf-332f-8a68" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="b86a-7aaf-332f-8a68" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1203,7 +1203,7 @@
             </selectionEntry>
             <selectionEntry id="c194-43f5-df69-277a" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="1bfd-051a-74a3-9166" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="1bfd-051a-74a3-9166" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1513,7 +1513,7 @@
             </selectionEntry>
             <selectionEntry id="aa72-260f-56ae-dfb4" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="7f0e-a1a9-47e2-a4bd" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="7f0e-a1a9-47e2-a4bd" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1645,7 +1645,7 @@
             </selectionEntry>
             <selectionEntry id="8f70-262a-31ab-09e0" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="a9c4-27ba-b15a-2dfb" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="a9c4-27ba-b15a-2dfb" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1814,7 +1814,7 @@
             </selectionEntry>
             <selectionEntry id="a7e7-98a3-b32a-fae0" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="e5be-b9ec-3f4f-a2f6" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="e5be-b9ec-3f4f-a2f6" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2006,7 +2006,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="d738-44fd-469b-ee9c" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="d738-44fd-469b-ee9c" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2156,7 +2156,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="8d7e-15c5-812b-6f07" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="8d7e-15c5-812b-6f07" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>

--- a/Goblins.cat
+++ b/Goblins.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a5f0-ec9e-8401-d5df" name="Goblins" revision="1" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a5f0-ec9e-8401-d5df" name="Goblins" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="7c72-b3c6-5f8f-2aee" name="Goblin Chieftain [59 pts]" hidden="false" collective="false" targetId="9b2e-c57f-ec1e-d70d" type="selectionEntry"/>
     <entryLink id="2ce4-b851-6bc0-7617" name="Goblin Chieftain in Wolf Chariot [151 pts]" hidden="false" collective="false" targetId="6dce-754d-7cff-650c" type="selectionEntry"/>
@@ -18,6 +18,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="9b2e-c57f-ec1e-d70d" name="Goblin Chieftain [59 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="684c-00f7-2c9e-845f" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
       </infoLinks>
@@ -38,6 +41,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89d1-0ce8-8631-6724" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -46,6 +50,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -62,6 +67,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6eef-8ef2-f81e-4fe2" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -70,6 +76,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -86,6 +93,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd12-7d02-fb2b-7c52" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -94,6 +102,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27e5-5cc3-1cc9-31ef" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -102,6 +111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="009d-9f31-6687-b5da" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -110,6 +120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="80d6-5260-94ae-9e57" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -118,6 +129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73bb-d5b8-ef1f-a893" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -126,6 +138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99a4-20c0-aa8f-68dd" name="Massive Maces" hidden="false" collective="false" type="upgrade">
@@ -134,6 +147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -158,6 +172,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="41.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="77a5-7c5e-7263-acba" name="Goblin Bodyguard in Light Armour" hidden="false" collective="false" type="model">
@@ -170,6 +185,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -177,6 +193,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="372d-60dc-ff13-7f91" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -193,6 +210,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="51.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="396e-a1a7-1262-db43" name="Goblin Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -202,6 +220,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -209,6 +228,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -224,6 +244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c553-2ca2-2337-3ca8" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -232,6 +253,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b642-2130-c3cc-905e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -240,6 +262,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c5c-9816-1d75-ea85" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -248,6 +271,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="77ff-d53d-723c-f2dc" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -256,6 +280,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="606d-bc15-404e-83a7" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -264,6 +289,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9a13-efd0-27c5-2587" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -272,6 +298,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -279,15 +306,19 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6dce-754d-7cff-650c" name="Goblin Chieftain in Wolf Chariot [151 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="f1c6-f1e1-48f2-f552" name="Goblin Chariot with Chieftain, pulled by 2 wolves" hidden="false" targetId="0d81-8af5-08c1-ceb5" type="profile"/>
         <infoLink id="b31b-f3de-8e84-b4e3" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="cc50-080c-0f4a-d777" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
         <infoLink id="bff5-f502-493a-a27f" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-        <infoLink id="5956-6a94-9538-454a" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+        <infoLink id="5956-6a94-9538-454a" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="25ce-5c59-3aa0-756d" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
@@ -305,6 +336,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -321,6 +353,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c571-82a5-3ee9-af1d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -329,6 +362,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd32-ccce-cccb-3604" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -337,6 +371,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf8b-6fe6-187e-9810" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -345,6 +380,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2590-1570-d5df-4eee" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -353,6 +389,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cc69-6e4e-9ca1-f750" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -361,6 +398,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1aae-fce8-afbc-ea9f" name="Massive Maces" hidden="false" collective="false" type="upgrade">
@@ -369,6 +407,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -391,6 +430,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -407,6 +447,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4738-e2f2-5397-28bf" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -415,6 +456,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -431,6 +473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a136-b4f1-1307-5df6" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -439,6 +482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -455,6 +499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -479,6 +524,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="146.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -486,6 +532,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8697-6dc8-aec9-1d96" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -502,6 +549,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="156.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -509,6 +557,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -525,6 +574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a0f-ba25-9f29-f0be" name="Dire Wolves" hidden="false" collective="false" type="upgrade">
@@ -533,6 +583,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -548,6 +599,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e3af-972c-2171-16b8" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -556,6 +608,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="beed-9166-0423-47c6" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -564,6 +617,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98a8-c5c7-8738-bd04" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -572,6 +626,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5a3f-c39b-2359-5891" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -580,6 +635,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="801e-7660-3546-a998" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -588,6 +644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a98c-e1ae-a737-32ec" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -596,6 +653,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -603,9 +661,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9b6c-6957-d526-e7ea" name="Goblin Shaman [52 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a01d-10ea-25e9-6527" type="max"/>
       </constraints>
@@ -626,6 +688,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3df4-abda-254d-2942" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -634,6 +697,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3ce-9aea-4213-57ac" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -642,6 +706,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -658,6 +723,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c74-7420-d7e4-f4a2" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -666,6 +732,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -683,6 +750,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="52.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -706,6 +774,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="7.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -713,6 +782,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="0e10-a7e6-7a05-cb74" name="Gobble Dogs" hidden="false" collective="false" type="upgrade">
@@ -729,6 +799,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="16.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -736,6 +807,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -754,6 +826,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="38cb-1368-ca79-cfdd" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -762,6 +835,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3624-d046-4359-4043" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -770,6 +844,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="01a2-3df1-fa23-0413" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -778,6 +853,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df7a-cf5c-7231-ce22" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -786,6 +862,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89e2-0470-6909-08d0" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -794,6 +871,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c07-4aab-ba23-7968" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -802,6 +880,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="11a7-47fe-1457-59a8" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -810,6 +889,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="29a0-3721-3779-68c6" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -818,6 +898,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4dcb-dbe7-fedf-8690" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -826,6 +907,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1edb-1d69-93d6-647f" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -834,6 +916,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a745-8305-c14b-b9d6" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -842,6 +925,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2446-a881-881c-312d" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -850,6 +934,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="488c-3cd7-c1ed-f6f5" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -858,6 +943,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -873,6 +959,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e5e6-d09b-0d41-568d" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -884,6 +971,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="473f-be7a-4f8f-1d55" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -895,6 +983,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff38-a0be-5362-7824" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -906,6 +995,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="16d9-d23e-a8fc-7d05" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -917,6 +1007,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d56-ffa2-5697-4977" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -928,6 +1019,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6943-4d3c-7930-8237" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -939,6 +1031,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="05ac-455d-4ffe-b766" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -950,6 +1043,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce9d-0ab7-473a-237b" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -961,6 +1055,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="efdb-bbbc-a461-6785" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -972,6 +1067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7895-145a-9f45-63f4" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -983,6 +1079,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e0a-b41e-e84c-e4e8" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -994,6 +1091,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c76b-447a-d992-73e1" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1005,6 +1103,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4552-4f8a-1e41-813f" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1016,6 +1115,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1031,6 +1131,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebaf-d6b4-1cd7-95de" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1039,6 +1140,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0592-ad61-3898-306a" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1047,6 +1149,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="47e7-024e-09b0-a96c" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1055,6 +1158,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ea52-795c-4c00-73ca" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1063,6 +1167,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b32-0a76-349b-7a45" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1071,6 +1176,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4575-0bb4-df35-676b" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1079,6 +1185,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1086,9 +1193,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="edf4-0805-90d6-cb5d" name="Goblin Guard [49 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c981-9d20-788f-5870" type="max"/>
       </constraints>
@@ -1111,6 +1222,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="286a-ea49-46c1-7f63" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1119,6 +1231,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bca3-60fb-ac29-f47e" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -1127,6 +1240,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83f9-6596-57c9-086e" name="Maces" hidden="false" collective="false" type="upgrade">
@@ -1135,6 +1249,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebcb-6b88-a645-dd7d" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1150,6 +1265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1174,6 +1290,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="89ea-e8d9-ce94-e742" name="Goblin Guard in Light Armour" hidden="false" collective="false" type="model">
@@ -1186,6 +1303,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1193,6 +1311,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e3e4-db71-b73d-7e2b" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1209,6 +1328,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b966-b009-58c1-6eaa" name="Goblin Guard in Medium Armour" hidden="false" collective="false" type="model">
@@ -1221,6 +1341,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1228,6 +1349,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1235,9 +1357,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="58a6-33e4-8a2f-c503" name="Goblin Warriors [47 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="cc8b-e368-dfd6-818e" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
@@ -1257,6 +1383,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="19.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9da7-eb54-800b-5442" name="Goblin Warriors" hidden="false" collective="false" type="model">
@@ -1269,6 +1396,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="7.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1285,6 +1413,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c194-43f5-df69-277a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1293,6 +1422,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a5bd-fe5b-3b19-2481" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1301,6 +1431,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1308,9 +1439,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c835-bc33-0ef5-7675" name="Goblin Archers [47 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="49e4-0c80-f821-ec0e" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="46d4-aa05-c21a-208d" name="Bow" hidden="false" targetId="95e1-d9f2-8182-5835" type="profile"/>
@@ -1340,6 +1475,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2b83-ca48-70fb-7d88" name="Goblin Archers with Bow and Sword or Axe" hidden="false" collective="false" type="model">
@@ -1352,6 +1488,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1359,6 +1496,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0d74-f50e-b097-464a" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1375,6 +1513,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8475-3024-5ba0-6198" name="Goblin Archers in Light Armour with Bow and Sword or Axe" hidden="false" collective="false" type="model">
@@ -1387,6 +1526,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1394,6 +1534,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1401,9 +1542,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="af02-f99a-22b1-78fc" name="Whirling Dervishes [90 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5258-48cf-2412-63d5" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1421,6 +1566,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1428,9 +1574,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d07b-876f-bc12-954b" name="Goblin Wolf Riders [69 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="01d5-4467-aab1-1f84" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
@@ -1450,6 +1600,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1474,6 +1625,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3d06-ffd9-7243-e241" name="Goblin Wolf Riders" hidden="false" collective="false" type="model">
@@ -1486,6 +1638,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1493,6 +1646,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf8b-3e1d-9e60-36a6" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1509,6 +1663,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="33.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="0baf-20b4-d706-5d51" name="Goblin Wolf Riders in Light Armour" hidden="false" collective="false" type="model">
@@ -1521,6 +1676,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1528,6 +1684,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1550,6 +1707,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1566,6 +1724,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa72-260f-56ae-dfb4" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1574,6 +1733,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="977b-2093-e683-2cee" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1582,6 +1742,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1589,14 +1750,18 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="607c-0a91-69c5-0af3" name="Goblin Wolf Chariot [99 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="9f5c-9175-15e7-f2ef" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="57e8-c5d6-eec0-844c" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
         <infoLink id="8b4e-eb2a-1610-d64c" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-        <infoLink id="7464-2b60-0154-2082" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+        <infoLink id="7464-2b60-0154-2082" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ceb1-a0bd-6ee2-5d5f" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
@@ -1613,6 +1778,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1629,6 +1795,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="defe-df41-ead1-171e" name="Dire Wolves" hidden="false" collective="false" type="upgrade">
@@ -1637,6 +1804,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1659,6 +1827,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1675,6 +1844,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8f70-262a-31ab-09e0" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1683,6 +1853,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e08c-a28d-b25e-63ff" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1691,6 +1862,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1707,6 +1879,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1723,6 +1896,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="89.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1730,9 +1904,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6116-5bf2-30da-f941" name="Goblin Sprog Swarm [81 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="973d-e14a-ab21-28ee" name="New CategoryLink" hidden="false" targetId="c820-d327-811d-1144" primary="true"/>
       </categoryLinks>
@@ -1750,6 +1928,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1772,6 +1951,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1779,9 +1959,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cb00-866a-fe1c-a04c" name="Gobble Dog Pack [83 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="0aa4-14ad-ef36-eed2" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="bfe1-3535-f4b2-4beb" name="Frenzied Charge" hidden="false" targetId="1c49-276e-425d-0999" type="rule"/>
@@ -1803,6 +1987,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1822,6 +2007,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="19.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f52d-6826-667d-6e22" name="Pack Master in Medium Armour" hidden="false" collective="false" type="model">
@@ -1833,6 +2019,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1849,6 +2036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a7e7-98a3-b32a-fae0" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1857,6 +2045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3205-56ff-059e-6088" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1865,6 +2054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1872,9 +2062,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e95e-cc72-7367-c272" name="Trolls [105 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="c519-02a4-fd04-1f53" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="c042-94cb-bb35-1f8e" name="Regenerate" hidden="false" targetId="0a0c-ed4c-9647-4398" type="rule"/>
@@ -1896,6 +2090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1903,9 +2098,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d779-99c9-c589-31fc" name="Goblin Stone Thrower [63 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="a4dc-af09-4456-606c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="3eca-9fbb-655e-f5d6" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1926,6 +2125,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b064-2191-2cb2-5d33" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -1934,6 +2134,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1958,6 +2159,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="3.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1965,6 +2167,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87b7-d89c-b55e-5c9b" name="Goblin Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1981,6 +2184,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1988,6 +2192,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2004,6 +2209,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af7f-d914-8f2d-524a" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2019,6 +2225,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="578b-b6a5-e352-748d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2034,6 +2241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2041,9 +2249,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9096-65fd-09c1-25cc" name="Goblin Bolt Thrower [51 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2587-b159-79a8-b8fb" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="a66f-4aea-0bb9-3d30" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2072,6 +2284,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="3.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2079,6 +2292,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10c8-9568-04ba-1d07" name="Goblin Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2095,6 +2309,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2102,6 +2317,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2118,6 +2334,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="31db-0295-7487-293d" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2127,6 +2344,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2143,6 +2361,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="823a-5d06-2b30-16f8" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2158,6 +2377,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0007-03c6-6849-4199" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2173,6 +2393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2180,6 +2401,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Halflings.cat
+++ b/Halflings.cat
@@ -45,7 +45,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="69.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="66e8-ed3b-530e-0911" name="Henchmen" hidden="false" collective="false" type="model">
@@ -58,7 +58,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -66,7 +66,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c11-8bf4-3580-e403" name="Light Armour (10pts + 2pts per Henchmen)" hidden="false" collective="false" type="upgrade">
@@ -83,7 +83,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="79.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="7adf-df3c-4c6d-b8b4" name="Henchmen" hidden="false" collective="false" type="model">
@@ -96,7 +96,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -104,12 +104,12 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="bf34-b0e5-ee2b-8f47" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="12b1-9fd7-1c2b-631d">
+        <selectionEntryGroup id="bf34-b0e5-ee2b-8f47" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="12b1-9fd7-1c2b-631d">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="854f-2177-c3e8-a5f8" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="030b-b57e-0f96-6135" type="max"/>
@@ -121,7 +121,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1095-ef0c-84fa-c09d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -130,7 +130,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="13d7-55cd-a401-ee1d" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -139,7 +139,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -155,7 +155,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -178,7 +178,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2350-2378-061f-0248" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -194,7 +194,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -217,7 +217,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -234,7 +234,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7385-dfc0-975d-c7f0" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -243,7 +243,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -260,7 +260,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8e5c-b2b2-fe84-aec4" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -269,85 +269,18 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="ff99-862e-004c-1d12" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63ce-35a3-3baa-3b73" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="a8de-7023-b231-7d37" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d649-a3f7-4d48-0fe8" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="03f7-9a1e-3658-77d1" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d9c3-0f74-f392-6297" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7279-b221-bae1-afda" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7252-80eb-6a07-22b3" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7c2b-b70c-dc06-1911" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="26b7-99b0-bfcb-0c96" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8bbe-8769-e446-3925" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="33f5-6d28-4957-58f2" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a973-4a7c-756a-11b8" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="568c-37d3-432b-245e" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7e3c-9fd8-e44e-3485" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4b18-389d-6b8f-aa07" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4351-cb43-45c7-9f9c" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6a05-8937-f0c2-efaa" name="Halfling Chief Sheriff in Cart [130 pts]" hidden="false" collective="false" type="unit">
@@ -360,6 +293,37 @@
         <categoryLink id="77c5-e4a0-0b2b-0265" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="456e-2e4b-2e6b-b047" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4f27-6147-1d92-830a" name="Cart" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f90-8b4a-3999-fc1c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e33-738e-b384-41ae" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="e0ca-8c3a-a674-539b" name="Cart with Sheriff and driver, pulled by one donkey" hidden="false" targetId="291a-239b-59ae-33b4" type="profile"/>
+            <infoLink id="4c01-cb35-6c0d-616d" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+            <infoLink id="26da-1d3a-9993-6c53" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+            <infoLink id="9dbe-6491-34a8-b17b" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="769e-3f93-798b-0bc4" name="Crew" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5947-6b61-b6ce-6b90" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52fd-e635-c4f6-fdd2" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="19f9-c3fa-6080-7e04" name="Halfling Cart Driver" hidden="false" targetId="03eb-955e-9942-2853" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="7022-bf4c-1f2f-6ac3" name="Sheriff Tough Selection" hidden="false" collective="false" defaultSelectionEntryId="5a9a-043e-afd6-1f14">
           <constraints>
@@ -373,7 +337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0d87-0c59-7871-784a" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -382,7 +346,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -399,7 +363,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b6bc-3982-cbe6-426a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -408,12 +372,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ad88-2272-4527-54c1" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="6a44-018b-9e02-fde9">
+        <selectionEntryGroup id="ad88-2272-4527-54c1" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="6a44-018b-9e02-fde9">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c24f-35f0-1b80-a8c7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb97-0037-46f2-3ced" type="max"/>
@@ -425,7 +389,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed7e-3922-a815-9f0e" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -434,7 +398,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f5c7-7f85-db23-2118" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -443,7 +407,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -459,7 +423,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -482,57 +446,23 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e979-0a9c-bfea-244c" name="Cart Fast Upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="e979-0a9c-bfea-244c" name="Judicious Use of Carrots" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="7dd3-f795-e4b1-7a6b" name="Upgrade Cart to FAST 8" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7dd3-f795-e4b1-7a6b" name="Upgrade to Fast 8" hidden="false" collective="false" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0098-80a0-008a-198b" type="max"/>
               </constraints>
+              <infoLinks>
+                <infoLink id="689c-3899-bb97-8a3e" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="9990-876f-38df-72a2" name="cart" hidden="false" collective="false" defaultSelectionEntryId="1ca0-b1f3-5d64-4b69">
-          <selectionEntries>
-            <selectionEntry id="1ca0-b1f3-5d64-4b69" name="Cart" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb5e-89a6-dccc-2847" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6cd-7d3b-15fb-ff4e" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="27d1-5f26-2b11-7306" name="Cart with Sheriff and driver, pulled by one donkey" hidden="false" targetId="291a-239b-59ae-33b4" type="profile"/>
-                <infoLink id="759a-9f5a-2216-0b7e" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="bc01-d293-1d0d-c2e0" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                <infoLink id="a814-7c01-6983-e895" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="d203-8136-8c0e-46d0" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="708f-1a2f-c781-8b13">
-          <selectionEntries>
-            <selectionEntry id="708f-1a2f-c781-8b13" name="Crew" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="361c-7a68-cf3f-e64c" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a45-4a6b-c968-65a0" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="76de-6573-c5a3-a55f" name="Halfling Cart Driver" hidden="false" targetId="03eb-955e-9942-2853" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -549,7 +479,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="130.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9eac-ba4f-c7b9-bd6d" name="Halfling Chief Sheriff in Light Armour (on Foot)" hidden="false" collective="false" type="model">
@@ -558,85 +488,18 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="140.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="ea33-1cd1-2b80-b006" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec3e-007e-5793-2da4" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="4172-627e-fb28-1871" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e021-43ba-cde1-1a12" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d29b-0232-16d2-edf2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1bce-973e-801a-6b23" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b2b0-799a-e3fa-0669" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1f4d-8bf3-11bc-f282" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e9ff-cae1-c686-6e1a" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b14a-4907-79e0-68c3" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="063a-988e-aa82-6815" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0d91-1d77-7346-84fc" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c60a-3804-e4d0-d447" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="edc3-8068-dc79-8680" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0ab2-e0c3-669c-4672" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8ffa-9f18-a003-b594" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="5451-1205-b18d-ebae" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a39d-0ad7-0df8-8f0f" name="Halfling Fortune Teller [51 pts]" hidden="false" collective="false" type="unit">
@@ -647,6 +510,22 @@
         <categoryLink id="f21b-e859-f494-7df7" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
         <categoryLink id="23de-2f5d-6192-5552" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0be2-e151-8693-fb5d" name="Halfling Fortune Teller" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1e1-7717-bc7f-1fe4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b5a-fd3a-489b-0139" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="8c60-60df-b046-3f23" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+            <infoLink id="61c4-1f20-499e-3ec5" name="Halfling Fortune Teller with club" hidden="false" targetId="25a5-fa5c-28f5-cb90" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="45.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="9b83-b851-48bd-2c6a" name="Magic Level" hidden="false" collective="false" defaultSelectionEntryId="ac99-118b-bb01-9f93">
           <constraints>
@@ -660,7 +539,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="855d-c917-3b73-2f38" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -669,7 +548,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="623e-9e06-264e-c979" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -678,7 +557,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -695,7 +574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0ab-063d-6822-a803" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -704,7 +583,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -727,25 +606,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="b9bf-c19e-25b7-b975" name="Fortune Teller" hidden="false" collective="false" defaultSelectionEntryId="cec9-9b88-6030-d19a">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1347-7ce6-23f7-f5e9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="590c-f8fa-c18b-eb02" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="cec9-9b88-6030-d19a" name="Halfling Fortune Teller" hidden="false" collective="false" type="model">
-              <infoLinks>
-                <infoLink id="3432-e150-52c3-1028" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
-                <infoLink id="c457-a2ef-7c93-bba7" name="Halfling Fortune Teller with club" hidden="false" targetId="25a5-fa5c-28f5-cb90" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="45.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -769,7 +630,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -777,7 +638,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f95-376f-1f4a-b62a" name="Spirit Guides" hidden="false" collective="false" type="upgrade">
@@ -794,7 +655,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -802,7 +663,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -818,7 +679,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8694-de67-033e-6e89" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -830,7 +691,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffd6-088f-3860-a2a7" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -842,7 +703,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f81-a6e7-f754-4f5b" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -854,7 +715,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e909-9414-093a-938d" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -866,7 +727,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd56-9008-3bf1-7e25" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -878,7 +739,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78fe-0325-3cd6-0df7" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -890,7 +751,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f942-2fde-bd85-c35b" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -902,7 +763,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="42ba-bf6d-ae9c-c0a0" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -914,7 +775,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a922-cd29-1ab1-fde2" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -926,7 +787,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="85d9-7edb-2684-f909" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -938,7 +799,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a90a-507f-1346-c7de" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -950,7 +811,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e20d-b40e-00ab-de80" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -962,7 +823,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc99-b403-0ef3-ec6c" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -974,7 +835,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -991,7 +852,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98f5-7e62-7e5a-a589" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1000,7 +861,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18a5-27ab-cbb8-9e02" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1009,7 +870,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36a4-b006-6e1a-47b7" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1018,7 +879,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44a8-6cdb-a591-c5a7" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1027,7 +888,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="82e8-b315-c4ce-5ab1" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1036,7 +897,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c384-dadd-fadd-4c51" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1045,7 +906,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="57e2-6056-2442-9e07" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1054,7 +915,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e8fa-1465-1ab9-b874" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1063,7 +924,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="47c0-e7c7-e115-9899" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1072,7 +933,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f711-1a08-7701-94bc" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1081,7 +942,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2cf2-7d1b-16b0-1de2" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1090,7 +951,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4cec-0dae-1caf-25e7" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1099,7 +960,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="69df-5769-e05f-fb98" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1108,85 +969,18 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="7990-18fc-7771-b5de" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3949-05d1-9a66-4df3" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="17c5-5ad9-f263-86f4" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8db2-beb9-4cb8-13f0" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e1b9-4f9f-fa7b-dd8a" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ff57-00cc-f6c8-fae4" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="bfd7-d0c1-6fad-b2bd" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="322b-b2d3-3b34-0d49" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6856-4bcc-a81a-a70e" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="11be-9f79-2e0d-358a" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d989-27f2-c683-fcbc" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8b0a-1e55-131f-d9de" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="54de-cad1-f3b2-6170" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d996-be5a-3a6c-4de7" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="cafb-d6ac-dae8-6660" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8fb2-c48a-36dc-72ee" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9445-b0c6-4044-2026" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8dcb-a098-4ac4-094e" name="Halfling Clan Chief [76 pts]" hidden="false" collective="false" type="unit">
@@ -1210,7 +1004,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="76.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6307-bc33-7de0-0d94" name="Clan Chief in Light Armour" hidden="false" collective="false" type="model">
@@ -1219,7 +1013,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1235,7 +1029,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1252,7 +1046,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="740f-0f75-2fca-c47f" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1261,7 +1055,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1278,7 +1072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18ea-60fa-6daf-c9dd" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1287,7 +1081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62a7-2b63-ffb1-a6df" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1296,7 +1090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1312,7 +1106,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1328,12 +1122,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="dbc4-0a94-7a37-8c35" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="2e94-2367-437e-0a6c">
+        <selectionEntryGroup id="dbc4-0a94-7a37-8c35" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="2e94-2367-437e-0a6c">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dd4-9b8a-36ce-1bb0" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cf5-c617-86bb-e770" type="max"/>
@@ -1345,7 +1139,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27db-415b-be75-94aa" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1354,7 +1148,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bba2-bdd3-8a1f-d0ec" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1363,91 +1157,24 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="7c9b-f9e8-19c7-8685" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e355-e66b-fb06-6138" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="57c4-8a81-1ea2-0810" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4e91-ed6b-be9e-c960" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a581-fcb2-8d9b-23cc" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="192e-c532-76f1-363c" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c113-b6c0-51bf-836e" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5bc7-fa1c-38d2-3657" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="64e2-8887-ab37-3d45" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8099-813f-3549-9ec2" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a675-8ee6-eb19-925e" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c962-6471-187e-7189" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="377a-fa27-043d-1f1a" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="040f-3e75-a7c4-4023" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="fa66-177b-9ee6-9387" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="93ee-8005-08d4-f8aa" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d4df-c0b2-212c-1cff" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3eed-5ce8-9c18-f10c" name="Mounted Halfling Clan Chief [87 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="ebc6-cb05-9577-16d7" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
-        <infoLink id="54bb-2468-e7df-a5d0" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="54bb-2468-e7df-a5d0" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="d5ca-fa78-5dba-8127" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
@@ -1466,7 +1193,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="87.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f12-ab2c-9701-24cc" name="Clan Chief in Light Armour" hidden="false" collective="false" type="model">
@@ -1475,7 +1202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="97.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1491,7 +1218,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1508,7 +1235,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e42c-a8d2-a6c6-e4fc" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1517,7 +1244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1534,7 +1261,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df88-9573-39dc-8d71" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1543,7 +1270,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30e1-e3d1-63c1-8325" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1552,7 +1279,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1568,12 +1295,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="485d-7a7f-a125-7611" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="096b-7ead-8783-c7d6">
+        <selectionEntryGroup id="485d-7a7f-a125-7611" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="096b-7ead-8783-c7d6">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5a8-ab71-ff01-a277" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8049-6cae-8c6d-9bbe" type="max"/>
@@ -1585,7 +1312,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="963e-e2cb-dd16-a2be" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1594,7 +1321,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44a3-6d7b-f763-cbb8" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1603,101 +1330,34 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="b312-5c5e-6283-a2c7" name="Use Carrots to make FAST 8" hidden="false" collective="false">
+        <selectionEntryGroup id="b312-5c5e-6283-a2c7" name="Judicious Use of Carrots (Fast 8)" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae39-b8aa-fe4c-dd47" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="a778-9751-20fe-d411" name="Fast 8" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="36c3-ea23-132d-c6bf" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+                <infoLink id="36c3-ea23-132d-c6bf" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="69e9-976d-2342-7389" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05ac-20de-696b-60d0" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="8649-172c-02a9-578b" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a841-f2c1-2147-5aff" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="68f9-fe1e-70bd-534f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b2ae-d59c-5fb8-a628" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a2a1-3513-f2c9-a58a" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="3d1b-f541-a4bb-0c61" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6716-3cf0-73c6-27b5" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="2c52-5941-07a6-feed" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1a91-50cf-1dd2-831d" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7bf1-ed6f-4548-4e01" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ab1a-b3b3-b4d3-e21c" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9088-8d2c-5b52-6014" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="88a6-fdec-8403-c698" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bb59-be29-bf03-ab99" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="dd8d-ea42-8c0e-2c4a" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="19e0-8c7c-366c-d7d0" name="Halfling Sheriffs [47 pts]" hidden="false" collective="false" type="unit">
@@ -1708,7 +1368,7 @@
         <categoryLink id="ad7c-763f-905f-fbf6" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="bb3c-cbe5-e886-3ddb" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="c5cb-3200-ac5c-1d1c">
+        <selectionEntryGroup id="bb3c-cbe5-e886-3ddb" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="c5cb-3200-ac5c-1d1c">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35e1-5adf-b83d-7fa2" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6213-8863-9abc-a2f0" type="max"/>
@@ -1727,7 +1387,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95d3-8149-6187-d6cd" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1743,7 +1403,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5cb-3200-ac5c-1d1c" name="Staves" hidden="false" collective="false" type="upgrade">
@@ -1752,7 +1412,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1775,7 +1435,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6bcb-e409-ee0a-e017" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -1791,7 +1451,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1807,7 +1467,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1832,7 +1492,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="364e-cc5f-1aea-94e5" name="Halfling Sheriffs" hidden="false" collective="false" type="model">
@@ -1845,7 +1505,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1853,7 +1513,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f11c-4a92-d889-7459" name="Sheriffs in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1870,7 +1530,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="95e1-8e9b-f11d-2a5a" name="Halfling Sheriffs" hidden="false" collective="false" type="model">
@@ -1883,7 +1543,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1891,7 +1551,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1914,7 +1574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1922,7 +1582,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0545-0a42-e1f7-1b28" name="Halfling Militia [42 pts]" hidden="false" collective="false" type="unit">
@@ -1943,7 +1603,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7fd4-635d-49df-f7b3" name="Halfling Militia" hidden="false" collective="false" type="model">
@@ -1956,7 +1616,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="6.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1972,7 +1632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1995,7 +1655,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2011,12 +1671,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="17c2-5652-a8e6-e97a" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="361a-0092-7d5d-acbb">
+        <selectionEntryGroup id="17c2-5652-a8e6-e97a" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="361a-0092-7d5d-acbb">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="687b-04a9-1d8e-5277" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8ff-191c-4614-51c9" type="max"/>
@@ -2035,7 +1695,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d12-d5be-81f0-dfce" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2051,7 +1711,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a07f-6229-8a1b-41d6" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2067,7 +1727,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="361a-0092-7d5d-acbb" name="Club" hidden="false" collective="false" type="upgrade">
@@ -2076,7 +1736,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6415-c6fc-feb6-0717" name="Cudgel" hidden="false" collective="false" type="upgrade">
@@ -2085,7 +1745,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af91-65c7-6253-67b5" name="Staves" hidden="false" collective="false" type="upgrade">
@@ -2101,7 +1761,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2109,7 +1769,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ad9d-9e1b-c214-43c1" name="Halfling Archers [52 pts]" hidden="false" collective="false" type="unit">
@@ -2129,7 +1789,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8c21-9f4e-34bf-5f04" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -2145,7 +1805,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2163,7 +1823,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fcbb-51f2-f96c-c4da" name="Archer" hidden="false" collective="false" type="model">
@@ -2176,77 +1836,10 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="2d6e-1337-0f67-19c0" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="97e3-1af0-2de6-3c95">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3ad-2daa-82bd-f0fd" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a33b-7e6c-d34c-30b4" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="3158-931f-b3b2-3294" name="Sword" hidden="false" collective="false" type="upgrade">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="2">
-                      <repeats>
-                        <repeat field="selections" scope="ad9d-9e1b-c214-43c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                      </repeats>
-                    </modifier>
-                  </modifiers>
-                  <infoLinks>
-                    <infoLink id="4bba-bd62-8499-6751" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="1335-03d3-3c17-41f9" name="Axe" hidden="false" collective="false" type="upgrade">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="2">
-                      <repeats>
-                        <repeat field="selections" scope="ad9d-9e1b-c214-43c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                      </repeats>
-                    </modifier>
-                  </modifiers>
-                  <infoLinks>
-                    <infoLink id="7d0a-578e-cb42-6eef" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="97e3-1af0-2de6-3c95" name="Club" hidden="false" collective="false" type="upgrade">
-                  <infoLinks>
-                    <infoLink id="0689-0995-514c-52ce" name="Club" hidden="false" targetId="0b17-24e8-fb18-654e" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="ad48-1bc6-547c-af95" name="Daggers" hidden="false" collective="false" type="upgrade">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="1">
-                      <repeats>
-                        <repeat field="selections" scope="ad9d-9e1b-c214-43c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                      </repeats>
-                    </modifier>
-                  </modifiers>
-                  <infoLinks>
-                    <infoLink id="ef32-93a3-7bc6-f4f9" name="Dagger" hidden="false" targetId="5514-08ba-d190-bf84" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
         </selectionEntryGroup>
         <selectionEntryGroup id="cc06-c866-5884-efc1" name="Dead Eye Shot Upgrade" hidden="false" collective="false">
           <selectionEntries>
@@ -2259,7 +1852,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2282,7 +1875,72 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="41ef-f296-25d8-cd0e" name="HtH Weapons" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a83-b2b4-e560-89b6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4c1-906d-70b7-21c0" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7de1-706d-e333-acd5" name="Sword" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="points" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="ad9d-9e1b-c214-43c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <infoLinks>
+                <infoLink id="e74f-31f1-0c6c-4330" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="06e4-660b-17a1-0c90" name="Axe" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="ad9d-9e1b-c214-43c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <infoLinks>
+                <infoLink id="fd87-8b04-3715-6bd5" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1537-3bde-f2ae-906e" name="Club" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="8c4b-51db-d0bf-1a80" name="Club" hidden="false" targetId="0b17-24e8-fb18-654e" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="daf2-7773-ee0e-db2f" name="Daggers" hidden="false" collective="false" type="upgrade">
+              <modifiers>
+                <modifier type="increment" field="points" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="ad9d-9e1b-c214-43c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <infoLinks>
+                <infoLink id="b370-4a3e-b326-b088" name="Dagger" hidden="false" targetId="5514-08ba-d190-bf84" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2290,7 +1948,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="00b9-460a-80f2-affb" name="Halfling Urchin Swarm [141 pts]" hidden="false" collective="false" type="unit">
@@ -2298,7 +1956,7 @@
         <categoryLink id="5702-500b-e79d-d4d7" name="New CategoryLink" hidden="false" targetId="c820-d327-811d-1144" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="55d4-a974-3897-acdd" name="models" hidden="false" collective="false">
+        <selectionEntryGroup id="55d4-a974-3897-acdd" name="Swarms" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="131e-70ae-4689-2a5b" name="Urchin Swarm" hidden="false" collective="false" type="model">
               <constraints>
@@ -2310,7 +1968,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="47.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2326,7 +1984,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2349,7 +2007,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2372,7 +2030,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2380,19 +2038,22 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="24b7-8d95-bb2a-1795" name="Mounted Halflings [63 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe22-cfe5-01a8-fb5a" type="max"/>
+      </constraints>
       <infoLinks>
-        <infoLink id="36c1-a5f8-fe10-ae8b" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="36c1-a5f8-fe10-ae8b" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
         <infoLink id="62ee-792f-bc27-4ee9" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1971-4957-7a2d-ce24" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b333-d93f-dba4-e0a9" name="models" hidden="false" collective="false" defaultSelectionEntryId="c1dc-de7e-f76f-d842">
+        <selectionEntryGroup id="b333-d93f-dba4-e0a9" name="Mounted Halflings" hidden="false" collective="false" defaultSelectionEntryId="c1dc-de7e-f76f-d842">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f7d-86a1-4bce-b578" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a51b-b580-2c30-70be" type="max"/>
@@ -2412,7 +2073,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="93a1-252a-d1db-d1ee" name="Mounted Halfling" hidden="false" collective="false" type="model">
@@ -2425,7 +2086,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2433,7 +2094,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="54d6-172a-2723-352e" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2450,7 +2111,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5ef4-2e25-c462-83e9" name="Mounted Halfling" hidden="false" collective="false" type="model">
@@ -2463,7 +2124,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2471,7 +2132,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2487,12 +2148,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4de0-3bee-0770-72cd" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="1611-e5e9-a46c-fc13">
+        <selectionEntryGroup id="4de0-3bee-0770-72cd" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="1611-e5e9-a46c-fc13">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9246-4a77-db74-82f7" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bc8-bf1c-703c-2354" type="max"/>
@@ -2504,7 +2165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4031-752e-741a-5060" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2513,7 +2174,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8f83-9b07-33a2-3550" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2522,7 +2183,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2545,7 +2206,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2553,15 +2214,32 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="87d2-b341-dc57-0825" name="Halfling Stone Thrower [72 pts]" hidden="false" collective="false" type="unit">
       <categoryLinks>
         <categoryLink id="344e-8498-6d57-e0cb" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c379-3673-4e53-47b6" name="Small Stone Thrower" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cdc-2aeb-437f-e95c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32c4-e76e-f9a1-dc7f" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="de66-d95f-64fe-c258" name="Small Stone Thrower" hidden="false" targetId="fee6-c34d-8a5d-a9e6" type="profile"/>
+            <infoLink id="26d8-b582-f646-c6d0" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+            <infoLink id="5dcb-7487-b715-48f9" name="Overhead" hidden="false" targetId="7751-622a-b896-4874" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="54.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ce57-a11e-ac45-94e0" name="crew" hidden="false" collective="false" defaultSelectionEntryId="0398-de31-9e78-6110">
+        <selectionEntryGroup id="ce57-a11e-ac45-94e0" name="Halfling Crew" hidden="false" collective="false" defaultSelectionEntryId="0398-de31-9e78-6110">
           <selectionEntries>
             <selectionEntry id="0398-de31-9e78-6110" name="Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -2571,33 +2249,16 @@
               <infoLinks>
                 <infoLink id="1277-f5c0-5aeb-3e1f" name="Halfling Crew with Stone-throwing engine" hidden="false" targetId="dd2b-812d-fa6f-1c8a" type="profile"/>
                 <infoLink id="9b4a-ced5-40a9-eed7" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="3d0b-273e-b187-3052" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+                <infoLink id="3d0b-273e-b187-3052" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="6.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="062f-5eb6-53c6-e791" name="stone thrower" hidden="false" collective="false" defaultSelectionEntryId="0d10-dc81-c045-f1d6">
-          <selectionEntries>
-            <selectionEntry id="0d10-dc81-c045-f1d6" name="Small Stone Thrower" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eca8-e1aa-039d-a940" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5060-23b7-f063-058f" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="4880-abc1-1525-6606" name="Small Stone Thrower" hidden="false" targetId="fee6-c34d-8a5d-a9e6" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="b2da-ff77-3f21-382f" name="Crew HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="4985-ebaa-f7e1-ce89">
+        <selectionEntryGroup id="b2da-ff77-3f21-382f" name="Crew HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="4985-ebaa-f7e1-ce89">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58bd-8525-0e76-8be1" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d99-87b1-453e-6699" type="max"/>
@@ -2616,7 +2277,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5de3-ff28-8c06-7e79" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2632,7 +2293,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4985-ebaa-f7e1-ce89" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -2641,7 +2302,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2649,15 +2310,30 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bac5-4a06-ae31-2485" name="Halfling Bolt Thrower [60 pts]" hidden="false" collective="false" type="unit">
       <categoryLinks>
         <categoryLink id="5ad0-37c1-0960-3fca" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d4e5-341c-edd6-35b8" name="Small Bolt Thrower" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="033d-7b54-0660-9fff" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9838-93d2-513b-7127" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0650-1716-ed80-ab3d" name="Small Bolt Thrower" hidden="false" targetId="ba80-a4f2-4c92-7844" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="42.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a761-cc8e-148d-3f5b" name="crew" hidden="false" collective="false" defaultSelectionEntryId="b7f1-e372-2316-27e2">
+        <selectionEntryGroup id="a761-cc8e-148d-3f5b" name="Halfling Crew" hidden="false" collective="false" defaultSelectionEntryId="b7f1-e372-2316-27e2">
           <selectionEntries>
             <selectionEntry id="b7f1-e372-2316-27e2" name="Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -2666,34 +2342,17 @@
               </constraints>
               <infoLinks>
                 <infoLink id="4e31-86c6-f0b3-b572" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="aeeb-1fd4-671a-1a96" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+                <infoLink id="aeeb-1fd4-671a-1a96" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
                 <infoLink id="7a93-acfb-c729-91bb" name="Halfling Crew with Bolt-throwing engine" hidden="false" targetId="70e2-57f8-092a-67c3" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="6.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="720b-ac8c-f2db-6625" name="Bolt thrower" hidden="false" collective="false" defaultSelectionEntryId="c84a-3297-c1c8-a5a6">
-          <selectionEntries>
-            <selectionEntry id="c84a-3297-c1c8-a5a6" name="Small Bolt Thrower" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="446a-44c2-b8da-235b" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9773-ae13-cb12-73f3" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="3924-b01d-4101-a82b" name="Small Bolt Thrower" hidden="false" targetId="ba80-a4f2-4c92-7844" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="f098-c355-e854-d8fb" name="Crew HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="e261-5f7e-70f0-43b7">
+        <selectionEntryGroup id="f098-c355-e854-d8fb" name="Crew HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="e261-5f7e-70f0-43b7">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fb9-608d-697f-904c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d8d-4a97-3e5e-2589" type="max"/>
@@ -2712,7 +2371,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0822-daf3-42c9-e209" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2728,7 +2387,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e261-5f7e-70f0-43b7" name="Clubs" hidden="false" collective="false" type="upgrade">
@@ -2737,7 +2396,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2753,7 +2412,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2761,7 +2420,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -2780,7 +2439,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">4</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, 3xHTH, Wound X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, 3x HtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="ad24-8064-8f0c-5cbf" name="Halfling Sheriff in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2791,7 +2450,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">4(5)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, 3xHTH, Wound X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, 3x HtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="bfeb-0136-c7c1-f9d3" name="Halfling Henchmen" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2835,7 +2494,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[4]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, Follow, 3xHTH, [Wound X]</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, Follow, 3x HtH, [Wound X]</characteristic>
       </characteristics>
     </profile>
     <profile id="7f36-037e-bd2d-3e1f" name="Halfling Chief Sheriff in light armour (cart-on foot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2846,7 +2505,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[4(5)]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, Follow, 3xHTH, [Wound X]</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, Follow, 3x HtH, [Wound X]</characteristic>
       </characteristics>
     </profile>
     <profile id="03eb-955e-9942-2853" name="Halfling Cart Driver" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2868,7 +2527,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHTH SV0</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1x HtH SV0</characteristic>
       </characteristics>
     </profile>
     <profile id="25a5-fa5c-28f5-cb90" name="Halfling Fortune Teller with club" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2901,7 +2560,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">3</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Sprit, 1xHTH SV1, Exchange of Missiles SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Sprit, 1x HtH SV1, Exchange of Missiles SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="fc99-b8bb-bec2-2645" name="Halfling Clan Chief" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2912,7 +2571,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">4</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHTH, Wound X, 3xRanged (if armed with Bow)</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3x HtH, Wound X, 3x Ranged (if armed with Bow)</characteristic>
       </characteristics>
     </profile>
     <profile id="8ed2-e6a1-7650-0f20" name="Halfling Clan Chief in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2923,7 +2582,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">4(5)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHTH, Wound X, 3xRanged (if armed with Bow)</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3x HtH, Wound X, 3x Ranged (if armed with Bow)</characteristic>
       </characteristics>
     </profile>
     <profile id="f986-03e0-e9d8-4039" name="Halfling Clan Chief Riding Donkey" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2934,7 +2593,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHTH, Wound X, 3xRanged (if armed with bow), Donkey 1xHTH SV0, Fast 6</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3x HtH, Wound X, 3x Ranged (if armed with bow), Donkey 1x HtH SV0, Fast 6</characteristic>
       </characteristics>
     </profile>
     <profile id="cb68-2ebe-84cb-9bb5" name="Halfling Clan Chief in Light Armour Riding Donkey" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2945,7 +2604,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHTH, Wound X, 3xRanged (if armed with bow), Donkey 1xHTH SV0, Fast 6</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3x HtH, Wound X, 3x Ranged (if armed with bow), Donkey 1x HtH SV0, Fast 6</characteristic>
       </characteristics>
     </profile>
     <profile id="9833-36bc-6eaf-cb33" name="Halfling Sheriff Leader" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3014,13 +2673,13 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="73f5-966d-080a-53a6" name="Rocks(thrown)" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="73f5-966d-080a-53a6" name="Rocks (thrown)" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
         <characteristic name="Range Extreme" typeId="49d3-642a-08be-5817">-</characteristic>
         <characteristic name="Strike Value" typeId="47c7-dced-6203-6b76">0</characteristic>
-        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Can also be used in HTH</characteristic>
+        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Can also be used in HtH</characteristic>
       </characteristics>
     </profile>
     <profile id="c6c0-9918-f701-79e2" name="Halfling Archer Leader" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3053,7 +2712,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH, 3xRanged</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3x HtH, 3x Ranged</characteristic>
       </characteristics>
     </profile>
     <profile id="bde3-c3c6-26a1-028f" name="Mounted Halfling Leader" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3064,7 +2723,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 6, Donkey 1xHTH SV0</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 6, Donkey 1x HtH SV0</characteristic>
       </characteristics>
     </profile>
     <profile id="0e9b-e07b-8422-77bb" name="Mounted Halfling Leader in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3075,7 +2734,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 6, Donkey 1xHTH SV0</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 6, Donkey 1x HtH SV0</characteristic>
       </characteristics>
     </profile>
     <profile id="4fda-d7f4-ab0b-aa6f" name="Mounted Halfling" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3086,7 +2745,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Donkey 1xHTH SV0</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Donkey 1x HtH SV0</characteristic>
       </characteristics>
     </profile>
     <profile id="6b84-e73a-8bc2-21b0" name="Mounted Halfling in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3097,7 +2756,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Donkey 1xHTH SV0</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Donkey 1x HtH SV0</characteristic>
       </characteristics>
     </profile>
     <profile id="dd2b-812d-fa6f-1c8a" name="Halfling Crew with Stone-throwing engine" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">

--- a/Halflings.cat
+++ b/Halflings.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="745c-5adf-6444-cac7" name="Halflings" revision="2" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="745c-5adf-6444-cac7" name="Halflings" revision="3" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d891-2083-8b78-b275" name="Halfling Chief Cheriff [85 pts]" hidden="false" collective="false" targetId="c9ff-893e-2ec9-3544" type="selectionEntry"/>
     <entryLink id="748f-2466-4dcf-674f" name="Halfling Chief Sheriff in Cart [130 pts]" hidden="false" collective="false" targetId="6a05-8937-f0c2-efaa" type="selectionEntry"/>
@@ -16,9 +16,6 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="c9ff-893e-2ec9-3544" name="Halfling Chief Sheriff [85 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="1a7f-ec79-5436-2ba0" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="dd40-1170-66ad-3992" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -48,7 +45,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="69.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="66e8-ed3b-530e-0911" name="Henchmen" hidden="false" collective="false" type="model">
@@ -61,7 +58,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -69,7 +66,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c11-8bf4-3580-e403" name="Light Armour (10pts + 2pts per Henchmen)" hidden="false" collective="false" type="upgrade">
@@ -86,7 +83,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="79.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="7adf-df3c-4c6d-b8b4" name="Henchmen" hidden="false" collective="false" type="model">
@@ -99,7 +96,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -107,7 +104,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -124,7 +121,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1095-ef0c-84fa-c09d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -133,7 +130,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="13d7-55cd-a401-ee1d" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -142,7 +139,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -158,7 +155,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -181,7 +178,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2350-2378-061f-0248" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -197,7 +194,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -220,7 +217,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -237,7 +234,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7385-dfc0-975d-c7f0" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -246,7 +243,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -263,7 +260,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8e5c-b2b2-fe84-aec4" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -272,7 +269,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -288,7 +285,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="03f7-9a1e-3658-77d1" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -297,7 +294,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7279-b221-bae1-afda" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -306,7 +303,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7c2b-b70c-dc06-1911" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -315,7 +312,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bbe-8769-e446-3925" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -324,7 +321,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a973-4a7c-756a-11b8" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -333,7 +330,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e3c-9fd8-e44e-3485" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -342,7 +339,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -350,13 +347,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6a05-8937-f0c2-efaa" name="Halfling Chief Sheriff in Cart [130 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="54b0-1542-a426-c212" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="f643-fe7d-7715-b283" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -379,7 +373,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0d87-0c59-7871-784a" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -388,7 +382,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -405,7 +399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b6bc-3982-cbe6-426a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -414,7 +408,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -431,7 +425,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed7e-3922-a815-9f0e" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -440,7 +434,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f5c7-7f85-db23-2118" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -449,7 +443,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -465,7 +459,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -488,7 +482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -501,7 +495,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -521,7 +515,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -538,7 +532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -555,7 +549,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="130.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9eac-ba4f-c7b9-bd6d" name="Halfling Chief Sheriff in Light Armour (on Foot)" hidden="false" collective="false" type="model">
@@ -564,7 +558,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="140.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -580,7 +574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d29b-0232-16d2-edf2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -589,7 +583,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b2b0-799a-e3fa-0669" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -598,7 +592,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e9ff-cae1-c686-6e1a" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -607,7 +601,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="063a-988e-aa82-6815" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -616,7 +610,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c60a-3804-e4d0-d447" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -625,7 +619,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ab2-e0c3-669c-4672" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -634,7 +628,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -642,13 +636,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a39d-0ad7-0df8-8f0f" name="Halfling Fortune Teller [51 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b46-a320-d4c8-6ce1" type="max"/>
       </constraints>
@@ -669,7 +660,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="855d-c917-3b73-2f38" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -678,7 +669,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="623e-9e06-264e-c979" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -687,7 +678,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -704,7 +695,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0ab-063d-6822-a803" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -713,7 +704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -736,7 +727,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -754,7 +745,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="45.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -778,7 +769,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -786,7 +777,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f95-376f-1f4a-b62a" name="Spirit Guides" hidden="false" collective="false" type="upgrade">
@@ -803,7 +794,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -811,7 +802,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -827,7 +818,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8694-de67-033e-6e89" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -839,7 +830,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffd6-088f-3860-a2a7" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -851,7 +842,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f81-a6e7-f754-4f5b" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -863,7 +854,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e909-9414-093a-938d" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -875,7 +866,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd56-9008-3bf1-7e25" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -887,7 +878,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78fe-0325-3cd6-0df7" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -899,7 +890,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f942-2fde-bd85-c35b" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -911,7 +902,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="42ba-bf6d-ae9c-c0a0" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -923,7 +914,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a922-cd29-1ab1-fde2" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -935,7 +926,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="85d9-7edb-2684-f909" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -947,7 +938,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a90a-507f-1346-c7de" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -959,7 +950,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e20d-b40e-00ab-de80" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -971,7 +962,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc99-b403-0ef3-ec6c" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -983,7 +974,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1000,7 +991,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98f5-7e62-7e5a-a589" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1009,7 +1000,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18a5-27ab-cbb8-9e02" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1018,7 +1009,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36a4-b006-6e1a-47b7" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1027,7 +1018,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44a8-6cdb-a591-c5a7" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1036,7 +1027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="82e8-b315-c4ce-5ab1" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1045,7 +1036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c384-dadd-fadd-4c51" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1054,7 +1045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="57e2-6056-2442-9e07" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1063,7 +1054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e8fa-1465-1ab9-b874" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1072,7 +1063,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="47c0-e7c7-e115-9899" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1081,7 +1072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f711-1a08-7701-94bc" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1090,7 +1081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2cf2-7d1b-16b0-1de2" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1099,7 +1090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4cec-0dae-1caf-25e7" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1108,7 +1099,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="69df-5769-e05f-fb98" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1117,7 +1108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1133,7 +1124,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e1b9-4f9f-fa7b-dd8a" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1142,7 +1133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bfd7-d0c1-6fad-b2bd" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1151,7 +1142,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6856-4bcc-a81a-a70e" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1160,7 +1151,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d989-27f2-c683-fcbc" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1169,7 +1160,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="54de-cad1-f3b2-6170" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1178,7 +1169,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cafb-d6ac-dae8-6660" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1187,7 +1178,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1195,13 +1186,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8dcb-a098-4ac4-094e" name="Halfling Clan Chief [76 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="3073-8db1-90d1-3678" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
       </infoLinks>
@@ -1222,7 +1210,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="76.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6307-bc33-7de0-0d94" name="Clan Chief in Light Armour" hidden="false" collective="false" type="model">
@@ -1231,7 +1219,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1247,7 +1235,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1264,7 +1252,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="740f-0f75-2fca-c47f" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1273,7 +1261,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1290,7 +1278,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18ea-60fa-6daf-c9dd" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1299,7 +1287,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62a7-2b63-ffb1-a6df" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1308,7 +1296,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1324,7 +1312,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1340,7 +1328,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1357,7 +1345,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27db-415b-be75-94aa" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1366,7 +1354,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bba2-bdd3-8a1f-d0ec" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1375,7 +1363,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1391,7 +1379,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a581-fcb2-8d9b-23cc" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1400,7 +1388,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c113-b6c0-51bf-836e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1409,7 +1397,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="64e2-8887-ab37-3d45" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1418,7 +1406,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a675-8ee6-eb19-925e" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1427,7 +1415,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="377a-fa27-043d-1f1a" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1436,7 +1424,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fa66-177b-9ee6-9387" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1445,7 +1433,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1453,13 +1441,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3eed-5ce8-9c18-f10c" name="Mounted Halfling Clan Chief [87 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="ebc6-cb05-9577-16d7" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
         <infoLink id="54bb-2468-e7df-a5d0" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
@@ -1481,7 +1466,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="87.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f12-ab2c-9701-24cc" name="Clan Chief in Light Armour" hidden="false" collective="false" type="model">
@@ -1490,7 +1475,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="97.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1506,7 +1491,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1523,7 +1508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e42c-a8d2-a6c6-e4fc" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1532,7 +1517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1549,7 +1534,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df88-9573-39dc-8d71" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1558,7 +1543,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30e1-e3d1-63c1-8325" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1567,7 +1552,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1583,7 +1568,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1600,7 +1585,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="963e-e2cb-dd16-a2be" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1609,7 +1594,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44a3-6d7b-f763-cbb8" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1618,7 +1603,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1634,7 +1619,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1650,7 +1635,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="68f9-fe1e-70bd-534f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1659,7 +1644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a2a1-3513-f2c9-a58a" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1668,7 +1653,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6716-3cf0-73c6-27b5" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1677,7 +1662,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a91-50cf-1dd2-831d" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1686,7 +1671,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ab1a-b3b3-b4d3-e21c" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1695,7 +1680,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88a6-fdec-8403-c698" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1704,7 +1689,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1712,13 +1697,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="19e0-8c7c-366c-d7d0" name="Halfling Sheriffs [47 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="58b0-8f0e-5974-caef" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
@@ -1745,7 +1727,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95d3-8149-6187-d6cd" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1761,7 +1743,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5cb-3200-ac5c-1d1c" name="Staves" hidden="false" collective="false" type="upgrade">
@@ -1770,7 +1752,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1793,7 +1775,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6bcb-e409-ee0a-e017" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -1809,7 +1791,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1825,7 +1807,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1850,7 +1832,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="364e-cc5f-1aea-94e5" name="Halfling Sheriffs" hidden="false" collective="false" type="model">
@@ -1863,7 +1845,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1871,7 +1853,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f11c-4a92-d889-7459" name="Sheriffs in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1888,7 +1870,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="95e1-8e9b-f11d-2a5a" name="Halfling Sheriffs" hidden="false" collective="false" type="model">
@@ -1901,7 +1883,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1909,7 +1891,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1932,7 +1914,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1940,13 +1922,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0545-0a42-e1f7-1b28" name="Halfling Militia [42 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="3e7b-2996-2b0a-b4be" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1964,7 +1943,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7fd4-635d-49df-f7b3" name="Halfling Militia" hidden="false" collective="false" type="model">
@@ -1977,7 +1956,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="6.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1993,7 +1972,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2016,7 +1995,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2032,7 +2011,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2056,7 +2035,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d12-d5be-81f0-dfce" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2072,7 +2051,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a07f-6229-8a1b-41d6" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2088,7 +2067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="361a-0092-7d5d-acbb" name="Club" hidden="false" collective="false" type="upgrade">
@@ -2097,7 +2076,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6415-c6fc-feb6-0717" name="Cudgel" hidden="false" collective="false" type="upgrade">
@@ -2106,7 +2085,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af91-65c7-6253-67b5" name="Staves" hidden="false" collective="false" type="upgrade">
@@ -2122,7 +2101,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2130,13 +2109,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ad9d-9e1b-c214-43c1" name="Halfling Archers [52 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="b163-839c-21e9-2497" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -2153,7 +2129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8c21-9f4e-34bf-5f04" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -2169,7 +2145,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2187,7 +2163,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fcbb-51f2-f96c-c4da" name="Archer" hidden="false" collective="false" type="model">
@@ -2200,7 +2176,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2224,7 +2200,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1335-03d3-3c17-41f9" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2240,7 +2216,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="97e3-1af0-2de6-3c95" name="Club" hidden="false" collective="false" type="upgrade">
@@ -2249,7 +2225,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ad48-1bc6-547c-af95" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -2265,7 +2241,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -2283,7 +2259,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2306,7 +2282,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2314,13 +2290,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="00b9-460a-80f2-affb" name="Halfling Urchin Swarm [141 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="5702-500b-e79d-d4d7" name="New CategoryLink" hidden="false" targetId="c820-d327-811d-1144" primary="true"/>
       </categoryLinks>
@@ -2337,7 +2310,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="47.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2353,7 +2326,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2376,7 +2349,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2399,7 +2372,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2407,13 +2380,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="24b7-8d95-bb2a-1795" name="Mounted Halflings [63 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="36c1-a5f8-fe10-ae8b" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
         <infoLink id="62ee-792f-bc27-4ee9" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
@@ -2442,7 +2412,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="93a1-252a-d1db-d1ee" name="Mounted Halfling" hidden="false" collective="false" type="model">
@@ -2455,7 +2425,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2463,7 +2433,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="54d6-172a-2723-352e" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2480,7 +2450,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5ef4-2e25-c462-83e9" name="Mounted Halfling" hidden="false" collective="false" type="model">
@@ -2493,7 +2463,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2501,7 +2471,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2517,7 +2487,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2534,7 +2504,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4031-752e-741a-5060" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2543,7 +2513,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8f83-9b07-33a2-3550" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2552,7 +2522,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2575,7 +2545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2583,13 +2553,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="87d2-b341-dc57-0825" name="Halfling Stone Thrower [72 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="344e-8498-6d57-e0cb" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2608,7 +2575,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="6.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2625,7 +2592,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2649,7 +2616,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5de3-ff28-8c06-7e79" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2665,7 +2632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4985-ebaa-f7e1-ce89" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -2674,7 +2641,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2682,13 +2649,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bac5-4a06-ae31-2485" name="Halfling Bolt Thrower [60 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="5ad0-37c1-0960-3fca" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2707,7 +2671,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="6.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2724,7 +2688,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2748,7 +2712,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0822-daf3-42c9-e209" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2764,7 +2728,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e261-5f7e-70f0-43b7" name="Clubs" hidden="false" collective="false" type="upgrade">
@@ -2773,7 +2737,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2789,7 +2753,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2797,7 +2761,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Halflings.cat
+++ b/Halflings.cat
@@ -126,7 +126,7 @@
             </selectionEntry>
             <selectionEntry id="1095-ef0c-84fa-c09d" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="b2d2-2221-fc31-7ce6" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="b2d2-2221-fc31-7ce6" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -394,7 +394,7 @@
             </selectionEntry>
             <selectionEntry id="ed7e-3922-a815-9f0e" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="66c6-db4c-e6b7-d3a8" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="66c6-db4c-e6b7-d3a8" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1144,7 +1144,7 @@
             </selectionEntry>
             <selectionEntry id="27db-415b-be75-94aa" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="a01e-4397-3146-e7d1" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="a01e-4397-3146-e7d1" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1317,7 +1317,7 @@
             </selectionEntry>
             <selectionEntry id="963e-e2cb-dd16-a2be" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="c3af-aba3-4673-d672" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="c3af-aba3-4673-d672" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1399,7 +1399,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="db01-94c1-37bf-fe30" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="db01-94c1-37bf-fe30" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1707,7 +1707,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="19c7-c238-7ca0-4067" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="19c7-c238-7ca0-4067" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1911,7 +1911,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="fd87-8b04-3715-6bd5" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="fd87-8b04-3715-6bd5" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2170,7 +2170,7 @@
             </selectionEntry>
             <selectionEntry id="4031-752e-741a-5060" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="1417-c0c5-4ca6-3e7e" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="1417-c0c5-4ca6-3e7e" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2289,7 +2289,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="fbec-1fad-5be6-6fda" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="fbec-1fad-5be6-6fda" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2383,7 +2383,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="6f8c-6dbc-4dd8-a305" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="6f8c-6dbc-4dd8-a305" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>

--- a/Halflings.cat
+++ b/Halflings.cat
@@ -25,7 +25,7 @@
         <categoryLink id="d513-47b8-993e-219f" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6da9-935c-7659-73eb" name="Models" hidden="false" collective="false" defaultSelectionEntryId="0798-8eb0-7e9b-26ea">
+        <selectionEntryGroup id="6da9-935c-7659-73eb" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="0798-8eb0-7e9b-26ea">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f54-e1d6-a89a-b781" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5aa0-8710-fbf8-2fab" type="max"/>
@@ -115,18 +115,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="030b-b57e-0f96-6135" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="12b1-9fd7-1c2b-631d" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="12b1-9fd7-1c2b-631d" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="1a17-61d4-cbd1-f71a" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1095-ef0c-84fa-c09d" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b2d2-2221-fc31-7ce6" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -383,18 +374,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb97-0037-46f2-3ced" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6a44-018b-9e02-fde9" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6a44-018b-9e02-fde9" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="5e6c-b1aa-351b-b5b0" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ed7e-3922-a815-9f0e" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="66c6-db4c-e6b7-d3a8" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -506,6 +488,9 @@
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b46-a320-d4c8-6ce1" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="6c6f-bf7a-bcff-5a3e" name="Cudgel" hidden="false" targetId="1f70-2881-7206-2fe9" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="f21b-e859-f494-7df7" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
         <categoryLink id="23de-2f5d-6192-5552" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1133,18 +1118,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cf5-c617-86bb-e770" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="2e94-2367-437e-0a6c" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2e94-2367-437e-0a6c" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="51c0-48d4-70c9-8043" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="27db-415b-be75-94aa" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a01e-4397-3146-e7d1" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="51c0-48d4-70c9-8043" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1306,18 +1282,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8049-6cae-8c6d-9bbe" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="096b-7ead-8783-c7d6" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="096b-7ead-8783-c7d6" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="771f-e7c7-aaa4-ae19" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="963e-e2cb-dd16-a2be" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c3af-aba3-4673-d672" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1374,7 +1341,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6213-8863-9abc-a2f0" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3ecd-f387-7bcf-596e" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3ecd-f387-7bcf-596e" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
@@ -1384,22 +1351,6 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="b4f3-c12a-c197-5412" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="95d3-8149-6187-d6cd" name="Axe" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="1">
-                  <repeats>
-                    <repeat field="selections" scope="19e0-8c7c-366c-d7d0" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="db01-94c1-37bf-fe30" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1472,7 +1423,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="08ad-60d8-bd56-4499" name="models" hidden="false" collective="false" defaultSelectionEntryId="ed51-875e-d625-cf70">
+        <selectionEntryGroup id="08ad-60d8-bd56-4499" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="ed51-875e-d625-cf70">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c922-73de-8160-365a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16ba-aef9-d796-d210" type="min"/>
@@ -1590,7 +1541,7 @@
         <categoryLink id="3e7b-2996-2b0a-b4be" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="830e-16e5-506a-4a78" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="830e-16e5-506a-4a78" name="Choose 4 to 9" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="d464-061c-a86a-aa37" name="Militia Leader" hidden="false" collective="false" type="model">
               <constraints>
@@ -1682,7 +1633,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8ff-191c-4614-51c9" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4085-70c3-57c8-14b3" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4085-70c3-57c8-14b3" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="2">
                   <repeats>
@@ -1692,22 +1643,6 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="de1e-5d93-0fd5-0bf2" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5d12-d5be-81f0-dfce" name="Axe" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="2">
-                  <repeats>
-                    <repeat field="selections" scope="0545-0a42-e1f7-1b28" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="19c7-c238-7ca0-4067" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1810,7 +1745,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="de63-8680-81f7-2214" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="de63-8680-81f7-2214" name="Choose 4 to 9" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="476d-0fbc-255f-e614" name="Archer Leader" hidden="false" collective="false" type="model">
               <constraints>
@@ -1886,23 +1821,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4c1-906d-70b7-21c0" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="7de1-706d-e333-acd5" name="Sword" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="2">
-                  <repeats>
-                    <repeat field="selections" scope="ad9d-9e1b-c214-43c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="e74f-31f1-0c6c-4330" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="06e4-660b-17a1-0c90" name="Axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7de1-706d-e333-acd5" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
@@ -1911,7 +1830,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="fd87-8b04-3715-6bd5" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="e74f-31f1-0c6c-4330" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2019,7 +1938,7 @@
           <selectionEntries>
             <selectionEntry id="f6f6-e0ff-b272-49e5" name="Slings" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="9">
+                <modifier type="increment" field="points" value="9.0">
                   <repeats>
                     <repeat field="selections" scope="00b9-460a-80f2-affb" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -2032,6 +1951,11 @@
                 <cost name="pts" typeId="points" value="0.0"/>
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
+            </selectionEntry>
+            <selectionEntry id="046f-eecd-b703-c680" name="Rocks" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="468a-6204-4f2c-4cc4" name="Rocks (thrown)" hidden="false" targetId="73f5-966d-080a-53a6" type="profile"/>
+              </infoLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -2159,18 +2083,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bc8-bf1c-703c-2354" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="1611-e5e9-a46c-fc13" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1611-e5e9-a46c-fc13" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="19ad-d710-9b58-931c" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4031-752e-741a-5060" name="Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1417-c0c5-4ca6-3e7e" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2229,8 +2144,8 @@
           </constraints>
           <infoLinks>
             <infoLink id="de66-d95f-64fe-c258" name="Small Stone Thrower" hidden="false" targetId="fee6-c34d-8a5d-a9e6" type="profile"/>
-            <infoLink id="26d8-b582-f646-c6d0" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
             <infoLink id="5dcb-7487-b715-48f9" name="Overhead" hidden="false" targetId="7751-622a-b896-4874" type="rule"/>
+            <infoLink id="555e-fb13-4cf7-9127" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="54.0"/>
@@ -2239,7 +2154,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ce57-a11e-ac45-94e0" name="Halfling Crew" hidden="false" collective="false" defaultSelectionEntryId="0398-de31-9e78-6110">
+        <selectionEntryGroup id="ce57-a11e-ac45-94e0" name="Choose 3 to 5" hidden="false" collective="false" defaultSelectionEntryId="0398-de31-9e78-6110">
           <selectionEntries>
             <selectionEntry id="0398-de31-9e78-6110" name="Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -2264,7 +2179,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d99-87b1-453e-6699" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8252-66f4-5467-b709" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8252-66f4-5467-b709" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="2">
                   <repeats>
@@ -2274,22 +2189,6 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="09f9-b43a-ce4f-1329" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5de3-ff28-8c06-7e79" name="Axe" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="2">
-                  <repeats>
-                    <repeat field="selections" scope="87d2-b341-dc57-0825" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="fbec-1fad-5be6-6fda" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2333,7 +2232,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a761-cc8e-148d-3f5b" name="Halfling Crew" hidden="false" collective="false" defaultSelectionEntryId="b7f1-e372-2316-27e2">
+        <selectionEntryGroup id="a761-cc8e-148d-3f5b" name="Choose 3 to 5" hidden="false" collective="false" defaultSelectionEntryId="b7f1-e372-2316-27e2">
           <selectionEntries>
             <selectionEntry id="b7f1-e372-2316-27e2" name="Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -2358,7 +2257,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d8d-4a97-3e5e-2589" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ac04-e4f6-64c6-92cb" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ac04-e4f6-64c6-92cb" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="2">
                   <repeats>
@@ -2368,22 +2267,6 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="e73b-905f-e92e-3c8a" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0822-daf3-42c9-e209" name="Axe" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="2">
-                  <repeats>
-                    <repeat field="selections" scope="bac5-4a06-ae31-2485" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="6f8c-6dbc-4dd8-a305" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2673,7 +2556,7 @@ Re-roll hits on unit if in cover.</description>
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="73f5-966d-080a-53a6" name="Rocks (thrown)" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="73f5-966d-080a-53a6" name="Rocks (thrown)" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>

--- a/Halflings.cat
+++ b/Halflings.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="745c-5adf-6444-cac7" name="Halflings" revision="1" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="745c-5adf-6444-cac7" name="Halflings" revision="2" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d891-2083-8b78-b275" name="Halfling Chief Cheriff [85 pts]" hidden="false" collective="false" targetId="c9ff-893e-2ec9-3544" type="selectionEntry"/>
     <entryLink id="748f-2466-4dcf-674f" name="Halfling Chief Sheriff in Cart [130 pts]" hidden="false" collective="false" targetId="6a05-8937-f0c2-efaa" type="selectionEntry"/>
@@ -16,6 +16,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="c9ff-893e-2ec9-3544" name="Halfling Chief Sheriff [85 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="1a7f-ec79-5436-2ba0" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="dd40-1170-66ad-3992" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -45,6 +48,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="69.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="66e8-ed3b-530e-0911" name="Henchmen" hidden="false" collective="false" type="model">
@@ -57,6 +61,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -64,6 +69,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c11-8bf4-3580-e403" name="Light Armour (10pts + 2pts per Henchmen)" hidden="false" collective="false" type="upgrade">
@@ -80,6 +86,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="79.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="7adf-df3c-4c6d-b8b4" name="Henchmen" hidden="false" collective="false" type="model">
@@ -92,6 +99,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -99,6 +107,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -115,6 +124,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1095-ef0c-84fa-c09d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -123,6 +133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="13d7-55cd-a401-ee1d" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -131,6 +142,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -146,6 +158,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -168,6 +181,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2350-2378-061f-0248" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -183,6 +197,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -205,6 +220,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -221,6 +237,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7385-dfc0-975d-c7f0" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -229,6 +246,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -245,6 +263,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8e5c-b2b2-fe84-aec4" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -253,6 +272,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -268,6 +288,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="03f7-9a1e-3658-77d1" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -276,6 +297,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7279-b221-bae1-afda" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -284,6 +306,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7c2b-b70c-dc06-1911" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -292,6 +315,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bbe-8769-e446-3925" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -300,6 +324,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a973-4a7c-756a-11b8" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -308,6 +333,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e3c-9fd8-e44e-3485" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -316,6 +342,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -323,9 +350,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6a05-8937-f0c2-efaa" name="Halfling Chief Sheriff in Cart [130 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="54b0-1542-a426-c212" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="f643-fe7d-7715-b283" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -348,6 +379,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0d87-0c59-7871-784a" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -356,6 +388,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -372,6 +405,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b6bc-3982-cbe6-426a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -380,6 +414,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -396,6 +431,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed7e-3922-a815-9f0e" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -404,6 +440,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f5c7-7f85-db23-2118" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -412,6 +449,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -427,6 +465,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -449,6 +488,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -461,6 +501,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -480,6 +521,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -496,6 +538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -512,6 +555,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="130.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9eac-ba4f-c7b9-bd6d" name="Halfling Chief Sheriff in Light Armour (on Foot)" hidden="false" collective="false" type="model">
@@ -520,6 +564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="140.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -535,6 +580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d29b-0232-16d2-edf2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -543,6 +589,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b2b0-799a-e3fa-0669" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -551,6 +598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e9ff-cae1-c686-6e1a" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -559,6 +607,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="063a-988e-aa82-6815" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -567,6 +616,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c60a-3804-e4d0-d447" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -575,6 +625,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ab2-e0c3-669c-4672" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -583,6 +634,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -590,9 +642,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a39d-0ad7-0df8-8f0f" name="Halfling Fortune Teller [51 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b46-a320-d4c8-6ce1" type="max"/>
       </constraints>
@@ -613,6 +669,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="855d-c917-3b73-2f38" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -621,6 +678,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="623e-9e06-264e-c979" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -629,6 +687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -645,6 +704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0ab-063d-6822-a803" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -653,6 +713,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -675,6 +736,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -692,6 +754,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="45.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -715,6 +778,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -722,6 +786,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f95-376f-1f4a-b62a" name="Spirit Guides" hidden="false" collective="false" type="upgrade">
@@ -738,6 +803,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -745,6 +811,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -760,6 +827,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8694-de67-033e-6e89" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -771,6 +839,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffd6-088f-3860-a2a7" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -782,6 +851,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f81-a6e7-f754-4f5b" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -793,6 +863,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e909-9414-093a-938d" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -804,6 +875,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd56-9008-3bf1-7e25" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -815,6 +887,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78fe-0325-3cd6-0df7" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -826,6 +899,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f942-2fde-bd85-c35b" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -837,6 +911,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="42ba-bf6d-ae9c-c0a0" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -848,6 +923,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a922-cd29-1ab1-fde2" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -859,6 +935,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="85d9-7edb-2684-f909" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -870,6 +947,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a90a-507f-1346-c7de" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -881,6 +959,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e20d-b40e-00ab-de80" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -892,6 +971,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc99-b403-0ef3-ec6c" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -903,6 +983,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -919,6 +1000,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98f5-7e62-7e5a-a589" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -927,6 +1009,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18a5-27ab-cbb8-9e02" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -935,6 +1018,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36a4-b006-6e1a-47b7" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -943,6 +1027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44a8-6cdb-a591-c5a7" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -951,6 +1036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="82e8-b315-c4ce-5ab1" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -959,6 +1045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c384-dadd-fadd-4c51" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -967,6 +1054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="57e2-6056-2442-9e07" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -975,6 +1063,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e8fa-1465-1ab9-b874" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -983,6 +1072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="47c0-e7c7-e115-9899" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -991,6 +1081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f711-1a08-7701-94bc" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -999,6 +1090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2cf2-7d1b-16b0-1de2" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1007,6 +1099,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4cec-0dae-1caf-25e7" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1015,6 +1108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="69df-5769-e05f-fb98" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1023,6 +1117,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1038,6 +1133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e1b9-4f9f-fa7b-dd8a" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1046,6 +1142,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bfd7-d0c1-6fad-b2bd" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1054,6 +1151,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6856-4bcc-a81a-a70e" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1062,6 +1160,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d989-27f2-c683-fcbc" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1070,6 +1169,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="54de-cad1-f3b2-6170" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1078,6 +1178,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cafb-d6ac-dae8-6660" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1086,6 +1187,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1093,9 +1195,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8dcb-a098-4ac4-094e" name="Halfling Clan Chief [76 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="3073-8db1-90d1-3678" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
       </infoLinks>
@@ -1116,6 +1222,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="76.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6307-bc33-7de0-0d94" name="Clan Chief in Light Armour" hidden="false" collective="false" type="model">
@@ -1124,6 +1231,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1139,6 +1247,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1155,6 +1264,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="740f-0f75-2fca-c47f" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1163,6 +1273,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1179,6 +1290,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18ea-60fa-6daf-c9dd" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1187,6 +1299,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62a7-2b63-ffb1-a6df" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1195,6 +1308,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1210,6 +1324,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1225,6 +1340,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1241,6 +1357,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27db-415b-be75-94aa" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1249,6 +1366,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bba2-bdd3-8a1f-d0ec" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1257,6 +1375,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1272,6 +1391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a581-fcb2-8d9b-23cc" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1280,6 +1400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c113-b6c0-51bf-836e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1288,6 +1409,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="64e2-8887-ab37-3d45" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1296,6 +1418,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a675-8ee6-eb19-925e" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1304,6 +1427,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="377a-fa27-043d-1f1a" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1312,6 +1436,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fa66-177b-9ee6-9387" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1320,6 +1445,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1327,9 +1453,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3eed-5ce8-9c18-f10c" name="Mounted Halfling Clan Chief [87 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="ebc6-cb05-9577-16d7" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
         <infoLink id="54bb-2468-e7df-a5d0" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
@@ -1351,6 +1481,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="87.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f12-ab2c-9701-24cc" name="Clan Chief in Light Armour" hidden="false" collective="false" type="model">
@@ -1359,6 +1490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="97.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1374,6 +1506,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1390,6 +1523,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e42c-a8d2-a6c6-e4fc" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1398,6 +1532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1414,6 +1549,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df88-9573-39dc-8d71" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1422,6 +1558,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="30e1-e3d1-63c1-8325" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1430,6 +1567,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1445,6 +1583,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1461,6 +1600,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="963e-e2cb-dd16-a2be" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1469,6 +1609,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44a3-6d7b-f763-cbb8" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1477,6 +1618,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1492,6 +1634,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1507,6 +1650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="68f9-fe1e-70bd-534f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1515,6 +1659,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a2a1-3513-f2c9-a58a" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1523,6 +1668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6716-3cf0-73c6-27b5" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1531,6 +1677,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a91-50cf-1dd2-831d" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1539,6 +1686,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ab1a-b3b3-b4d3-e21c" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1547,6 +1695,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88a6-fdec-8403-c698" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1555,6 +1704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1562,11 +1712,15 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="19e0-8c7c-366c-d7d0" name="Halfling Sheriffs [47 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
-        <infoLink id="58b0-8f0e-5974-caef" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="58b0-8f0e-5974-caef" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ad7c-763f-905f-fbf6" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -1591,6 +1745,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95d3-8149-6187-d6cd" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1606,6 +1761,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5cb-3200-ac5c-1d1c" name="Staves" hidden="false" collective="false" type="upgrade">
@@ -1614,6 +1770,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1636,6 +1793,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6bcb-e409-ee0a-e017" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -1651,6 +1809,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1666,6 +1825,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1690,6 +1850,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="364e-cc5f-1aea-94e5" name="Halfling Sheriffs" hidden="false" collective="false" type="model">
@@ -1702,6 +1863,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1709,6 +1871,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f11c-4a92-d889-7459" name="Sheriffs in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1725,6 +1888,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="95e1-8e9b-f11d-2a5a" name="Halfling Sheriffs" hidden="false" collective="false" type="model">
@@ -1737,6 +1901,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1744,6 +1909,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1766,6 +1932,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1773,9 +1940,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0545-0a42-e1f7-1b28" name="Halfling Militia [42 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3e7b-2996-2b0a-b4be" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1793,6 +1964,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7fd4-635d-49df-f7b3" name="Halfling Militia" hidden="false" collective="false" type="model">
@@ -1805,6 +1977,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="6.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1820,6 +1993,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1842,6 +2016,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1857,6 +2032,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1880,6 +2056,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d12-d5be-81f0-dfce" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1895,6 +2072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a07f-6229-8a1b-41d6" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1910,6 +2088,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="361a-0092-7d5d-acbb" name="Club" hidden="false" collective="false" type="upgrade">
@@ -1918,6 +2097,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6415-c6fc-feb6-0717" name="Cudgel" hidden="false" collective="false" type="upgrade">
@@ -1926,6 +2106,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af91-65c7-6253-67b5" name="Staves" hidden="false" collective="false" type="upgrade">
@@ -1941,6 +2122,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1948,9 +2130,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ad9d-9e1b-c214-43c1" name="Halfling Archers [52 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b163-839c-21e9-2497" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1967,6 +2153,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8c21-9f4e-34bf-5f04" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -1982,6 +2169,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1999,6 +2187,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fcbb-51f2-f96c-c4da" name="Archer" hidden="false" collective="false" type="model">
@@ -2011,6 +2200,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="8.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2034,6 +2224,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1335-03d3-3c17-41f9" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2049,6 +2240,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="97e3-1af0-2de6-3c95" name="Club" hidden="false" collective="false" type="upgrade">
@@ -2057,6 +2249,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="ad48-1bc6-547c-af95" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -2072,6 +2265,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -2089,6 +2283,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2111,6 +2306,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2118,9 +2314,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="00b9-460a-80f2-affb" name="Halfling Urchin Swarm [141 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5702-500b-e79d-d4d7" name="New CategoryLink" hidden="false" targetId="c820-d327-811d-1144" primary="true"/>
       </categoryLinks>
@@ -2137,6 +2337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="47.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2152,6 +2353,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2174,6 +2376,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2196,6 +2399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2203,12 +2407,16 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="24b7-8d95-bb2a-1795" name="Mounted Halflings [63 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="36c1-a5f8-fe10-ae8b" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-        <infoLink id="62ee-792f-bc27-4ee9" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="62ee-792f-bc27-4ee9" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1971-4957-7a2d-ce24" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
@@ -2234,6 +2442,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="29.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="93a1-252a-d1db-d1ee" name="Mounted Halfling" hidden="false" collective="false" type="model">
@@ -2246,6 +2455,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2253,6 +2463,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="54d6-172a-2723-352e" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2269,6 +2480,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5ef4-2e25-c462-83e9" name="Mounted Halfling" hidden="false" collective="false" type="model">
@@ -2281,6 +2493,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2288,6 +2501,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2303,6 +2517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2319,6 +2534,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4031-752e-741a-5060" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2327,6 +2543,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8f83-9b07-33a2-3550" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2335,6 +2552,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2357,6 +2575,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2364,9 +2583,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="87d2-b341-dc57-0825" name="Halfling Stone Thrower [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="344e-8498-6d57-e0cb" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2385,6 +2608,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="6.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2401,6 +2625,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2424,6 +2649,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5de3-ff28-8c06-7e79" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2439,6 +2665,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4985-ebaa-f7e1-ce89" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -2447,6 +2674,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2454,9 +2682,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bac5-4a06-ae31-2485" name="Halfling Bolt Thrower [60 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5ad0-37c1-0960-3fca" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2475,6 +2707,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="6.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2491,6 +2724,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2514,6 +2748,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0822-daf3-42c9-e209" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2529,6 +2764,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e261-5f7e-70f0-43b7" name="Clubs" hidden="false" collective="false" type="upgrade">
@@ -2537,6 +2773,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2552,6 +2789,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2559,6 +2797,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Knights working copy v1.cat
+++ b/Knights working copy v1.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2855-3dab-f953-6528" name="Knights" revision="3" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2855-3dab-f953-6528" name="Knights" revision="4" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d945-4af9-b188-d23e" name="Court Wizard" hidden="false" collective="false" targetId="4e36-8ca9-21c5-f370" type="selectionEntry"/>
     <entryLink id="a117-4d48-a7c7-ed6c" name="Foot Knights" hidden="false" collective="false" targetId="2296-e410-da07-d236" type="selectionEntry"/>
@@ -37,14 +37,11 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4e36-8ca9-21c5-f370" name="Court Wizard (56 pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="326e-0e5e-49ee-cb8c" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="808b-dab8-1c77-d697" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+        <infoLink id="808b-dab8-1c77-d697" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="702e-b284-c94a-d8bc" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
@@ -65,7 +62,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="55.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -82,7 +79,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f6c-e715-66f1-7d0c" name="Tough Lvl 2" hidden="false" collective="false" type="upgrade">
@@ -91,7 +88,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -108,7 +105,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -136,7 +133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3208-10c7-f7db-ecc0" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -145,7 +142,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="08db-1b7a-ac6c-3e95" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -154,7 +151,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -177,7 +174,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -185,7 +182,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f0e-2c55-63ab-5296" name="Wizards Familiars" hidden="false" collective="false" type="upgrade">
@@ -202,7 +199,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -210,7 +207,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -227,7 +224,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="440d-72f7-f47d-9715" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -236,7 +233,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d9c-a064-187b-5c99" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -245,7 +242,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad45-daa5-dd02-ddec" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -254,7 +251,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d6f2-3852-2a24-4a1c" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -263,7 +260,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87f7-1236-a1a3-ea1e" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -272,7 +269,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ce9-bc0a-a30a-1c8b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -281,7 +278,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c07c-9d16-21e5-0feb" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -290,7 +287,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a7de-f6a3-5498-6a3b" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -299,7 +296,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6630-5ea8-bf55-4b5c" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -308,7 +305,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ecf9-32b3-d437-cce3" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -317,7 +314,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff03-207d-b5fa-5595" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -326,7 +323,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1dea-a210-287f-2705" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -335,7 +332,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8580-b297-4f17-698e" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -344,7 +341,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -360,7 +357,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5ac-60df-2376-b997" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -372,7 +369,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bff-e72b-9032-3e03" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -384,7 +381,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ce1-b9ca-4e65-b6ac" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -396,7 +393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e33-b72a-d19e-bc45" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -408,7 +405,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bd5-8da3-0c1a-c789" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -420,7 +417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5e18-79d3-01dd-f1d3" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -432,7 +429,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="538c-ac74-2847-0992" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -444,7 +441,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="620c-21b8-9463-3cb2" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -456,7 +453,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5f38-2b66-4069-0456" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -468,7 +465,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04e0-0e54-7f46-4e78" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -480,7 +477,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="81fc-daf9-0b1b-1b51" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -492,7 +489,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed3c-182f-f9fd-e59a" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -504,7 +501,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da40-ee64-4a81-3605" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -516,7 +513,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -532,7 +529,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="caa3-78c5-5995-ba58" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -541,7 +538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5dbb-b1fe-a8ed-bb90" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -550,7 +547,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99e9-0302-37ed-754d" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -559,7 +556,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5588-ad6d-2a56-3afc" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -568,7 +565,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e814-80c1-10c6-00e7" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -577,7 +574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e313-6747-96ce-f6fa" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -586,7 +583,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -594,13 +591,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2296-e410-da07-d236" name="Foot Knights (77pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="2da5-f815-5f05-5d85" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
       </infoLinks>
@@ -621,7 +615,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7945-8dc5-2f0e-02e0" name="Foot Knights" hidden="false" collective="false" type="model">
@@ -634,7 +628,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="13.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -651,7 +645,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83b5-2567-73cc-3512" name="Mace" hidden="false" collective="false" type="upgrade">
@@ -660,7 +654,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="70fa-100a-9ab9-f3e5" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -669,7 +663,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e71b-68a6-a5e9-1ac9" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -678,7 +672,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -702,13 +696,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f2d3-51c1-7590-f825" name="Foot Retainers (72pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="3bfe-a540-57d2-f394" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -734,7 +725,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b637-3ab2-6835-69c0" name="Foot Retainer" hidden="false" collective="false" type="model">
@@ -747,7 +738,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -755,7 +746,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c57c-1e1b-9b14-f4c5" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -772,7 +763,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c664-0e0a-1dba-763b" name="Foot Retainer Sergeant" hidden="false" collective="false" type="model">
@@ -786,7 +777,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -794,7 +785,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -811,7 +802,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="94f1-d8e2-ff21-47de" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -820,7 +811,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="423c-9030-53f6-a19b" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -829,7 +820,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -849,13 +840,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e0e0-025c-09d2-4e02" name="Archers (67pts base)" hidden="false" collective="false" type="upgrade">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="4974-1a8f-32ef-03a6" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -881,7 +869,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1ae1-6a75-6bed-c849" name="Archer" hidden="false" collective="false" type="model">
@@ -894,7 +882,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -902,7 +890,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f718-282b-4899-2bb7" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -920,7 +908,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="40c9-ade9-0f20-5673" name="Archer" hidden="false" collective="false" type="model">
@@ -933,7 +921,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -941,7 +929,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -965,7 +953,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0fb2-1984-62a7-e547" name="Bow" hidden="false" collective="false" type="upgrade">
@@ -974,7 +962,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -998,7 +986,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4297-115f-1e92-90bd" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -1007,7 +995,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1023,7 +1011,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1031,13 +1019,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8d42-0633-18ea-46a3" name="Crossbowmen (72 pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="3367-091b-c4ec-8f3d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1052,7 +1037,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1069,7 +1054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78c7-6f21-1de7-1c4d" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -1085,7 +1070,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1111,7 +1096,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="af26-600e-bb96-14bd" name="Crossbowman Seargeant" hidden="false" collective="false" type="model">
@@ -1125,7 +1110,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1133,7 +1118,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f907-e902-d680-eef5" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1151,7 +1136,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ba87-8a1d-0f2b-0e9d" name="Crossbowman Seargeant" hidden="false" collective="false" type="model">
@@ -1165,7 +1150,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1173,7 +1158,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="976e-0393-e70a-e7eb" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1191,7 +1176,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f44d-41cd-861a-ca35" name="Crossbowman Seargeant" hidden="false" collective="false" type="model">
@@ -1205,7 +1190,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1213,7 +1198,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1221,16 +1206,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8405-fc2d-45e0-0c26" name="Arbalestiers (Hvy Xbow) (72 pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="dc61-2813-ce77-d4a9" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
-        <infoLink id="c63e-ae16-0b08-59f1" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="c63e-ae16-0b08-59f1" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ef51-6251-ce63-2879" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -1246,7 +1228,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1263,7 +1245,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d23b-f47c-042c-60af" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -1279,7 +1261,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1304,7 +1286,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c0c9-e5ae-da5c-56ca" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1317,7 +1299,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1325,7 +1307,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c1be-d060-b37e-f68b" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1342,7 +1324,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="89df-5ba8-5989-2ff0" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1355,7 +1337,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1363,7 +1345,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="748c-126a-41a9-6e54" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1380,7 +1362,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e429-daa6-3d15-0860" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1393,7 +1375,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1401,7 +1383,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="79e7-7ddf-a7f2-d721" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
@@ -1418,7 +1400,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1f64-b27e-78e6-5f00" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1431,7 +1413,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1439,7 +1421,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1462,7 +1444,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1470,13 +1452,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4255-a125-b8e7-427a" name="Peasants (32 pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="27f1-736e-c78c-c79a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1494,7 +1473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ddb3-b98b-1b35-1ffb" name="Peasant Yeoman" hidden="false" collective="false" type="model">
@@ -1509,7 +1488,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1526,7 +1505,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de67-af2c-c065-a27d" name="Pitchforks, Bills or Glaives" hidden="false" collective="false" type="upgrade">
@@ -1542,7 +1521,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ba62-b8d8-499b-8026" name="Cudgel &amp; Slings" hidden="false" collective="false" type="upgrade">
@@ -1559,7 +1538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1567,13 +1546,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f319-8ba2-6e61-a9fc" name="Flagellants (92 pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="412f-bfb8-a4ae-9814" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="462f-3819-73cc-0390" name="Zealous" hidden="false" targetId="45bb-28cf-94fd-f899" type="rule"/>
@@ -1592,7 +1568,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1609,7 +1585,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b79-f7e1-d195-a1ea" name="Flagellant" hidden="false" collective="false" type="model">
@@ -1622,7 +1598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1638,7 +1614,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1646,13 +1622,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7eb6-cd0d-3dbe-5a46" name="Ballista (69 pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="f024-ace8-02e5-ce3b" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="d978-1b52-1278-001d" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1681,7 +1654,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1689,7 +1662,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2dc5-a742-133a-892e" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1706,7 +1679,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1714,7 +1687,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1731,7 +1704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad99-64ce-8898-64d1" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -1740,7 +1713,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1757,7 +1730,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3a5f-e63e-ac56-defd" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1773,7 +1746,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1790,7 +1763,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1798,13 +1771,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f0c0-2cef-09ea-cd94" name="Mangonel (81 pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="c5e5-22a4-b8ec-6bf1" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="2693-e158-7240-eec4" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1833,7 +1803,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1841,7 +1811,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fa22-06bf-2135-79bf" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1858,7 +1828,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1866,7 +1836,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1883,7 +1853,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7f2d-d797-1367-9eeb" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -1892,7 +1862,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="75.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1909,7 +1879,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4f97-a2d2-e312-c471" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1925,7 +1895,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1933,13 +1903,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f453-102d-f811-3d2f" name="Mounted Retainers (72 pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="2794-5bf8-26f4-0118" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -1968,7 +1935,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fd88-c56c-36a4-bbd2" name="Retainer, Riding Horse" hidden="false" collective="false" type="model">
@@ -1981,7 +1948,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1989,7 +1956,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eadb-b8bb-8741-0d60" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2007,7 +1974,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="69de-a24a-1a97-aaa0" name="Retainer, Riding Horse" hidden="false" collective="false" type="model">
@@ -2020,7 +1987,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2028,7 +1995,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2051,7 +2018,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b18-b397-ded2-1804" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -2067,7 +2034,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2084,7 +2051,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="afc0-544a-8a60-8fc3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2093,7 +2060,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fba9-9109-7b43-803d" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -2109,7 +2076,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2117,13 +2084,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ddfa-279f-4b28-fb6a" name="Knights on Warhorses (96 pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="97b8-a305-e7d0-7794" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -2144,7 +2108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="40.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f8ad-f5f3-c04b-89bb" name="Knight, Riding Warhorse" hidden="false" collective="false" type="model">
@@ -2157,7 +2121,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2178,7 +2142,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2195,7 +2159,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5258-8162-38f2-03ea" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2204,7 +2168,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="525e-a9b5-dd1d-95f8" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -2213,7 +2177,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b99-92cf-8f8c-a176" name="Warhammer" hidden="false" collective="false" type="upgrade">
@@ -2222,7 +2186,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="13bc-a627-29f3-7dd0" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -2238,7 +2202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2246,13 +2210,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="634f-e1a7-3261-1cb3" name="Priest (64pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2259-e30c-15f2-5d27" type="max"/>
       </constraints>
@@ -2284,7 +2245,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="64.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ad0c-8963-dd95-1834" name="Supplicant" hidden="false" collective="false" type="model">
@@ -2296,7 +2257,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2304,7 +2265,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8381-b890-cfbf-5149" name="Hair Shirt Armour Upgrade" hidden="false" collective="false" type="upgrade">
@@ -2325,7 +2286,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="74.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1ff2-5e03-69dc-e75c" name="Supplicant" hidden="false" collective="false" type="model">
@@ -2337,7 +2298,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2345,7 +2306,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2362,7 +2323,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e6e-07f5-507a-a342" name="Insufferably Sanctimonious (Tough 2)" hidden="false" collective="false" type="upgrade">
@@ -2371,7 +2332,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2387,7 +2348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="34c1-fc8d-c37e-265e" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2396,7 +2357,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95ab-4993-696f-b1d6" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2405,7 +2366,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58a8-95c6-cd47-b2d3" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2414,7 +2375,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c984-fb5e-6157-f5fa" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2423,7 +2384,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b362-21f8-9320-c5dd" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2432,7 +2393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5c8c-b804-9281-c4b6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2441,7 +2402,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2449,13 +2410,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8927-f10c-9b13-777a" name="Knightly Chamption" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c16-c59b-9330-4278" type="max"/>
       </constraints>
@@ -2480,7 +2438,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2496,7 +2454,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2513,7 +2471,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7142-85d5-6100-3b00" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2522,7 +2480,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2539,7 +2497,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02b6-e293-1eaa-aa89" name="Upgrade to Wound 3" hidden="false" collective="false" type="upgrade">
@@ -2548,7 +2506,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ac9-b8b0-e85a-dcaf" name="Wound" hidden="false" collective="false" type="upgrade">
@@ -2557,7 +2515,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2573,7 +2531,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bbd3-01a1-1f47-338b" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2582,7 +2540,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6002-14c0-1adb-94cc" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2591,7 +2549,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99cb-1ec6-2f3b-b47b" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2600,7 +2558,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bbf9-0621-c970-a187" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2609,7 +2567,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2bff-c278-4a7a-a0c0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2618,7 +2576,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b0da-20ef-e2f7-4d9c" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2627,7 +2585,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2635,13 +2593,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="96.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="21a8-e570-5189-b243" name="Mounted Lord Knight (128 pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="7ac0-7f8a-f5e0-58c6" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="921e-59fc-b679-c149" name="Mounted Unit" hidden="false" targetId="mounted unit" primary="false"/>
@@ -2661,7 +2616,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="88.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2e7d-6a10-5f2d-6186" name="Knights, Riding Horse" hidden="false" collective="false" type="model">
@@ -2675,7 +2630,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2692,7 +2647,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad2a-cd99-78eb-2e2e" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2701,7 +2656,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1605-9eb3-ff1b-cf99" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -2717,7 +2672,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2740,7 +2695,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2757,7 +2712,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="134a-2a30-4126-b981" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2766,7 +2721,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2783,7 +2738,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5763-1cd3-5807-b782" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2792,7 +2747,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2816,7 +2771,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc56-e07d-912e-4ec7" name="Regular Horses" hidden="false" collective="false" type="upgrade">
@@ -2825,7 +2780,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2841,7 +2796,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4a8c-a520-95bf-f664" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2850,7 +2805,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="01a5-b233-5dc6-1855" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2859,7 +2814,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9611-8723-3219-ca80" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2868,7 +2823,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e372-fa4b-f227-9512" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2877,7 +2832,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fb2f-c702-fc87-989d" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2886,7 +2841,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="14c4-c81e-9719-ce60" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2895,7 +2850,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2903,13 +2858,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="671a-408e-2386-3c7e" name="Lord Knight (106 pts base)" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="afab-21d2-59da-ee82" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
       </categoryLinks>
@@ -2929,7 +2881,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="78.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac70-dd1d-aa51-2021" name="Knights" hidden="false" collective="false" type="model">
@@ -2942,7 +2894,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2959,7 +2911,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2cc5-0e7a-0c1e-5053" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2968,7 +2920,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66b0-aaf8-4e03-e8f6" name="Chain Mace" hidden="false" collective="false" type="upgrade">
@@ -2977,7 +2929,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4703-1bb9-d4cc-e959" name="Morning Star" hidden="false" collective="false" type="upgrade">
@@ -2986,7 +2938,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b9a-a7d1-e934-6569" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -2995,7 +2947,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="848d-5c98-7dbb-3651" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -3004,7 +2956,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3024,7 +2976,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3041,7 +2993,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a74e-66c0-e86b-e60c" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -3050,7 +3002,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3067,7 +3019,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df6b-4c99-d4a9-bc16" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -3076,7 +3028,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3092,7 +3044,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62b6-feac-9c47-e8e3" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -3101,7 +3053,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="61c7-1d0a-eee4-ea38" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -3110,7 +3062,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="511a-0396-1178-9bd1" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -3119,7 +3071,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f9f1-6634-a352-cd12" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -3128,7 +3080,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55c2-c307-547b-2719" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -3137,7 +3089,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f92-e097-7f60-5a03" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -3146,7 +3098,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3154,7 +3106,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Knights working copy v1.cat
+++ b/Knights working copy v1.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2855-3dab-f953-6528" name="Knights" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2855-3dab-f953-6528" name="Knights" revision="3" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="d945-4af9-b188-d23e" name="Court Wizard" hidden="false" collective="false" targetId="4e36-8ca9-21c5-f370" type="selectionEntry"/>
     <entryLink id="a117-4d48-a7c7-ed6c" name="Foot Knights" hidden="false" collective="false" targetId="2296-e410-da07-d236" type="selectionEntry"/>
@@ -37,6 +37,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4e36-8ca9-21c5-f370" name="Court Wizard (56 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="326e-0e5e-49ee-cb8c" type="max"/>
       </constraints>
@@ -62,6 +65,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="55.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -78,6 +82,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f6c-e715-66f1-7d0c" name="Tough Lvl 2" hidden="false" collective="false" type="upgrade">
@@ -86,6 +91,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -102,6 +108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -129,6 +136,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3208-10c7-f7db-ecc0" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -137,6 +145,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="08db-1b7a-ac6c-3e95" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -145,6 +154,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -167,6 +177,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -174,6 +185,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f0e-2c55-63ab-5296" name="Wizards Familiars" hidden="false" collective="false" type="upgrade">
@@ -190,6 +202,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -197,6 +210,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -213,6 +227,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="440d-72f7-f47d-9715" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -221,6 +236,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d9c-a064-187b-5c99" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -229,6 +245,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad45-daa5-dd02-ddec" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -237,6 +254,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d6f2-3852-2a24-4a1c" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -245,6 +263,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87f7-1236-a1a3-ea1e" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -253,6 +272,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ce9-bc0a-a30a-1c8b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -261,6 +281,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c07c-9d16-21e5-0feb" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -269,6 +290,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a7de-f6a3-5498-6a3b" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -277,6 +299,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6630-5ea8-bf55-4b5c" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -285,6 +308,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ecf9-32b3-d437-cce3" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -293,6 +317,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff03-207d-b5fa-5595" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -301,6 +326,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1dea-a210-287f-2705" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -309,6 +335,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8580-b297-4f17-698e" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -317,6 +344,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -332,6 +360,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5ac-60df-2376-b997" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -343,6 +372,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bff-e72b-9032-3e03" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -354,6 +384,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ce1-b9ca-4e65-b6ac" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -365,6 +396,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e33-b72a-d19e-bc45" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -376,6 +408,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bd5-8da3-0c1a-c789" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -387,6 +420,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5e18-79d3-01dd-f1d3" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -398,6 +432,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="538c-ac74-2847-0992" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -409,6 +444,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="620c-21b8-9463-3cb2" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -420,6 +456,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5f38-2b66-4069-0456" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -431,6 +468,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04e0-0e54-7f46-4e78" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -442,6 +480,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="81fc-daf9-0b1b-1b51" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -453,6 +492,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed3c-182f-f9fd-e59a" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -464,6 +504,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da40-ee64-4a81-3605" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -475,6 +516,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -490,6 +532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="caa3-78c5-5995-ba58" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -498,6 +541,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5dbb-b1fe-a8ed-bb90" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -506,6 +550,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99e9-0302-37ed-754d" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -514,6 +559,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5588-ad6d-2a56-3afc" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -522,6 +568,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e814-80c1-10c6-00e7" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -530,6 +577,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e313-6747-96ce-f6fa" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -538,6 +586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -545,9 +594,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2296-e410-da07-d236" name="Foot Knights (77pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2da5-f815-5f05-5d85" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
       </infoLinks>
@@ -568,6 +621,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7945-8dc5-2f0e-02e0" name="Foot Knights" hidden="false" collective="false" type="model">
@@ -580,6 +634,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="13.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -596,6 +651,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83b5-2567-73cc-3512" name="Mace" hidden="false" collective="false" type="upgrade">
@@ -604,6 +660,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="70fa-100a-9ab9-f3e5" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -612,6 +669,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e71b-68a6-a5e9-1ac9" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -620,13 +678,14 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="43aa-170b-4c5e-43a3" name="Unit Upgrades" hidden="false" collective="false">
           <entryLinks>
-            <entryLink id="9d2b-1da9-b816-cd18" name="Zealous" hidden="false" collective="false" targetId="23bc-d28a-656c-3fd5" type="selectionEntry">
+            <entryLink id="9d2b-1da9-b816-cd18" name="Foot Knights (77pts base)" hidden="false" collective="false" targetId="2296-e410-da07-d236" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="5">
                   <repeats>
@@ -643,17 +702,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="23bc-d28a-656c-3fd5" name="Zealous" hidden="false" collective="false" type="upgrade">
-      <infoLinks>
-        <infoLink id="00f3-1145-8dd3-402e" name="Zealous" hidden="false" targetId="45bb-28cf-94fd-f899" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f2d3-51c1-7590-f825" name="Foot Retainers (72pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3bfe-a540-57d2-f394" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -679,6 +734,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b637-3ab2-6835-69c0" name="Foot Retainer" hidden="false" collective="false" type="model">
@@ -691,6 +747,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -698,6 +755,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c57c-1e1b-9b14-f4c5" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -714,6 +772,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c664-0e0a-1dba-763b" name="Foot Retainer Sergeant" hidden="false" collective="false" type="model">
@@ -727,6 +786,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -734,6 +794,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -750,6 +811,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="94f1-d8e2-ff21-47de" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -758,6 +820,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="423c-9030-53f6-a19b" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -766,6 +829,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -785,9 +849,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e0e0-025c-09d2-4e02" name="Archers (67pts base)" hidden="false" collective="false" type="upgrade">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="4974-1a8f-32ef-03a6" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -813,6 +881,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1ae1-6a75-6bed-c849" name="Archer" hidden="false" collective="false" type="model">
@@ -825,6 +894,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -832,6 +902,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f718-282b-4899-2bb7" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -849,6 +920,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="40c9-ade9-0f20-5673" name="Archer" hidden="false" collective="false" type="model">
@@ -861,6 +933,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -868,6 +941,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -891,6 +965,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0fb2-1984-62a7-e547" name="Bow" hidden="false" collective="false" type="upgrade">
@@ -899,6 +974,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -922,6 +998,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4297-115f-1e92-90bd" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -930,6 +1007,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -945,6 +1023,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -952,9 +1031,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8d42-0633-18ea-46a3" name="Crossbowmen (72 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3367-091b-c4ec-8f3d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -969,6 +1052,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -985,6 +1069,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78c7-6f21-1de7-1c4d" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -1000,6 +1085,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1025,6 +1111,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="af26-600e-bb96-14bd" name="Crossbowman Seargeant" hidden="false" collective="false" type="model">
@@ -1038,6 +1125,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1045,6 +1133,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f907-e902-d680-eef5" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1062,6 +1151,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ba87-8a1d-0f2b-0e9d" name="Crossbowman Seargeant" hidden="false" collective="false" type="model">
@@ -1075,6 +1165,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1082,6 +1173,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="976e-0393-e70a-e7eb" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1099,6 +1191,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f44d-41cd-861a-ca35" name="Crossbowman Seargeant" hidden="false" collective="false" type="model">
@@ -1112,6 +1205,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1119,6 +1213,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1126,9 +1221,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8405-fc2d-45e0-0c26" name="Arbalestiers (Hvy Xbow) (72 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="dc61-2813-ce77-d4a9" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
         <infoLink id="c63e-ae16-0b08-59f1" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
@@ -1147,6 +1246,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1163,6 +1263,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d23b-f47c-042c-60af" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -1178,6 +1279,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1202,6 +1304,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c0c9-e5ae-da5c-56ca" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1214,6 +1317,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1221,6 +1325,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c1be-d060-b37e-f68b" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1237,6 +1342,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="89df-5ba8-5989-2ff0" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1249,6 +1355,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1256,6 +1363,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="748c-126a-41a9-6e54" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1272,6 +1380,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e429-daa6-3d15-0860" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1284,6 +1393,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1291,6 +1401,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="79e7-7ddf-a7f2-d721" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
@@ -1307,6 +1418,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1f64-b27e-78e6-5f00" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1319,6 +1431,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1326,6 +1439,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1348,6 +1462,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1355,9 +1470,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4255-a125-b8e7-427a" name="Peasants (32 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="27f1-736e-c78c-c79a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1375,6 +1494,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ddb3-b98b-1b35-1ffb" name="Peasant Yeoman" hidden="false" collective="false" type="model">
@@ -1389,6 +1509,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1405,6 +1526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de67-af2c-c065-a27d" name="Pitchforks, Bills or Glaives" hidden="false" collective="false" type="upgrade">
@@ -1420,6 +1542,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ba62-b8d8-499b-8026" name="Cudgel &amp; Slings" hidden="false" collective="false" type="upgrade">
@@ -1436,6 +1559,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1443,9 +1567,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f319-8ba2-6e61-a9fc" name="Flagellants (92 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="412f-bfb8-a4ae-9814" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="462f-3819-73cc-0390" name="Zealous" hidden="false" targetId="45bb-28cf-94fd-f899" type="rule"/>
@@ -1464,6 +1592,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -1480,6 +1609,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b79-f7e1-d195-a1ea" name="Flagellant" hidden="false" collective="false" type="model">
@@ -1492,6 +1622,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1507,6 +1638,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1514,9 +1646,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7eb6-cd0d-3dbe-5a46" name="Ballista (69 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="f024-ace8-02e5-ce3b" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="d978-1b52-1278-001d" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1545,6 +1681,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1552,6 +1689,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2dc5-a742-133a-892e" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1568,6 +1706,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1575,6 +1714,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1591,6 +1731,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad99-64ce-8898-64d1" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -1599,6 +1740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1615,6 +1757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3a5f-e63e-ac56-defd" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1630,6 +1773,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1646,6 +1790,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1653,9 +1798,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f0c0-2cef-09ea-cd94" name="Mangonel (81 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="c5e5-22a4-b8ec-6bf1" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="2693-e158-7240-eec4" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -1684,6 +1833,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1691,6 +1841,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fa22-06bf-2135-79bf" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1707,6 +1858,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1714,6 +1866,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1730,6 +1883,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7f2d-d797-1367-9eeb" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -1738,6 +1892,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="75.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1754,6 +1909,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4f97-a2d2-e312-c471" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1769,6 +1925,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1776,9 +1933,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f453-102d-f811-3d2f" name="Mounted Retainers (72 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2794-5bf8-26f4-0118" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -1807,6 +1968,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fd88-c56c-36a4-bbd2" name="Retainer, Riding Horse" hidden="false" collective="false" type="model">
@@ -1819,6 +1981,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1826,6 +1989,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eadb-b8bb-8741-0d60" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1843,6 +2007,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="69de-a24a-1a97-aaa0" name="Retainer, Riding Horse" hidden="false" collective="false" type="model">
@@ -1855,6 +2020,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1862,6 +2028,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1884,6 +2051,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b18-b397-ded2-1804" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -1899,6 +2067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1915,6 +2084,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="afc0-544a-8a60-8fc3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1923,6 +2093,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fba9-9109-7b43-803d" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -1938,6 +2109,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1945,9 +2117,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ddfa-279f-4b28-fb6a" name="Knights on Warhorses (96 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="97b8-a305-e7d0-7794" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -1968,6 +2144,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="40.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f8ad-f5f3-c04b-89bb" name="Knight, Riding Warhorse" hidden="false" collective="false" type="model">
@@ -1980,6 +2157,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2000,6 +2178,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2016,6 +2195,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5258-8162-38f2-03ea" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2024,6 +2204,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="525e-a9b5-dd1d-95f8" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -2032,6 +2213,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b99-92cf-8f8c-a176" name="Warhammer" hidden="false" collective="false" type="upgrade">
@@ -2040,6 +2222,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="13bc-a627-29f3-7dd0" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -2055,6 +2238,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2062,9 +2246,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="634f-e1a7-3261-1cb3" name="Priest (64pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2259-e30c-15f2-5d27" type="max"/>
       </constraints>
@@ -2096,6 +2284,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="64.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ad0c-8963-dd95-1834" name="Supplicant" hidden="false" collective="false" type="model">
@@ -2107,6 +2296,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2114,6 +2304,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8381-b890-cfbf-5149" name="Hair Shirt Armour Upgrade" hidden="false" collective="false" type="upgrade">
@@ -2134,6 +2325,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="74.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1ff2-5e03-69dc-e75c" name="Supplicant" hidden="false" collective="false" type="model">
@@ -2145,6 +2337,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2152,6 +2345,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2168,6 +2362,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e6e-07f5-507a-a342" name="Insufferably Sanctimonious (Tough 2)" hidden="false" collective="false" type="upgrade">
@@ -2176,6 +2371,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2191,6 +2387,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="34c1-fc8d-c37e-265e" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2199,6 +2396,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95ab-4993-696f-b1d6" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2207,6 +2405,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58a8-95c6-cd47-b2d3" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2215,6 +2414,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c984-fb5e-6157-f5fa" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2223,6 +2423,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b362-21f8-9320-c5dd" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2231,6 +2432,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5c8c-b804-9281-c4b6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2239,6 +2441,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2246,9 +2449,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8927-f10c-9b13-777a" name="Knightly Chamption" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c16-c59b-9330-4278" type="max"/>
       </constraints>
@@ -2273,6 +2480,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2288,6 +2496,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2304,6 +2513,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7142-85d5-6100-3b00" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2312,6 +2522,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2328,6 +2539,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02b6-e293-1eaa-aa89" name="Upgrade to Wound 3" hidden="false" collective="false" type="upgrade">
@@ -2336,6 +2548,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ac9-b8b0-e85a-dcaf" name="Wound" hidden="false" collective="false" type="upgrade">
@@ -2344,6 +2557,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2359,6 +2573,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bbd3-01a1-1f47-338b" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2367,6 +2582,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6002-14c0-1adb-94cc" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2375,6 +2591,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99cb-1ec6-2f3b-b47b" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2383,6 +2600,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bbf9-0621-c970-a187" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2391,6 +2609,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2bff-c278-4a7a-a0c0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2399,6 +2618,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b0da-20ef-e2f7-4d9c" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2407,6 +2627,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2414,9 +2635,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="96.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="21a8-e570-5189-b243" name="Mounted Lord Knight (128 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="7ac0-7f8a-f5e0-58c6" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="921e-59fc-b679-c149" name="Mounted Unit" hidden="false" targetId="mounted unit" primary="false"/>
@@ -2436,6 +2661,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="88.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2e7d-6a10-5f2d-6186" name="Knights, Riding Horse" hidden="false" collective="false" type="model">
@@ -2449,6 +2675,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2465,6 +2692,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad2a-cd99-78eb-2e2e" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2473,6 +2701,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1605-9eb3-ff1b-cf99" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -2488,6 +2717,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2510,6 +2740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2526,6 +2757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="134a-2a30-4126-b981" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2534,6 +2766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2550,6 +2783,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5763-1cd3-5807-b782" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2558,6 +2792,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2581,6 +2816,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc56-e07d-912e-4ec7" name="Regular Horses" hidden="false" collective="false" type="upgrade">
@@ -2589,6 +2825,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2604,6 +2841,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4a8c-a520-95bf-f664" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2612,6 +2850,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="01a5-b233-5dc6-1855" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2620,6 +2859,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9611-8723-3219-ca80" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2628,6 +2868,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e372-fa4b-f227-9512" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2636,6 +2877,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fb2f-c702-fc87-989d" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2644,6 +2886,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="14c4-c81e-9719-ce60" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2652,6 +2895,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2659,9 +2903,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="671a-408e-2386-3c7e" name="Lord Knight (106 pts base)" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="afab-21d2-59da-ee82" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
       </categoryLinks>
@@ -2681,6 +2929,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="78.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac70-dd1d-aa51-2021" name="Knights" hidden="false" collective="false" type="model">
@@ -2693,6 +2942,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2709,6 +2959,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2cc5-0e7a-0c1e-5053" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2717,6 +2968,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66b0-aaf8-4e03-e8f6" name="Chain Mace" hidden="false" collective="false" type="upgrade">
@@ -2725,6 +2977,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4703-1bb9-d4cc-e959" name="Morning Star" hidden="false" collective="false" type="upgrade">
@@ -2733,6 +2986,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b9a-a7d1-e934-6569" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -2741,6 +2995,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="848d-5c98-7dbb-3651" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -2749,6 +3004,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2768,6 +3024,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2784,6 +3041,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a74e-66c0-e86b-e60c" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2792,6 +3050,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2808,6 +3067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df6b-4c99-d4a9-bc16" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2816,6 +3076,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2831,6 +3092,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62b6-feac-9c47-e8e3" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2839,6 +3101,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="61c7-1d0a-eee4-ea38" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2847,6 +3110,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="511a-0396-1178-9bd1" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2855,6 +3119,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f9f1-6634-a352-cd12" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2863,6 +3128,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55c2-c307-547b-2719" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2871,6 +3137,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f92-e097-7f60-5a03" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2879,6 +3146,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2886,6 +3154,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Knights.cat
+++ b/Knights.cat
@@ -570,7 +570,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a97e-5fcc-0531-a2be" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6e0a-053e-f8f1-4568" name="Swords" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6e0a-053e-f8f1-4568" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="f6d0-437a-5053-75f0" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
@@ -990,7 +990,7 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="78c7-6f21-1de7-1c4d" name="Swords" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="78c7-6f21-1de7-1c4d" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
@@ -1162,7 +1162,7 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d23b-f47c-042c-60af" name="Swords" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d23b-f47c-042c-60af" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>

--- a/Knights.cat
+++ b/Knights.cat
@@ -36,10 +36,7 @@
     <entryLink id="e92d-36d5-86df-be27" name="Lord Knight" hidden="false" collective="false" targetId="671a-408e-2386-3c7e" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="4e36-8ca9-21c5-f370" name="Court Wizard (56 pts base)" hidden="false" collective="false" type="unit">
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="326e-0e5e-49ee-cb8c" type="max"/>
-      </constraints>
+    <selectionEntry id="4e36-8ca9-21c5-f370" name="Court Wizard" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="808b-dab8-1c77-d697" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
       </infoLinks>
@@ -47,26 +44,22 @@
         <categoryLink id="702e-b284-c94a-d8bc" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="4163-864c-f764-d889" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4d03-caf7-b983-77a1" name="Court Wizard" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c41-abb1-a0aa-e45b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9329-c0ce-e4ee-3d66" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="2b60-d16f-cd81-0edd" name="Court Wizard" hidden="false" targetId="6308-aee3-a022-0f70" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="55.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="de86-dd01-45df-1504" name="Models" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="699e-d97f-ece1-e13c" name="Court Wizard" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a3c-7091-33c8-3cfc" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3dd-69db-4a67-dcb7" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="7980-511f-3e4a-d147" name="Court Wizard" hidden="false" targetId="6308-aee3-a022-0f70" type="profile"/>
-                <infoLink id="ff8c-fdaf-84bf-92ab" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                <infoLink id="886b-c162-c71c-b3b3" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="55.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
         <selectionEntryGroup id="2964-02d8-6d5e-aac5" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="11bb-cb36-4b98-aec3">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df79-64ab-bf98-ecf1" type="max"/>
@@ -79,7 +72,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f6c-e715-66f1-7d0c" name="Tough Lvl 2" hidden="false" collective="false" type="upgrade">
@@ -88,12 +81,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="99b0-e15e-41b7-0ea7" name="Weapon Choice" hidden="false" collective="false" defaultSelectionEntryId="5b0e-766b-b044-3274">
+        <selectionEntryGroup id="99b0-e15e-41b7-0ea7" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="5b0e-766b-b044-3274">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ecc-4c5d-f2ed-dc40" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bb2-151d-fb46-de1b" type="min"/>
@@ -105,19 +98,22 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="d562-62fa-3b65-f227" name="Sword" hidden="false" collective="false" targetId="6ce7-b3cb-cc54-c24f" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="points" value="2">
+                <modifier type="increment" field="points" value="2.0">
                   <repeats>
                     <repeat field="selections" scope="4e36-8ca9-21c5-f370" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
               </modifiers>
+              <infoLinks>
+                <infoLink id="acaf-afde-6d3c-dfe5" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+              </infoLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -133,7 +129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3208-10c7-f7db-ecc0" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -142,7 +138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="08db-1b7a-ac6c-3e95" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -151,7 +147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -174,7 +170,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -182,7 +178,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f0e-2c55-63ab-5296" name="Wizards Familiars" hidden="false" collective="false" type="upgrade">
@@ -199,7 +195,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -207,7 +203,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -224,7 +220,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="440d-72f7-f47d-9715" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -233,7 +229,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d9c-a064-187b-5c99" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -242,7 +238,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad45-daa5-dd02-ddec" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -251,7 +247,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d6f2-3852-2a24-4a1c" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -260,7 +256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87f7-1236-a1a3-ea1e" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -269,7 +265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ce9-bc0a-a30a-1c8b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -278,7 +274,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c07c-9d16-21e5-0feb" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -287,7 +283,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a7de-f6a3-5498-6a3b" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -296,7 +292,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6630-5ea8-bf55-4b5c" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -305,7 +301,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ecf9-32b3-d437-cce3" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -314,7 +310,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff03-207d-b5fa-5595" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -323,7 +319,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1dea-a210-287f-2705" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -332,7 +328,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8580-b297-4f17-698e" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -341,7 +337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -357,7 +353,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5ac-60df-2376-b997" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -369,7 +365,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bff-e72b-9032-3e03" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -381,7 +377,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ce1-b9ca-4e65-b6ac" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -393,7 +389,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e33-b72a-d19e-bc45" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -405,7 +401,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8bd5-8da3-0c1a-c789" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -417,7 +413,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5e18-79d3-01dd-f1d3" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -429,7 +425,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="538c-ac74-2847-0992" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -441,7 +437,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="620c-21b8-9463-3cb2" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -453,7 +449,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5f38-2b66-4069-0456" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -465,7 +461,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04e0-0e54-7f46-4e78" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -477,7 +473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="81fc-daf9-0b1b-1b51" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -489,7 +485,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed3c-182f-f9fd-e59a" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -501,7 +497,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da40-ee64-4a81-3605" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -513,111 +509,46 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="63c3-e93a-0285-98c4" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a21-82a1-c940-9b04" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="44ea-3ed2-3576-79c0" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="804c-9f72-4cef-77a2" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="caa3-78c5-5995-ba58" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0c9d-1b06-0357-cace" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5dbb-b1fe-a8ed-bb90" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5ec9-207e-6199-e845" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="99e9-0302-37ed-754d" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c53d-3f58-1c2a-b041" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5588-ad6d-2a56-3afc" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8238-431b-b6a0-dfdc" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e814-80c1-10c6-00e7" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9372-1a57-a6ce-88db" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e313-6747-96ce-f6fa" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="6925-9e50-7154-b95e" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3e01-e078-692d-8c15" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2296-e410-da07-d236" name="Foot Knights (77pts base)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="2296-e410-da07-d236" name="Foot Knights" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="2da5-f815-5f05-5d85" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
+        <infoLink id="e3ea-1740-0a5e-1795" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="54f5-b82b-aafe-128d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8ea6-33c7-093d-391d" name="Knight Leader" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb72-9d21-2343-a3c3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4980-05d5-9e9f-8ce2" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="c2b9-f9de-f35d-aa6e" name="Foot Knight Leader" hidden="false" targetId="68be-5332-b2f8-2876" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="25.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5d9c-880a-3a7f-28ce" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="5d9c-880a-3a7f-28ce" name="Choose 4 to 9" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="93b6-7b20-2ec2-f37c" name="Knight Leader" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5149-ec5d-dd15-559d" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a9f-3cab-a607-6f34" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="e24a-7d37-c7cb-ecdb" name="Foot Knight Leader" hidden="false" targetId="68be-5332-b2f8-2876" type="profile"/>
-                <infoLink id="7b27-0c02-9556-bfcc" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="7945-8dc5-2f0e-02e0" name="Foot Knights" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5c3-0eec-ecd1-13f7" type="min"/>
@@ -628,7 +559,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="13.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -645,7 +576,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="83b5-2567-73cc-3512" name="Mace" hidden="false" collective="false" type="upgrade">
@@ -654,7 +585,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="70fa-100a-9ab9-f3e5" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -663,7 +594,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e71b-68a6-a5e9-1ac9" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -672,39 +603,50 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="43aa-170b-4c5e-43a3" name="Unit Upgrades" hidden="false" collective="false">
-          <entryLinks>
-            <entryLink id="9d2b-1da9-b816-cd18" name="Foot Knights (77pts base)" hidden="false" collective="false" targetId="2296-e410-da07-d236" type="selectionEntry">
+        <selectionEntryGroup id="bf33-c3d7-f94c-351d" name="Zealous Upgrade" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4b2-aeec-3f72-249d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="070c-6a08-c1d9-4858" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="dc75-3c65-d366-2250" name="Zealous" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="5">
+                <modifier type="increment" field="points" value="5.0">
                   <repeats>
                     <repeat field="selections" scope="2296-e410-da07-d236" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
               </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32c0-9ec0-841e-baf6" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
+              <infoLinks>
+                <infoLink id="cca3-dfb1-b523-e987" name="Zealous" hidden="false" targetId="45bb-28cf-94fd-f899" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f2d3-51c1-7590-f825" name="Foot Retainers (72pts base)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="f2d3-51c1-7590-f825" name="Foot Retainers" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="84e9-8244-f2f9-1aee" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="3bfe-a540-57d2-f394" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5ab7-311b-790d-fd58" name="Models" hidden="false" collective="false" defaultSelectionEntryId="d16e-16a8-0edd-8623">
+        <selectionEntryGroup id="5ab7-311b-790d-fd58" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="d16e-16a8-0edd-8623">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e08-2c3d-e998-64bc" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbfe-8fa3-81d9-9680" type="min"/>
@@ -721,11 +663,10 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="74b9-f3fd-33fe-0b5b" name="Foot Retainer Sergeant" hidden="false" targetId="d140-ae4b-e847-992e" type="profile"/>
-                        <infoLink id="4638-841a-7dd9-3600" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b637-3ab2-6835-69c0" name="Foot Retainer" hidden="false" collective="false" type="model">
@@ -738,7 +679,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -746,7 +687,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c57c-1e1b-9b14-f4c5" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -763,7 +704,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c664-0e0a-1dba-763b" name="Foot Retainer Sergeant" hidden="false" collective="false" type="model">
@@ -772,12 +713,11 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="482f-b402-30de-5f09" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="7944-4a1a-aa15-2634" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="a732-6929-13e8-1793" name="Foot Retainer Sergeant in Medium Armour" hidden="false" targetId="6fc8-5047-fae8-d1a2" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -785,7 +725,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -802,7 +742,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="94f1-d8e2-ff21-47de" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -811,7 +751,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="423c-9030-53f6-a19b" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -820,35 +760,40 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
             <entryLink id="de1b-5bd5-cc6f-b4f6" name="Halberds" hidden="false" collective="false" targetId="83cf-506e-8f65-96e6" type="selectionEntry">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="f2d3-51c1-7590-f825" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
               </modifiers>
+              <infoLinks>
+                <infoLink id="6ad0-b86e-906e-289d" name="Halberds" hidden="false" targetId="595c-60a6-3a30-b259" type="profile"/>
+              </infoLinks>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="ee9b-3ce1-bbbc-b427" name="Unit Upgrades" hidden="false" collective="false"/>
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e0e0-025c-09d2-4e02" name="Archers (67pts base)" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="e0e0-025c-09d2-4e02" name="Archers" hidden="false" collective="false" type="upgrade">
+      <infoLinks>
+        <infoLink id="b754-f541-4df3-859e" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="4974-1a8f-32ef-03a6" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="0329-295e-cbd8-5d5f" name="Models" hidden="false" collective="false" defaultSelectionEntryId="306c-5139-16c1-3835">
+        <selectionEntryGroup id="0329-295e-cbd8-5d5f" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="306c-5139-16c1-3835">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="681f-16b5-5e93-1836" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e05d-70ef-5465-a41e" type="min"/>
@@ -865,11 +810,10 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="0418-953a-b8a6-4467" name="Archer Seargeant" hidden="false" targetId="7709-0641-70ab-2371" type="profile"/>
-                        <infoLink id="7ff0-1b1c-e741-f33e" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1ae1-6a75-6bed-c849" name="Archer" hidden="false" collective="false" type="model">
@@ -882,7 +826,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -890,7 +834,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f718-282b-4899-2bb7" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -903,12 +847,11 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddb2-a8bd-639f-14f8" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="c1d3-0eb0-d1c0-0a66" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="9738-1287-6b06-03ed" name="Archer Seargeant in Light Armour" hidden="false" targetId="dd49-02b7-7f60-3a52" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="40c9-ade9-0f20-5673" name="Archer" hidden="false" collective="false" type="model">
@@ -921,7 +864,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -929,7 +872,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -953,7 +896,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0fb2-1984-62a7-e547" name="Bow" hidden="false" collective="false" type="upgrade">
@@ -962,12 +905,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0de2-047e-f04f-d101" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="4297-115f-1e92-90bd">
+        <selectionEntryGroup id="0de2-047e-f04f-d101" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="4297-115f-1e92-90bd">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6162-7bc5-e887-6fa7" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f76a-5f18-209e-1a71" type="min"/>
@@ -986,7 +929,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4297-115f-1e92-90bd" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -995,14 +938,14 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4126-4b08-57dd-6a19" name="Unit Upgrades" hidden="false" collective="false">
+        <selectionEntryGroup id="4126-4b08-57dd-6a19" name="Deadeye Shot Upgrade" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="a397-1135-9d96-aa8d" name="Dead Eye Shot (Re-roll one miss)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a397-1135-9d96-aa8d" name="Dead Eye Shot" hidden="false" collective="false" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96a6-d4e6-085a-b806" type="max"/>
               </constraints>
@@ -1011,7 +954,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1019,30 +962,20 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8d42-0633-18ea-46a3" name="Crossbowmen (72 pts base)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="8d42-0633-18ea-46a3" name="Crossbowmen" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="4e03-cedc-9173-0f8c" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
+        <infoLink id="ff89-5eae-9677-c761" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="edc8-3750-bcb0-3839" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="3367-091b-c4ec-8f3d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="2419-75a5-d9ed-e19b" name="Crossbow" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ac2-59fa-11fc-8fa1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2ca-f27f-0a09-687d" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="666f-f970-2e4c-2032" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b1d5-0eee-5927-3a2f" name="HTH Weapon" hidden="false" collective="false" defaultSelectionEntryId="ed4d-36a0-a42c-c85d">
+        <selectionEntryGroup id="b1d5-0eee-5927-3a2f" name="HtH Weapon" hidden="false" collective="false" defaultSelectionEntryId="ed4d-36a0-a42c-c85d">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c752-b596-155e-b96c" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7888-dabb-d7ab-067c" type="min"/>
@@ -1054,7 +987,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="78c7-6f21-1de7-1c4d" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -1070,12 +1003,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="2aeb-b908-dc90-974c" name="Models" hidden="false" collective="false" defaultSelectionEntryId="a24a-986e-31f4-9569">
+        <selectionEntryGroup id="2aeb-b908-dc90-974c" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="a24a-986e-31f4-9569">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b882-08c1-340c-86dd" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e3d-4005-d435-e29d" type="min"/>
@@ -1092,11 +1025,10 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="67cc-c0d6-da5c-e36a" name="Crossbowman" hidden="false" targetId="9f19-6ae3-cefd-5539" type="profile"/>
-                        <infoLink id="6953-b904-77cd-b44a" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="af26-600e-bb96-14bd" name="Crossbowman Seargeant" hidden="false" collective="false" type="model">
@@ -1105,12 +1037,11 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4698-ac91-e0dc-d139" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="0abc-81fe-b367-2a1c" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="828f-07e2-634d-c16c" name="Crossbowman Seargeant" hidden="false" targetId="6f57-fd25-6e8e-211b" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1118,7 +1049,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f907-e902-d680-eef5" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1131,12 +1062,11 @@
                         <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c79-7eb1-3b71-95f9" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="9069-ab67-095e-5be4" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
                         <infoLink id="a2bf-d4eb-236b-acd5" name="Crossbowman in Light Armour" hidden="false" targetId="bb86-6822-a7e8-3f81" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ba87-8a1d-0f2b-0e9d" name="Crossbowman Seargeant" hidden="false" collective="false" type="model">
@@ -1145,12 +1075,11 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e14-ba55-a981-0dd5" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="7c3c-6283-2063-acef" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="9b45-f622-593d-86ab" name="Crossbowman Seargeant in Light Armour" hidden="false" targetId="6d1c-328b-2be2-0a58" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1158,7 +1087,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="976e-0393-e70a-e7eb" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1171,12 +1100,11 @@
                         <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6352-b99d-aedc-d53b" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="6727-7e0c-db49-7fc4" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
                         <infoLink id="d92b-6acd-306e-a226" name="Crossbowman in Medium Armour" hidden="false" targetId="5b8c-f156-18f2-9084" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f44d-41cd-861a-ca35" name="Crossbowman Seargeant" hidden="false" collective="false" type="model">
@@ -1185,12 +1113,11 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48ea-1c23-0d52-b64c" type="min"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="96eb-ef5f-e494-31a3" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="d8b2-62ef-1beb-8894" name="Crossbowman Seargeant in Medium Armour" hidden="false" targetId="694e-de7d-0762-b024" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1198,7 +1125,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1206,34 +1133,21 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8405-fc2d-45e0-0c26" name="Arbalestiers (Hvy Xbow) (72 pts base)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="8405-fc2d-45e0-0c26" name="Arbalestiers" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="dc61-2813-ce77-d4a9" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
         <infoLink id="c63e-ae16-0b08-59f1" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="8988-f375-f22c-bae0" name="Heavy Crossbow" hidden="false" targetId="5690-ead7-6d4a-d2c0" type="profile"/>
+        <infoLink id="a690-472a-46c9-dd98" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ef51-6251-ce63-2879" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="c9b6-1974-a131-826d" name="Heavy Crossbow" hidden="false" collective="false" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90dd-6b4b-6f49-1ec2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="522c-9c8c-cd41-0d7c" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="442a-17b0-e449-7d4e" name="Heavy Crossbow" hidden="false" targetId="5690-ead7-6d4a-d2c0" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="fd29-df3b-eba7-a9f1" name="HTH Weapon" hidden="false" collective="false" defaultSelectionEntryId="4955-e261-6907-fffa">
+        <selectionEntryGroup id="fd29-df3b-eba7-a9f1" name="HtH Weapon" hidden="false" collective="false" defaultSelectionEntryId="4955-e261-6907-fffa">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb6f-9965-42d2-7ab2" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c741-9681-bf52-b3af" type="min"/>
@@ -1245,7 +1159,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d23b-f47c-042c-60af" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -1261,12 +1175,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="28c4-f323-2890-40ff" name="Models" hidden="false" collective="false" defaultSelectionEntryId="65fb-a08b-f524-7462">
+        <selectionEntryGroup id="28c4-f323-2890-40ff" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="65fb-a08b-f524-7462">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d79f-b897-32fc-fa8d" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="023b-c8e0-b129-d09d" type="min"/>
@@ -1286,7 +1200,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c0c9-e5ae-da5c-56ca" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1299,7 +1213,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1307,7 +1221,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c1be-d060-b37e-f68b" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1324,7 +1238,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="89df-5ba8-5989-2ff0" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1337,7 +1251,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1345,7 +1259,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="748c-126a-41a9-6e54" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1362,7 +1276,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e429-daa6-3d15-0860" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1375,7 +1289,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1383,7 +1297,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="79e7-7ddf-a7f2-d721" name="Heavy Armour" hidden="false" collective="false" type="upgrade">
@@ -1400,7 +1314,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1f64-b27e-78e6-5f00" name="Arbalestier Seargeant" hidden="false" collective="false" type="model">
@@ -1413,7 +1327,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1421,16 +1335,16 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e15e-8348-6a4c-e8bc" name="Unit Upgrades" hidden="false" collective="false">
+        <selectionEntryGroup id="e15e-8348-6a4c-e8bc" name="Pavise Upgrade" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="1f0c-165c-5b86-aad7" name="Pavisse" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1f0c-165c-5b86-aad7" name="Pavise" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="8405-fc2d-45e0-0c26" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -1440,11 +1354,11 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="829a-d0d9-21b2-3831" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="5bd6-5a9f-692c-6c5f" name="Pavisse" hidden="false" targetId="160b-fca8-adb7-3d5b" type="rule"/>
+                <infoLink id="5bd6-5a9f-692c-6c5f" name="Pavise" hidden="false" targetId="160b-fca8-adb7-3d5b" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1452,15 +1366,34 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4255-a125-b8e7-427a" name="Peasants (32 pts base)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="4255-a125-b8e7-427a" name="Peasants" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="ed01-e32e-0beb-3ad1" name="Surly" hidden="false" targetId="8a4d-4dea-f005-ddc5" type="rule"/>
+        <infoLink id="c956-dfb3-9480-fe61" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="27f1-736e-c78c-c79a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4add-2c60-f85d-fe94" name="Peasant Yeoman" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7758-9fb8-8021-a0f9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f6b-8a86-4646-5cde" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="5bc7-ac8a-100d-41fa" name="Peasant Yeoman" hidden="false" targetId="7820-07f3-147d-4a5d" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="16.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="088c-c9ec-f689-ca3d" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="088c-c9ec-f689-ca3d" name="Choose 4 to 9" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="e707-62ab-c638-62e1" name="Peasant" hidden="false" collective="false" type="model">
               <constraints>
@@ -1469,31 +1402,15 @@
               </constraints>
               <infoLinks>
                 <infoLink id="2a02-17e2-8749-23bc" name="Peasant" hidden="false" targetId="6d26-f63a-895a-8a26" type="profile"/>
-                <infoLink id="2c58-442e-4f04-9073" name="Surly" hidden="false" targetId="8a4d-4dea-f005-ddc5" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ddb3-b98b-1b35-1ffb" name="Peasant Yeoman" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf55-b0be-0cb3-d834" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ff3-e63a-ef93-9754" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="c3d4-9982-adb6-8c7b" name="Peasant Yeoman" hidden="false" targetId="7820-07f3-147d-4a5d" type="profile"/>
-                <infoLink id="fbfd-c925-f279-fb76" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                <infoLink id="4632-d8d0-b762-d86a" name="Surly" hidden="false" targetId="8a4d-4dea-f005-ddc5" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9de5-9cb9-7822-ca9a" name="HTH Weapon" hidden="false" collective="false" defaultSelectionEntryId="bc30-d403-03a6-0a01">
+        <selectionEntryGroup id="9de5-9cb9-7822-ca9a" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="bc30-d403-03a6-0a01">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4df2-cc2a-35ba-b7d8" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9a5-48e8-6ec2-76a6" type="min"/>
@@ -1505,7 +1422,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de67-af2c-c065-a27d" name="Pitchforks, Bills or Glaives" hidden="false" collective="false" type="upgrade">
@@ -1521,12 +1438,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ba62-b8d8-499b-8026" name="Cudgel &amp; Slings" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="3">
+                <modifier type="increment" field="points" value="3.0">
                   <repeats>
                     <repeat field="selections" scope="4255-a125-b8e7-427a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -1538,7 +1455,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1546,48 +1463,39 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f319-8ba2-6e61-a9fc" name="Flagellants (92 pts base)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="f319-8ba2-6e61-a9fc" name="Flagellants" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90b7-4766-d726-be4c" type="max"/>
+      </constraints>
       <infoLinks>
-        <infoLink id="412f-bfb8-a4ae-9814" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="412f-bfb8-a4ae-9814" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="462f-3819-73cc-0390" name="Zealous" hidden="false" targetId="45bb-28cf-94fd-f899" type="rule"/>
+        <infoLink id="4808-4f67-06a7-7c5a" name="Scourge" hidden="false" targetId="3f74-469a-cb98-f949" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="18e8-bb80-0088-2c5d" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="3d96-e066-7e8b-a0ff" name="Scourges" hidden="false" collective="false" type="upgrade">
+        <selectionEntry id="d614-3011-a6ad-cd4e" name="Flagellant Leader" hidden="false" collective="false" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9c6-246f-b7d9-5a71" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee4d-de2a-36bf-4fd9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f190-30c2-ae65-6325" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="427b-c5ab-a620-256f" type="min"/>
           </constraints>
           <infoLinks>
-            <infoLink id="d43a-dcbd-1dba-a273" name="Scourge" hidden="false" targetId="3f74-469a-cb98-f949" type="profile"/>
+            <infoLink id="b592-7d59-b364-0698" name="Flagellant Leader" hidden="false" targetId="cf3a-5914-32a7-3062" type="profile"/>
           </infoLinks>
           <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+            <cost name="pts" typeId="points" value="28.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4dd8-1c71-5dca-2089" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="4dd8-1c71-5dca-2089" name="Choose 4 to 9" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="3f46-a20a-0979-0335" name="Flagellant Leader" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a63e-95bb-e618-a21a" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0150-dc44-d724-dca7" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="1dde-3088-30dd-106e" name="Flagellant Leader" hidden="false" targetId="cf3a-5914-32a7-3062" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="0b79-f7e1-d195-a1ea" name="Flagellant" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b663-d81c-7fe2-5057" type="max"/>
@@ -1598,12 +1506,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="5fec-6c5a-a5cb-7caa" name="Unit Upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="5fec-6c5a-a5cb-7caa" name="Flaming Wheel Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b191-b27e-1c57-7e2a" type="max"/>
           </constraints>
@@ -1611,10 +1519,11 @@
             <selectionEntry id="111d-857d-af73-a121" name="Flaming Wheel Upgrade" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="9b3f-af94-d7ec-9a2c" name="Flaming Wheel" hidden="false" targetId="3e6e-06c9-509a-1716" type="profile"/>
+                <infoLink id="64a7-9f14-1a26-7622" name="Flaming Wheel" hidden="false" targetId="3a29-1b97-6c21-75e7" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1622,19 +1531,20 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7eb6-cd0d-3dbe-5a46" name="Ballista (69 pts base)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="7eb6-cd0d-3dbe-5a46" name="Ballista" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="f024-ace8-02e5-ce3b" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="d978-1b52-1278-001d" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+        <infoLink id="d978-1b52-1278-001d" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="16a2-15a9-6876-9859" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="54d5-4495-464a-0b6c" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4cf7-20d7-03d5-6609" name="Models" hidden="false" collective="false" defaultSelectionEntryId="a174-1ef7-e6b3-9b0a">
+        <selectionEntryGroup id="4cf7-20d7-03d5-6609" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="a174-1ef7-e6b3-9b0a">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f955-2fc0-73e0-f2a2" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75ee-3b5f-4013-867f" type="max"/>
@@ -1654,7 +1564,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1662,7 +1572,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2dc5-a742-133a-892e" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1679,7 +1589,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1687,12 +1597,12 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4edc-d7b6-ec1f-dbee" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="0e3c-b092-502a-cdd9">
+        <selectionEntryGroup id="4edc-d7b6-ec1f-dbee" name="Bolt Thrower" hidden="false" collective="false" defaultSelectionEntryId="0e3c-b092-502a-cdd9">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c7aa-b026-c167-a349" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ff7-0dfe-338b-64e1" type="min"/>
@@ -1704,21 +1614,22 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad99-64ce-8898-64d1" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="92de-833c-b803-b00b" name="Large Bolt Thrower" hidden="false" targetId="fbdf-a3cf-f1d1-8d05" type="profile"/>
+                <infoLink id="a2f5-d4f1-c4a3-3d3c" name="Unstoppable" hidden="false" targetId="a8bf-f48c-1b08-58e6" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="51f2-3bc7-537d-2b60" name="HTH Weapon" hidden="false" collective="false" defaultSelectionEntryId="2245-cc60-624c-00ef">
+        <selectionEntryGroup id="51f2-3bc7-537d-2b60" name="HtH Weapon" hidden="false" collective="false" defaultSelectionEntryId="2245-cc60-624c-00ef">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e118-2b11-5a48-3ac3" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fa9-1d54-572f-c7d4" type="min"/>
@@ -1730,12 +1641,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3a5f-e63e-ac56-defd" name="Sword" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="7eb6-cd0d-3dbe-5a46" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -1746,24 +1657,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="8d87-4bbc-dffc-a4af" name="Bolt Thrower" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="0ee5-9257-bc64-4560" name="Equipment: Bolt Thrower" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1f9-4433-8110-26f2" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f428-0b9f-97f2-fd4d" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="8c0a-6d48-ad53-516f" name="Bolt Thrower" hidden="false" targetId="58bd-d77d-aeb4-775c" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1771,19 +1665,21 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f0c0-2cef-09ea-cd94" name="Mangonel (81 pts base)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="f0c0-2cef-09ea-cd94" name="Mangonel" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="c5e5-22a4-b8ec-6bf1" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="2693-e158-7240-eec4" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+        <infoLink id="2693-e158-7240-eec4" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="ff41-3df7-6a33-e69e" name="Overhead" hidden="false" targetId="7751-622a-b896-4874" type="rule"/>
+        <infoLink id="2ca1-28eb-05c6-4395" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="cf3f-1742-86a5-a843" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d32d-cea8-6c3a-7b90" name="Models" hidden="false" collective="false" defaultSelectionEntryId="4565-4030-1dcb-bf8f">
+        <selectionEntryGroup id="d32d-cea8-6c3a-7b90" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="4565-4030-1dcb-bf8f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04d2-ff0e-53af-39c4" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d682-4fc4-a4d8-8d37" type="min"/>
@@ -1803,7 +1699,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1811,7 +1707,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fa22-06bf-2135-79bf" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1828,7 +1724,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1836,7 +1732,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1853,7 +1749,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7f2d-d797-1367-9eeb" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -1862,12 +1758,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="75.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="be10-b627-443b-884a" name="HTH Weapon" hidden="false" collective="false">
+        <selectionEntryGroup id="be10-b627-443b-884a" name="HtH Weapon" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="907e-5d60-9aec-a3ca" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28ac-aada-335b-b092" type="min"/>
@@ -1879,7 +1775,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4f97-a2d2-e312-c471" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1895,7 +1791,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1903,18 +1799,18 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f453-102d-f811-3d2f" name="Mounted Retainers (72 pts base)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="f453-102d-f811-3d2f" name="Mounted Retainers" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="2794-5bf8-26f4-0118" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="2794-5bf8-26f4-0118" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c8a7-85e2-dfc2-da0b" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="65c1-11cc-1b6a-1903" name="Models" hidden="false" collective="false" defaultSelectionEntryId="ef22-bdd3-86b7-0263">
+        <selectionEntryGroup id="65c1-11cc-1b6a-1903" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="ef22-bdd3-86b7-0263">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="044f-7ad3-9443-9031" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8776-e457-504f-3129" type="min"/>
@@ -1935,7 +1831,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fd88-c56c-36a4-bbd2" name="Retainer, Riding Horse" hidden="false" collective="false" type="model">
@@ -1948,7 +1844,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1956,7 +1852,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eadb-b8bb-8741-0d60" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1974,7 +1870,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="69de-a24a-1a97-aaa0" name="Retainer, Riding Horse" hidden="false" collective="false" type="model">
@@ -1987,7 +1883,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1995,7 +1891,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2018,12 +1914,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b18-b397-ded2-1804" name="Crossbows" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="3">
+                <modifier type="increment" field="points" value="3.0">
                   <repeats>
                     <repeat field="selections" scope="f453-102d-f811-3d2f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -2031,15 +1927,16 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="fdbd-3eee-97c2-fc07" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
+                <infoLink id="503e-5fd1-f97d-e0f5" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c998-ba2b-0ed1-0c8a" name="HTH Weapon" hidden="false" collective="false" defaultSelectionEntryId="babf-6e69-56b5-fceb">
+        <selectionEntryGroup id="c998-ba2b-0ed1-0c8a" name="HtH Weapon" hidden="false" collective="false" defaultSelectionEntryId="babf-6e69-56b5-fceb">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6d9-c142-2323-4d5b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1703-d04c-592a-d2ef" type="min"/>
@@ -2051,21 +1948,21 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="afc0-544a-8a60-8fc3" name="Spears" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="bfc3-89c7-8194-7da6" name="Spears" hidden="false" targetId="c79a-48d1-9b48-2c68" type="profile"/>
+                <infoLink id="bfc3-89c7-8194-7da6" name="Spear" hidden="false" targetId="c79a-48d1-9b48-2c68" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fba9-9109-7b43-803d" name="Lances" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="f453-102d-f811-3d2f" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -2076,7 +1973,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2084,18 +1981,18 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ddfa-279f-4b28-fb6a" name="Knights on Warhorses (96 pts base)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="ddfa-279f-4b28-fb6a" name="Knights on Warhorses" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="97b8-a305-e7d0-7794" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="97b8-a305-e7d0-7794" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="175c-f898-d9ca-a375" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="7ace-a5ff-9e6b-91d1" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="7ace-a5ff-9e6b-91d1" name="Choose 2 to 4" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="d48b-ab17-f497-00e7" name="Knight Leader, Riding Warhorse" hidden="false" collective="false" type="model">
               <constraints>
@@ -2108,7 +2005,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="40.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f8ad-f5f3-c04b-89bb" name="Knight, Riding Warhorse" hidden="false" collective="false" type="model">
@@ -2121,28 +2018,30 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="34f9-81f7-1bc6-f2f9" name="Upgrades" hidden="false" collective="false">
+        <selectionEntryGroup id="34f9-81f7-1bc6-f2f9" name="Zealous Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d40b-94f3-97c4-d930" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="531f-c0a6-13e3-c9aa" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="19f5-d318-7f28-45fa" name="Zealous" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="5">
+                <modifier type="increment" field="points" value="5.0">
                   <repeats>
                     <repeat field="selections" scope="ddfa-279f-4b28-fb6a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
               </modifiers>
+              <infoLinks>
+                <infoLink id="3318-34fd-2204-a9fc" name="Zealous" hidden="false" targetId="45bb-28cf-94fd-f899" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2159,7 +2058,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5258-8162-38f2-03ea" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2168,7 +2067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="525e-a9b5-dd1d-95f8" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -2177,21 +2076,21 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b99-92cf-8f8c-a176" name="Warhammer" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="41c7-a1ec-e094-67f7" name="Warhammers" hidden="false" targetId="096c-a0fe-df46-77c4" type="profile"/>
+                <infoLink id="41c7-a1ec-e094-67f7" name="Warhammer" hidden="false" targetId="096c-a0fe-df46-77c4" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="13bc-a627-29f3-7dd0" name="Lances" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="ddfa-279f-4b28-fb6a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -2202,7 +2101,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2210,44 +2109,48 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="634f-e1a7-3261-1cb3" name="Priest (64pts base)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="634f-e1a7-3261-1cb3" name="Priest" hidden="false" collective="false" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2259-e30c-15f2-5d27" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="c17d-3382-2b7e-f194" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+        <infoLink id="ab0c-3ac8-d4ac-95ea" name="Divine Intervention" hidden="false" targetId="a447-d495-b7ab-1477" type="rule"/>
+        <infoLink id="eac6-b37e-4492-dfc4" name="Wound 2" hidden="false" targetId="342b-a482-cb16-67e0" type="rule"/>
+        <infoLink id="8206-5777-c93a-234b" name="Mace" hidden="false" targetId="abab-c6f8-5036-1cb4" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="76d4-c070-9e66-38aa" name="New CategoryLink" hidden="false" targetId="warrior command unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e66d-0b0b-ccd8-aa5e" name="Models" hidden="false" collective="false" defaultSelectionEntryId="3a76-c90d-7408-88e0">
+        <selectionEntryGroup id="e66d-0b0b-ccd8-aa5e" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="3a76-c90d-7408-88e0">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfee-5101-651e-7d12" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aba5-0c61-f5fd-b4e6" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="3a76-c90d-7408-88e0" name="No Armour" hidden="false" collective="false" type="upgrade">
+              <selectionEntries>
+                <selectionEntry id="b7cf-4973-03cd-6fa0" name="Priest" hidden="false" collective="false" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a769-5a88-7d2d-aacf" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccfe-d784-1ce7-fffa" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="91f7-4931-7d09-8750" name="Priest with Mace" hidden="false" targetId="c78b-7b49-b75b-cdbc" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="64.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups>
-                <selectionEntryGroup id="4ca6-e2a6-51cc-82cf" name="No Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="4ca6-e2a6-51cc-82cf" name="Choose up to 2" hidden="false" collective="false">
                   <selectionEntries>
-                    <selectionEntry id="6b82-554f-3835-ff9e" name="Priest" hidden="false" collective="false" type="model">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7188-97c5-fe63-b28d" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33cd-4202-e952-646b" type="min"/>
-                      </constraints>
-                      <infoLinks>
-                        <infoLink id="99fb-c124-1a5c-b738" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                        <infoLink id="2699-41c0-1c3c-dad7" name="Divine Intervention" hidden="false" targetId="a447-d495-b7ab-1477" type="rule"/>
-                        <infoLink id="fde4-cb82-8a44-b36f" name="Wound 2" hidden="false" targetId="342b-a482-cb16-67e0" type="rule"/>
-                        <infoLink id="f356-629f-644f-e891" name="Priest" hidden="false" targetId="c78b-7b49-b75b-cdbc" type="profile"/>
-                        <infoLink id="c3a7-b9fa-8673-9451" name="Mace" hidden="false" targetId="abab-c6f8-5036-1cb4" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="64.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
                     <selectionEntry id="ad0c-8963-dd95-1834" name="Supplicant" hidden="false" collective="false" type="model">
                       <constraints>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abf3-a2f1-2d7f-14b0" type="max"/>
@@ -2257,7 +2160,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2265,30 +2168,28 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8381-b890-cfbf-5149" name="Hair Shirt Armour Upgrade" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8381-b890-cfbf-5149" name="Hair Shirt" hidden="false" collective="false" type="upgrade">
+              <selectionEntries>
+                <selectionEntry id="ebc6-915d-890d-5dcc" name="Priest" hidden="false" collective="false" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50ee-8c5b-7d6d-90e1" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7a9-1845-ac4f-827d" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="6a24-d549-9683-a3e7" name="Priest with Mace, in Hair Shirt" hidden="false" targetId="b344-2f18-9226-cd26" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="74.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <selectionEntryGroups>
-                <selectionEntryGroup id="b0d1-0d0b-8e30-7357" name="Hair Shirt Armour Upgrade" hidden="false" collective="false">
+                <selectionEntryGroup id="b0d1-0d0b-8e30-7357" name="Choose up to 2" hidden="false" collective="false">
                   <selectionEntries>
-                    <selectionEntry id="6d5f-6c61-be26-a2ad" name="Priest" hidden="false" collective="false" type="model">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63c0-a66a-5992-e1dd" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c72-d03e-d871-66dd" type="min"/>
-                      </constraints>
-                      <infoLinks>
-                        <infoLink id="7090-9efa-217c-6a2b" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                        <infoLink id="ac0d-23fc-f716-9bc0" name="Divine Intervention" hidden="false" targetId="a447-d495-b7ab-1477" type="rule"/>
-                        <infoLink id="769e-3035-0864-0052" name="Wound 2" hidden="false" targetId="342b-a482-cb16-67e0" type="rule"/>
-                        <infoLink id="2932-be75-e477-af2e" name="Mace" hidden="false" targetId="abab-c6f8-5036-1cb4" type="profile"/>
-                        <infoLink id="8b1f-c8f2-4ba6-f87e" name="Priest with Mace, in Hair Shirt" hidden="false" targetId="b344-2f18-9226-cd26" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="74.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
                     <selectionEntry id="1ff2-5e03-69dc-e75c" name="Supplicant" hidden="false" collective="false" type="model">
                       <constraints>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84b3-4163-b3ae-c245" type="max"/>
@@ -2298,7 +2199,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2306,7 +2207,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2323,86 +2224,16 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0e6e-07f5-507a-a342" name="Insufferably Sanctimonious (Tough 2)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0e6e-07f5-507a-a342" name="Tough 2" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="2ffd-99a4-cbfd-c0f0" name="Tough 2" hidden="false" targetId="487f-dc82-bce1-c0f6" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="ddad-d6c7-3b64-f745" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb43-615d-366c-3310" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="25e2-0350-0981-8e2c" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1be2-3db8-a36c-4871" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="34c1-fc8d-c37e-265e" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b8c6-b4bb-0de7-b1a4" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="95ab-4993-696f-b1d6" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5d56-15e6-d99f-fe80" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="58a8-95c6-cd47-b2d3" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8ce8-5377-56f5-a7da" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c984-fb5e-6157-f5fa" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9f19-237d-3723-76c8" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b362-21f8-9320-c5dd" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="786c-b6fb-7388-d803" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5c8c-b804-9281-c4b6" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="141a-f07e-4623-fbe5" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2410,10 +2241,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8927-f10c-9b13-777a" name="Knightly Chamption" hidden="false" collective="false" type="unit">
+    <selectionEntry id="8927-f10c-9b13-777a" name="Knightly Champion" hidden="false" collective="false" type="unit">
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c16-c59b-9330-4278" type="max"/>
       </constraints>
@@ -2421,15 +2252,16 @@
         <infoLink id="1994-ae7b-6fb9-c4a4" name="Knightly Chamption, Riding Warhorse" hidden="false" targetId="d182-66b1-1b85-a5ac" type="profile"/>
         <infoLink id="e76c-0f95-c923-c84f" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
         <infoLink id="0ee4-f46e-f644-8361" name="Lance" hidden="false" targetId="e601-dcfc-7485-2164" type="profile"/>
-        <infoLink id="59ad-cd68-5cc1-2169" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="59ad-cd68-5cc1-2169" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="9e8e-9ad4-3c9a-a51d" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
+        <categoryLink id="9e8e-9ad4-3c9a-a51d" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="false"/>
+        <categoryLink id="850a-2aaf-700a-f4a4" name="Hero Unit" hidden="false" targetId="hero unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="5631-7484-cf4c-d1a0" name="Challenge Upgrade" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="ec76-4a1b-5c31-f13d" name="Give Champion Challenge Rule" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ec76-4a1b-5c31-f13d" name="Challenge" hidden="false" collective="false" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de12-bbfa-cb4a-3c23" type="max"/>
               </constraints>
@@ -2438,14 +2270,14 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3fa0-9980-fbf3-4f75" name="Zealous" hidden="false" collective="false">
+        <selectionEntryGroup id="3fa0-9980-fbf3-4f75" name="Zealous Upgrade" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="e822-5d90-5892-297f" name="Give Champion Zealous rule" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e822-5d90-5892-297f" name="Zealous" hidden="false" collective="false" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8825-3e80-d3b4-68a4" type="max"/>
               </constraints>
@@ -2454,12 +2286,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6f1b-a35f-d346-3838" name="Tough " hidden="false" collective="false" defaultSelectionEntryId="7142-85d5-6100-3b00">
+        <selectionEntryGroup id="6f1b-a35f-d346-3838" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="7142-85d5-6100-3b00">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dcc-fcb6-c268-e0f7" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e638-a8b5-83c9-a9a3" type="min"/>
@@ -2471,7 +2303,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7142-85d5-6100-3b00" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2480,162 +2312,99 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="cfa2-c776-3c32-eea4" name="Wound upgrade" hidden="false" collective="false" defaultSelectionEntryId="4ac9-b8b0-e85a-dcaf">
+        <selectionEntryGroup id="cfa2-c776-3c32-eea4" name="Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="4ac9-b8b0-e85a-dcaf">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9af-3ada-acd8-6700" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d506-e187-5d67-72bd" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="dcb4-f8cf-4b56-1951" name="Upgrade to Wound 2" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="dcb4-f8cf-4b56-1951" name="Wound 2" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="ee85-ff15-1e72-058f" name="Wound 2" hidden="false" targetId="342b-a482-cb16-67e0" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="02b6-e293-1eaa-aa89" name="Upgrade to Wound 3" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="02b6-e293-1eaa-aa89" name="Wound 3" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="07d0-56ff-255c-d5ef" name="Wound 3" hidden="false" targetId="2724-2057-e745-23a3" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ac9-b8b0-e85a-dcaf" name="Wound" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="f849-752b-100c-904d" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+                <infoLink id="f849-752b-100c-904d" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="ee8e-7775-c32a-2a22" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d690-01ba-7685-d9ba" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="ca1d-88b2-2755-488d" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9fa3-8c93-6224-d5c3" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="bbd3-01a1-1f47-338b" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ff38-7d42-9382-7d58" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6002-14c0-1adb-94cc" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="f462-0afb-03d6-e605" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="99cb-1ec6-2f3b-b47b" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="f058-80f4-2aa5-e454" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="bbf9-0621-c970-a187" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1696-18b6-91ec-6c29" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2bff-c278-4a7a-a0c0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7208-0d5c-dd8e-11b6" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b0da-20ef-e2f7-4d9c" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7a04-3f3d-ba15-a976" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="2696-82ec-cb24-f172" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="96.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="21a8-e570-5189-b243" name="Mounted Lord Knight (128 pts base)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="21a8-e570-5189-b243" name="Mounted Lord Knight" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="e3a0-21d8-f120-35b9" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+        <infoLink id="4c41-c8a5-f2e0-1895" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7ac0-7f8a-f5e0-58c6" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="921e-59fc-b679-c149" name="Mounted Unit" hidden="false" targetId="mounted unit" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4b54-93f0-f0e8-f583" name="Lord Knight, Riding Horse" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cf9-40e1-81c6-ea65" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c9b-666e-fb99-563b" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6098-7994-f3a8-e974" name="Mounted Lord Knight" hidden="false" targetId="759d-3f08-25ee-42e1" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="88.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3787-653f-d829-e051" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="3787-653f-d829-e051" name="Bodyguard" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="0752-1d26-9c0e-a0e2" name="Lord Knight, Riding Horse" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d628-0a40-c789-2521" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cf4-905d-edeb-b395" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="66b0-7fc0-89b6-67ed" name="Mounted Lord Knight" hidden="false" targetId="759d-3f08-25ee-42e1" type="profile"/>
-                <infoLink id="5cf6-88b5-7cbf-b64f" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                <infoLink id="227d-65ac-91f0-e61b" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="88.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2e7d-6a10-5f2d-6186" name="Knights, Riding Horse" hidden="false" collective="false" type="model">
+            <selectionEntry id="2e7d-6a10-5f2d-6186" name="Mounted Knights" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dda1-6ca4-bc66-e26f" type="max"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e88a-b5d5-fd21-10f8" type="min"/>
               </constraints>
               <infoLinks>
-                <infoLink id="90b0-f25b-326a-aed6" name="Knights, Riding Warhorses (Lord knight retinue)" hidden="false" targetId="4ed9-bb0f-4cfa-caf1" type="profile"/>
+                <infoLink id="90b0-f25b-326a-aed6" name="Knights Riding Warhorses (Lord Retinue)" hidden="false" targetId="4ed9-bb0f-4cfa-caf1" type="profile"/>
                 <infoLink id="970d-056a-aac3-4d7e" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="db70-37cf-6a02-1c36" name="Weapon Choice" hidden="false" collective="false" defaultSelectionEntryId="ad2a-cd99-78eb-2e2e">
+        <selectionEntryGroup id="db70-37cf-6a02-1c36" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="ad2a-cd99-78eb-2e2e">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f2f-6c64-1070-2b95" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="112d-9993-fc3a-dc1d" type="min"/>
@@ -2647,7 +2416,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad2a-cd99-78eb-2e2e" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2656,10 +2425,10 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1605-9eb3-ff1b-cf99" name="Lances" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1605-9eb3-ff1b-cf99" name="Lance" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
@@ -2672,7 +2441,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2695,7 +2464,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2712,7 +2481,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="134a-2a30-4126-b981" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -2721,12 +2490,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4471-02d4-7298-bf74" name="Wound" hidden="false" collective="false" defaultSelectionEntryId="186a-19d1-55fe-2af2">
+        <selectionEntryGroup id="4471-02d4-7298-bf74" name="Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="186a-19d1-55fe-2af2">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fec9-1a4f-5173-2ad1" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f93-50ad-cfa5-eff6" type="min"/>
@@ -2738,7 +2507,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5763-1cd3-5807-b782" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2747,12 +2516,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d208-92b9-f1df-6903" name="Warhorses" hidden="false" collective="false" defaultSelectionEntryId="fc56-e07d-912e-4ec7">
+        <selectionEntryGroup id="d208-92b9-f1df-6903" name="Mounts" hidden="false" collective="false" defaultSelectionEntryId="fc56-e07d-912e-4ec7">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4cb-c035-64ac-2de4" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5275-9b8c-04d5-9037" type="min"/>
@@ -2771,7 +2540,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc56-e07d-912e-4ec7" name="Regular Horses" hidden="false" collective="false" type="upgrade">
@@ -2780,110 +2549,48 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="6a54-1d0a-a376-9a80" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc05-06ca-b3a0-78c8" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="295a-0a23-defa-8eb6" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9c3b-ab9a-1197-62bb" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4a8c-a520-95bf-f664" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="778a-2188-e5df-70b9" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="01a5-b233-5dc6-1855" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a301-2796-7620-d4fa" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9611-8723-3219-ca80" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d669-43fc-60f4-e2f8" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e372-fa4b-f227-9512" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="500e-c325-a44b-7b33" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="fb2f-c702-fc87-989d" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0263-b307-86ed-79f7" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="14c4-c81e-9719-ce60" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="025b-3e3c-f534-137d" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4e34-f31a-bed2-7cf7" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="671a-408e-2386-3c7e" name="Lord Knight (106 pts base)" hidden="false" collective="false" type="unit">
+    <selectionEntry id="671a-408e-2386-3c7e" name="Lord Knight" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="7a53-abc7-b8d2-3c24" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+        <infoLink id="a569-cbe1-88a8-a44f" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
+        <infoLink id="db4e-d2fc-e550-cec6" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="afab-21d2-59da-ee82" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
+        <categoryLink id="b56d-7e7c-a77c-557c" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d144-d085-765a-6362" name="Lord Knight" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1d7-3b58-0987-8568" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e93-4440-c044-ae4d" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f210-2f16-748b-d08c" name="Lord Knight (on foot)" hidden="false" targetId="694e-7556-d311-fa57" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="78.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="214d-b589-31b8-cfe5" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="214d-b589-31b8-cfe5" name="2 to 4 Bodyguard" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="c28b-2fda-e002-6210" name="Lord Knight" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d44-7c9a-8a8a-62ca" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82c8-e37d-2e6f-b193" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="862d-f993-22f3-055a" name="Lord Knight (on foot)" hidden="false" targetId="694e-7556-d311-fa57" type="profile"/>
-                <infoLink id="b11c-5a4c-dd71-e497" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
-                <infoLink id="65a1-dc63-9550-1cdb" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                <infoLink id="53f1-b18c-ee6c-3651" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="78.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="ac70-dd1d-aa51-2021" name="Knights" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a663-b36b-61b3-5c7a" type="max"/>
@@ -2894,7 +2601,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2911,7 +2618,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2cc5-0e7a-0c1e-5053" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2920,7 +2627,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66b0-aaf8-4e03-e8f6" name="Chain Mace" hidden="false" collective="false" type="upgrade">
@@ -2929,7 +2636,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4703-1bb9-d4cc-e959" name="Morning Star" hidden="false" collective="false" type="upgrade">
@@ -2938,7 +2645,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b9a-a7d1-e934-6569" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -2947,7 +2654,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="848d-5c98-7dbb-3651" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -2956,32 +2663,35 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a371-eec6-74fe-1232" name="Zealous Upgrade for unit" hidden="false" collective="false">
+        <selectionEntryGroup id="a371-eec6-74fe-1232" name="Zealous Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcc7-635d-5c35-8a0e" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="c9d2-6c40-8c61-dc32" name="Zealous" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="5">
+                <modifier type="increment" field="points" value="5.0">
                   <repeats>
                     <repeat field="selections" scope="671a-408e-2386-3c7e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
               </modifiers>
+              <infoLinks>
+                <infoLink id="a635-bfef-9bc1-521b" name="Zealous" hidden="false" targetId="45bb-28cf-94fd-f899" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="432a-0ebe-0f4a-4bd0" name="Lord Knight Tough selection" hidden="false" collective="false" defaultSelectionEntryId="8322-8332-b0ed-8623">
+        <selectionEntryGroup id="432a-0ebe-0f4a-4bd0" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="8322-8332-b0ed-8623">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc0d-8119-ee7f-7cf9" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e74-cb82-bf0d-fba9" type="min"/>
@@ -2993,7 +2703,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a74e-66c0-e86b-e60c" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -3002,12 +2712,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="69ca-883a-778d-625e" name="Lord Knight Wound Selection" hidden="false" collective="false" defaultSelectionEntryId="316e-159d-ea3e-b9c6">
+        <selectionEntryGroup id="69ca-883a-778d-625e" name="Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="316e-159d-ea3e-b9c6">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b79-9c92-39b2-7c30" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bca-1323-5532-e280" type="min"/>
@@ -3019,7 +2729,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df6b-4c99-d4a9-bc16" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -3028,85 +2738,18 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="3ec9-f8ab-54dd-7aaa" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9583-0d8d-0371-1d4b" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="ced3-6226-afe6-d2c1" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4f33-c1d2-728e-c1ae" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="62b6-feac-9c47-e8e3" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8463-2b53-45d8-ff92" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="61c7-1d0a-eee4-ea38" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="fdfc-9f18-b313-a635" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="511a-0396-1178-9bd1" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="39b0-adcd-f82f-316b" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f9f1-6634-a352-cd12" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b9b7-8b24-ec55-0871" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="55c2-c307-547b-2719" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="dbf0-a7e6-7415-2683" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6f92-e097-7f60-5a03" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="714e-5c11-5aef-21b2" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4daa-eb7d-c7bb-049a" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -3119,7 +2762,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Wound, Magic Level X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Wound 1, Magic Level X</characteristic>
       </characteristics>
     </profile>
     <profile id="dbaf-0a83-4e8f-dfe1" name="Wizards Familiars" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3130,7 +2773,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">3</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1X HTH SV1, Exchange of Missiles SV1, Spirit</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1x HtH SV1, Exchange of Missiles SV1, Spirit</characteristic>
       </characteristics>
     </profile>
     <profile id="1311-256f-9651-565a" name="Wizards Apprentices" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3152,7 +2795,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Heavily Laden</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Heavily Laden</characteristic>
       </characteristics>
     </profile>
     <profile id="4112-2c83-9786-b22a" name="Foot Knight" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3185,7 +2828,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="7709-0641-70ab-2371" name="Archer Seargeant" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3196,7 +2839,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="7acf-189b-31da-1ac0" name="Archer" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3218,7 +2861,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="9f19-6ae3-cefd-5539" name="Crossbowman" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3240,7 +2883,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Heavily Laden</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Heavily Laden</characteristic>
       </characteristics>
     </profile>
     <profile id="3a5d-4b88-f62e-bde7" name="Arbalestiers" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3262,7 +2905,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Surly</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Surly</characteristic>
       </characteristics>
     </profile>
     <profile id="6d26-f63a-895a-8a26" name="Peasant" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3284,7 +2927,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Zealous</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Zealous</characteristic>
       </characteristics>
     </profile>
     <profile id="852f-e917-51a2-2824" name="Flagellant" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3320,17 +2963,6 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="068f-4c8e-bdce-431a" name="Stone Thrower" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
-      <characteristics>
-        <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">-</characteristic>
-        <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
-        <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61">-</characteristic>
-        <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
-        <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
-        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
-      </characteristics>
-    </profile>
     <profile id="e8e3-531a-bab2-06c3" name="Crew" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
@@ -3350,7 +2982,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 8</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 8</characteristic>
       </characteristics>
     </profile>
     <profile id="95af-5a7d-f977-a1a9" name="Retainer" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3364,7 +2996,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 8</characteristic>
       </characteristics>
     </profile>
-    <profile id="b609-bb69-d924-5acc" name="Knight Leader, Riding Warhorse" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="b609-bb69-d924-5acc" name="Knight Leader Riding Warhorse" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">4</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3372,10 +3004,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 8, Warhorse: 1XHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 8, Warhorse: 1x HtH SV1</characteristic>
       </characteristics>
     </profile>
-    <profile id="b3cb-d600-a318-555b" name="Knight, Riding Warhorse" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="b3cb-d600-a318-555b" name="Knight Riding Warhorse" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">4</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3383,7 +3015,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 8, Warhorse: 1XHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 8, Warhorse: 1x HtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="c78b-7b49-b75b-cdbc" name="Priest with Mace" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3394,10 +3026,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Command, Divine Intervention, Wound 2</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Divine Intervention, Wound 2</characteristic>
       </characteristics>
     </profile>
-    <profile id="4481-df48-bbb3-7169" name="Supplicants with maces" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="4481-df48-bbb3-7169" name="Supplicants with Maces" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3408,7 +3040,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="d182-66b1-1b85-a5ac" name="Knightly Chamption, Riding Warhorse" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="d182-66b1-1b85-a5ac" name="Knightly Champion Riding Warhorse" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3416,7 +3048,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">9</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHTH, Wound X,  Warhorse:1xHTH SV1, Fast 8</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3x HtH, Wound X,  Warhorse:1x HtH SV1, Fast 8</characteristic>
       </characteristics>
     </profile>
     <profile id="c067-4245-7aa3-3f58" name="Warhorses" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3427,7 +3059,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1x HtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="759d-3f08-25ee-42e1" name="Mounted Lord Knight" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3438,10 +3070,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Command, Follow, Heavily Laden, Fast 8, 3xHTH, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, Heavily Laden, Fast 8, 3x HtH, Wound X</characteristic>
       </characteristics>
     </profile>
-    <profile id="4ed9-bb0f-4cfa-caf1" name="Knights, Riding Warhorses (Lord knight retinue)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="4ed9-bb0f-4cfa-caf1" name="Mounted Knights on Horses (Lord Retinue)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">4</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3452,7 +3084,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Heavily Laden, Fast 8</characteristic>
       </characteristics>
     </profile>
-    <profile id="694e-7556-d311-fa57" name="Lord Knight (on foot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="694e-7556-d311-fa57" name="Lord Knight" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">4</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3460,10 +3092,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Command, Follow, Heavily Laden, 3xHTH, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, Heavily Laden, 3x HtH, Wound X</characteristic>
       </characteristics>
     </profile>
-    <profile id="192f-7b31-a7cd-5680" name="Knights (on foot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="192f-7b31-a7cd-5680" name="Knights" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">4</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3474,7 +3106,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Heavily Laden</characteristic>
       </characteristics>
     </profile>
-    <profile id="b344-2f18-9226-cd26" name="Priest with Mace, in Hair Shirt" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="b344-2f18-9226-cd26" name="Priest with Mace in Hair Shirt" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3482,10 +3114,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Command, Divine Intervention, Wound 2</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Divine Intervention, Wound 2</characteristic>
       </characteristics>
     </profile>
-    <profile id="60d1-f087-9356-69af" name="Supplicants with maces in Hair Shirt" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="60d1-f087-9356-69af" name="Supplicants with Maces in Hair Shirt" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3504,7 +3136,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 8</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 8</characteristic>
       </characteristics>
     </profile>
     <profile id="f7da-f843-26a8-a7e5" name="Retainer in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3526,7 +3158,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="da81-52c7-fd8a-6b4d" name="Foot Retainer in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3548,7 +3180,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="a2c1-e2c6-7567-a0f7" name="Archer in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3570,7 +3202,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="694e-de7d-0762-b024" name="Crossbowman Seargeant in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3581,7 +3213,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="bb86-6822-a7e8-3f81" name="Crossbowman in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3614,7 +3246,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Heavily Laden</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Heavily Laden</characteristic>
       </characteristics>
     </profile>
     <profile id="4e6c-a882-4903-93a0" name="Arbalestiers Seargeant in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3625,7 +3257,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Heavily Laden</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Heavily Laden</characteristic>
       </characteristics>
     </profile>
     <profile id="361e-4d8c-3fac-2a68" name="Arbalestiers Seargeant in Heavy Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3636,7 +3268,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Heavily Laden</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Heavily Laden</characteristic>
       </characteristics>
     </profile>
     <profile id="5b14-68ce-e840-7729" name="Arbalestiers in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">

--- a/Knights.cat
+++ b/Knights.cat
@@ -103,7 +103,7 @@
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="d562-62fa-3b65-f227" name="Sword" hidden="false" collective="false" targetId="6ce7-b3cb-cc54-c24f" type="selectionEntry">
+            <entryLink id="d562-62fa-3b65-f227" name="Sword or Axe" hidden="false" collective="false" targetId="6ce7-b3cb-cc54-c24f" type="selectionEntry">
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
@@ -112,7 +112,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="acaf-afde-6d3c-dfe5" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="acaf-afde-6d3c-dfe5" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
             </entryLink>
           </entryLinks>
@@ -572,7 +572,7 @@
           <selectionEntries>
             <selectionEntry id="6e0a-053e-f8f1-4568" name="Swords" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="f6d0-437a-5053-75f0" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="f6d0-437a-5053-75f0" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -736,9 +736,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50e8-52a7-7585-117a" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="2f5f-e9d7-411c-bdd0" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2f5f-e9d7-411c-bdd0" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="312b-6537-d926-a5eb" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="312b-6537-d926-a5eb" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -916,7 +916,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f76a-5f18-209e-1a71" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="79b1-e8c9-76b1-6eaf" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="79b1-e8c9-76b1-6eaf" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
@@ -925,7 +925,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="b343-722d-da53-c3da" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="b343-722d-da53-c3da" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -999,7 +999,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="6e28-f3eb-a4e7-927a" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="6e28-f3eb-a4e7-927a" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1171,7 +1171,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="6513-4b0b-c89b-e1f8" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="6513-4b0b-c89b-e1f8" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1644,7 +1644,7 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3a5f-e63e-ac56-defd" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="3a5f-e63e-ac56-defd" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
@@ -1653,7 +1653,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="4ff2-758c-5a64-1efe" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="4ff2-758c-5a64-1efe" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1778,7 +1778,7 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="4f97-a2d2-e312-c471" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4f97-a2d2-e312-c471" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
@@ -1787,7 +1787,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="6794-212f-3389-51d7" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="6794-212f-3389-51d7" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1942,9 +1942,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1703-d04c-592a-d2ef" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="babf-6e69-56b5-fceb" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="babf-6e69-56b5-fceb" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="da79-5982-f828-2dec" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="da79-5982-f828-2dec" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2061,9 +2061,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5258-8162-38f2-03ea" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5258-8162-38f2-03ea" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="a1ce-fb66-c2a2-3ae0" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="a1ce-fb66-c2a2-3ae0" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2419,9 +2419,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="ad2a-cd99-78eb-2e2e" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ad2a-cd99-78eb-2e2e" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="33b5-29fb-b9c7-50f4" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="33b5-29fb-b9c7-50f4" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2621,9 +2621,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="2cc5-0e7a-0c1e-5053" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2cc5-0e7a-0c1e-5053" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="a70c-7ae8-5a8a-330e" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="a70c-7ae8-5a8a-330e" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>

--- a/Monsters.cat
+++ b/Monsters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ce73-81f1-52bf-8170" name="Monsters" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ce73-81f1-52bf-8170" name="Monsters" revision="3" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="359d-f1ed-6ac3-3016" name="Basilisk [158/178/198 pts]" hidden="false" collective="false" targetId="c7ea-f805-9726-6682" type="selectionEntry"/>
     <entryLink id="a95f-fd53-c1f1-9ece" name="Chimera [158/178/198 pts]" hidden="false" collective="false" targetId="ba39-ac09-15fb-f789" type="selectionEntry"/>
@@ -30,9 +30,6 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="c7ea-f805-9726-6682" name="Basilisk [158/178/198 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="b50b-63c0-d15b-5fae" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="94e4-ce18-68ed-b342" name="Baleful Glare" hidden="false" targetId="9855-31c9-3745-714d" type="rule"/>
@@ -52,19 +49,19 @@
             <selectionEntry id="c5a7-8e57-be4d-8c80" name="Wild Basilisk" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="158.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f3a3-9d1c-83ee-c624" name="Bound Basilisk" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="178.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1e81-3fb8-f486-f5a1" name="Allied Basilisk" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="198.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -72,13 +69,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ba39-ac09-15fb-f789" name="Chimera [158/178/198 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="007f-9486-f0f3-1f73" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="2304-6feb-8524-6d85" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -99,19 +93,19 @@
             <selectionEntry id="3a95-41d5-222d-e969" name="Wild Chimera" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="158.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8808-6e3a-105b-97fd" name="Bound Chimera" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="178.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18bd-1699-eadd-7ec2" name="Allied Chimera" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="198.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -127,7 +121,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -135,13 +129,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b01e-a8c7-82df-f6d8" name="Cockatrice [157/177/197 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="e451-e901-db8e-53bf" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="3268-1191-9ede-35f1" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -162,19 +153,19 @@
             <selectionEntry id="9bd8-50f1-127a-f210" name="Wild Cockatrice" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="157.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f172-d87b-3cae-700e" name="Bound Cockatrice" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="177.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e24a-ce4c-dde1-1d35" name="Allied Cockatrice" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="197.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -182,13 +173,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5b3b-b3f4-bbba-7609" name="Cyclops [150/170/190 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="31ea-673a-7d1d-8b0c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5057-ca34-d221-9d56" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -207,19 +195,19 @@
             <selectionEntry id="547a-d807-5442-8c10" name="Wild Cyclops" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="150.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e40a-8db7-c5c6-195b" name="Bound Cyclops" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="170.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7ec1-cc0d-fdd1-13cb" name="Allied Cyclops" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="190.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -235,7 +223,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -243,13 +231,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6617-5ad0-1f45-cbe3" name="Dragon [380/410/440 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="3.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="43bd-198f-38f9-4937" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5e9d-c84f-74ac-7e57" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -272,19 +257,19 @@
             <selectionEntry id="3e21-a58d-f9ab-e3b0" name="Wild Dragon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="380.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="39d6-1fc9-414d-1bd6" name="Bound Dragon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="410.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f91-1fec-a33b-76e9" name="Allied Dragon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="440.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -300,7 +285,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -316,7 +301,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -329,7 +314,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -342,7 +327,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -350,13 +335,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="3.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ff4-044a-e595-a1b7" name="Ghouls [85/95/105 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="26c9-5596-ea23-5088" name="Ghouls" hidden="false" targetId="7b72-6afa-c85b-64c1" type="profile"/>
       </infoLinks>
@@ -382,7 +364,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -404,7 +386,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -412,7 +394,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="85.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ae9e-2739-5689-b484" name="Bound Ghouls" hidden="false" collective="false" type="upgrade">
@@ -426,7 +408,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -434,7 +416,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58b1-de83-d5ce-5f03" name="Allied Ghouls" hidden="false" collective="false" type="upgrade">
@@ -448,7 +430,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -456,7 +438,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="105.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -469,7 +451,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -477,13 +459,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4fea-a33c-4fc3-b70b" name="Giant [253/283/313 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="3.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="67ff-6c49-1de3-34e7" name="Giant" hidden="false" targetId="e5bb-3c2b-9a60-9c05" type="profile"/>
         <infoLink id="cb89-14df-4900-c743" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -504,19 +483,19 @@
             <selectionEntry id="69bc-e6b8-ecbd-ab78" name="Wild Giant" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="253.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="735b-b165-3df7-5fe6" name="Bound Giant" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="283.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3ede-d6a0-25b7-5eb0" name="Allied Giant" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="313.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -532,7 +511,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -548,7 +527,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -556,13 +535,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="3.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d456-6e73-d1fc-5db4" name="Giant Rats [46/56/66 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="fcb1-715e-dd6d-1648" name="Giant Rats" hidden="false" targetId="cd05-6e8f-63cf-f6ad" type="profile"/>
         <infoLink id="2af1-c96c-56d5-a957" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
@@ -588,7 +564,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -596,7 +572,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="46.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9ff-9571-4ea4-40e6" name="Bound Giant Rats" hidden="false" collective="false" type="upgrade">
@@ -610,7 +586,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -618,7 +594,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="56.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="48e8-ed6c-33e2-7806" name="Allied Giant Rats" hidden="false" collective="false" type="upgrade">
@@ -632,7 +608,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -640,7 +616,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="66.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -653,7 +629,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -661,16 +637,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="452a-2a19-4531-92b8" name="Giant Scorpions [57/67/77 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="41f0-23ba-bb43-390b" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
-        <infoLink id="a718-0d20-0e0d-3d45" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+        <infoLink id="a718-0d20-0e0d-3d45" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
         <infoLink id="c6fa-f692-e046-66a2" name="Giant Scorpions" hidden="false" targetId="9cd1-3fa7-9244-5170" type="profile"/>
       </infoLinks>
       <categoryLinks>
@@ -694,7 +667,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -702,7 +675,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="57.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f4d0-49aa-8e85-20c3" name="Bound Giant Scorpions" hidden="false" collective="false" type="upgrade">
@@ -716,7 +689,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -724,7 +697,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="67.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27b3-fd62-b1f5-fb6a" name="Allied Giant Scorpions" hidden="false" collective="false" type="upgrade">
@@ -738,7 +711,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -746,7 +719,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="77.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -759,7 +732,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="59.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -767,15 +740,12 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="051b-44ef-ec3d-a1c1" name="Giant Spiders [50/60/70 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
-        <infoLink id="bcb1-41fa-2bc3-7fe0" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+        <infoLink id="bcb1-41fa-2bc3-7fe0" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
         <infoLink id="d2e8-3189-34b5-3822" name="Giant Spiders" hidden="false" targetId="70ab-0608-068e-a498" type="profile"/>
       </infoLinks>
       <categoryLinks>
@@ -799,7 +769,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -807,7 +777,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44f6-eaa3-c092-6ede" name="Bound Giant Spiders" hidden="false" collective="false" type="upgrade">
@@ -821,7 +791,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -829,7 +799,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5bf-349f-7dd0-f647" name="Allied Giant Spiders" hidden="false" collective="false" type="upgrade">
@@ -843,7 +813,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -851,7 +821,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="70.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -864,7 +834,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="52.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -872,13 +842,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2846-5918-fd84-7e29" name="Gigantic Spider [218/238/258 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="8ffb-7b41-1748-a62a" name="Gigantic Spider" hidden="false" targetId="ca3a-b6cb-8358-d7d9" type="profile"/>
         <infoLink id="0d8b-3229-a256-b8c6" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -898,19 +865,19 @@
             <selectionEntry id="89a1-e66a-a003-4cd8" name="Wild Gigantic Spider" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="218.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c54e-49dc-5a0c-3fbc" name="Bound Gigantic Spider" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="238.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ee0-30cf-e562-3f38" name="Allied Gigantic Spider" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="258.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -926,7 +893,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -934,18 +901,15 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7835-8a79-e484-397e" name="Golem [64 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="9df5-9e0f-f770-8a7c" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="1912-83de-49d8-38e3" name="Golem" hidden="false" targetId="ec10-cee9-9e3f-9783" type="profile"/>
-        <infoLink id="d239-a5d0-f4a2-ae19" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="a177-2893-16c8-de3a" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+        <infoLink id="96f8-3846-6d66-8680" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="2bc8-02d7-6109-2e47" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
@@ -960,7 +924,7 @@
             <selectionEntry id="1897-fb06-b190-6c50" name="Bound Golem" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="64.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -976,7 +940,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -984,13 +948,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b90a-e799-9047-9183" name="Griffin [144/164/184 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="ba6c-b5a4-87d6-9244" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="b17f-aa01-9b6f-27b9" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1012,19 +973,19 @@
             <selectionEntry id="a3bf-db9b-f57b-6e62" name="Wild Griffin" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="144.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b370-b36b-43ca-a71c" name="Bound Griffon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="164.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b331-fbf6-1c50-ebee" name="Allied Griffin" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="184.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1032,13 +993,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="30d1-8869-3361-d27b" name="Hippogriff [138/159/179 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="1fae-240f-11ae-1659" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="794e-15ba-aeff-8c62" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1059,19 +1017,19 @@
             <selectionEntry id="70a7-aa27-b130-ad73" name="Wild Hippogriff" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="138.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c8c8-e773-51c3-6cee" name="Bound Hippogriff" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="159.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3a43-2059-fef8-b1b2" name="Allied Hippogriff" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="179.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1079,13 +1037,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1826-be4d-e802-d903" name="Hydra [182/202/222 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="50a9-c5bc-9431-4e0a" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="bd23-8ea6-af19-6925" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1106,19 +1061,19 @@
             <selectionEntry id="cb50-75bc-b388-29f5" name="Wild Hydra" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="182.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a1ee-e6d1-d095-f330" name="Bound Hydra" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="202.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed64-f50f-d38e-3488" name="Allied Hydra" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="222.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1135,7 +1090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1151,7 +1106,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1159,13 +1114,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3c5b-7264-8586-c81c" name="Manticore [158/178/198 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="82a1-b369-5dad-45a8" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="c30c-22bf-14f9-b0a7" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1184,19 +1136,19 @@
             <selectionEntry id="944c-8f6d-0c3c-2775" name="Wild Manticore" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="158.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b02e-ae6c-1e3f-9414" name="Bound Manticore" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="178.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5f8a-a49e-21b5-2691" name="Allied Manticore" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="198.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1212,7 +1164,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1232,7 +1184,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da4b-100f-1b25-b303" name="Manticore" hidden="false" collective="false" type="upgrade">
@@ -1244,7 +1196,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1252,13 +1204,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bdbd-2e9c-63ce-9620" name="Ogres [28/38/48 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="a08d-bc50-05c7-48a5" name="Frenzied Charge" hidden="false" targetId="1c49-276e-425d-0999" type="rule"/>
         <infoLink id="dbec-2695-bc32-575e" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1276,19 +1225,19 @@
             <selectionEntry id="10fd-618a-e4ea-206c" name="Wild" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95ed-5dcf-9a9f-723c" name="Bound" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="84ab-9d2d-9bd0-f9f9" name="Allied" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1313,7 +1262,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1321,7 +1270,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="49d4-9052-fe2a-c388" name="Ogres in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1338,7 +1287,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1346,7 +1295,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1363,7 +1312,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96a6-d255-dca8-5529" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -1372,7 +1321,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce2a-712b-0058-45d6" name="Warhammer" hidden="false" collective="false" type="upgrade">
@@ -1381,7 +1330,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c4b-eb71-1dbf-f127" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1390,7 +1339,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1410,7 +1359,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1418,13 +1367,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="71af-c82c-450e-2b37" name="Wild Swarms [75 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="d22a-534c-0358-514b" name="New CategoryLink" hidden="false" targetId="c820-d327-811d-1144" primary="true"/>
       </categoryLinks>
@@ -1442,7 +1388,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="22d1-b18d-b1a9-e05c" name="Batswarm" hidden="false" collective="false" type="upgrade">
@@ -1453,7 +1399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b3f8-e4f3-9d0f-6baa" name="Spiderswarm" hidden="false" collective="false" type="upgrade">
@@ -1462,7 +1408,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5baa-7f1c-6d03-a96e" name="Frogswarm" hidden="false" collective="false" type="upgrade">
@@ -1472,7 +1418,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3259-16f8-1a76-b829" name="Beeswarm" hidden="false" collective="false" type="upgrade">
@@ -1483,7 +1429,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3291-9eba-d0a4-e5d7" name="Serpentswarm" hidden="false" collective="false" type="upgrade">
@@ -1494,7 +1440,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1508,7 +1454,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1516,13 +1462,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5943-a398-3d77-7af7" name="Wyvern [160/180/200 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="8047-0ae2-5fde-30a9" name="Wyvern " hidden="false" targetId="c844-35e2-768e-50f8" type="profile"/>
         <infoLink id="e741-a542-0958-f574" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1542,19 +1485,19 @@
             <selectionEntry id="3692-feb9-6467-959f" name="Wild Wyvern" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="160.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dfe9-9eec-b034-aa25" name="Bound Wyvern" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="180.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8f81-0caf-1d01-ec4b" name="Allied Wyvern" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="200.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1571,7 +1514,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96dd-35c0-46c4-15f6" name="Beastly Breath" hidden="false" collective="false" type="upgrade">
@@ -1580,7 +1523,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1597,7 +1540,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d229-e8a7-8781-1915" name="Venomous" hidden="false" collective="false" type="upgrade">
@@ -1606,7 +1549,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1614,13 +1557,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="853f-a790-4f4e-0d98" name="Allied Giant Treeman [204 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="ca7a-c26f-0c79-0909" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="d13a-f5db-2a1a-6350" name="Blundering" hidden="false" targetId="087e-dfda-76c2-09bf" type="rule"/>
@@ -1646,7 +1586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="204.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1662,7 +1602,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1670,13 +1610,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6491-3e79-cfd5-76db" name="Allied Treemen/Dryads" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="8bc0-6f99-fbe7-77ca" name="Blundering" hidden="false" targetId="087e-dfda-76c2-09bf" type="rule"/>
         <infoLink id="4bb4-42a6-3f94-eca5" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1701,7 +1638,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="53.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f347-3d89-8a61-7e10" name="Additional Treemen/Dryads" hidden="false" collective="false" type="model">
@@ -1710,7 +1647,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="33.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1718,13 +1655,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="45c6-60cf-f892-7efa" name="Trolls [105/115 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="9a36-64d4-76ed-3e08" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5d10-c992-7ceb-8196" name="Regenerate" hidden="false" targetId="0a0c-ed4c-9647-4398" type="rule"/>
@@ -1746,7 +1680,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1760,13 +1694,13 @@
             <selectionEntry id="2270-2d2f-e43a-4d4f" name="Wild" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5c2-0b03-6640-007c" name="Bound" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1774,19 +1708,16 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cfc8-c933-eeab-5e21" name="Cave Bear" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="88c6-0967-6a45-8abc" name="Cave Bear" hidden="false" targetId="da16-d143-b468-26c3" type="profile"/>
         <infoLink id="2201-d7c9-fea8-e342" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="6708-cc7f-f63e-a0e6" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
         <infoLink id="c317-b222-9e18-d240" name="Frenzied Charge" hidden="false" targetId="1c49-276e-425d-0999" type="rule"/>
-        <infoLink id="356c-23b5-7702-d775" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+        <infoLink id="356c-23b5-7702-d775" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="470e-6966-9ba9-ed81" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
@@ -1801,13 +1732,13 @@
             <selectionEntry id="8466-565c-872e-39ef" name="Wild Cave Bear" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="21e9-914d-c0a4-f6dd" name="Allied Were Bear" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="82.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1815,13 +1746,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="903f-9d10-4831-bf0f" name="Brontosaur [115/135 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="2fcb-45a2-d98b-188f" name="Brontosaur" hidden="false" targetId="5ca4-7d22-6678-4dc5" type="profile"/>
         <infoLink id="eeea-e415-ab59-aba9" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1841,13 +1769,13 @@
             <selectionEntry id="6ee4-fa2e-f18a-e585" name="Wild Brontosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="115.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="93f4-cb20-966f-0aeb" name="Bound Brontosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="135.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1855,13 +1783,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4f7e-f547-4d5a-8c7c" name="Tyrannosaur [188/208 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="0a43-75c0-306c-dc81" name="Tyrannosaur" hidden="false" targetId="c74b-e0c7-6a3d-bc2a" type="profile"/>
         <infoLink id="ee39-5489-a196-f333" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1882,13 +1807,13 @@
             <selectionEntry id="2346-0528-6126-5d9f" name="Wild Tyrannosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="188.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c57-a04b-6fb8-7f01" name="Bound Tyrannosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="208.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1896,13 +1821,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3aff-bbec-a820-725d" name="Horned Dinosaur [122/142 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="fe58-085f-9e71-bc8e" name="Horned Dinosaur" hidden="false" targetId="68aa-6640-b9da-6ee0" type="profile"/>
         <infoLink id="307f-3fd4-9ab7-6ece" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1923,13 +1845,13 @@
             <selectionEntry id="09d1-5c85-75f4-4881" name="Wild Horned Dinosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="122.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="12dd-9ea6-8083-cb4a" name="Bound Horned Dinosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="142.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1937,7 +1859,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Monsters.cat
+++ b/Monsters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ce73-81f1-52bf-8170" name="Monsters" revision="1" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="ce73-81f1-52bf-8170" name="Monsters" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="359d-f1ed-6ac3-3016" name="Basilisk [158/178/198 pts]" hidden="false" collective="false" targetId="c7ea-f805-9726-6682" type="selectionEntry"/>
     <entryLink id="a95f-fd53-c1f1-9ece" name="Chimera [158/178/198 pts]" hidden="false" collective="false" targetId="ba39-ac09-15fb-f789" type="selectionEntry"/>
@@ -30,6 +30,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="c7ea-f805-9726-6682" name="Basilisk [158/178/198 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="b50b-63c0-d15b-5fae" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="94e4-ce18-68ed-b342" name="Baleful Glare" hidden="false" targetId="9855-31c9-3745-714d" type="rule"/>
@@ -49,16 +52,19 @@
             <selectionEntry id="c5a7-8e57-be4d-8c80" name="Wild Basilisk" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="158.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f3a3-9d1c-83ee-c624" name="Bound Basilisk" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="178.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1e81-3fb8-f486-f5a1" name="Allied Basilisk" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="198.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -66,9 +72,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ba39-ac09-15fb-f789" name="Chimera [158/178/198 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="007f-9486-f0f3-1f73" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="2304-6feb-8524-6d85" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -89,16 +99,19 @@
             <selectionEntry id="3a95-41d5-222d-e969" name="Wild Chimera" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="158.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8808-6e3a-105b-97fd" name="Bound Chimera" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="178.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18bd-1699-eadd-7ec2" name="Allied Chimera" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="198.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -114,6 +127,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -121,9 +135,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b01e-a8c7-82df-f6d8" name="Cockatrice [157/177/197 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="e451-e901-db8e-53bf" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="3268-1191-9ede-35f1" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -144,16 +162,19 @@
             <selectionEntry id="9bd8-50f1-127a-f210" name="Wild Cockatrice" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="157.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f172-d87b-3cae-700e" name="Bound Cockatrice" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="177.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e24a-ce4c-dde1-1d35" name="Allied Cockatrice" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="197.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -161,9 +182,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5b3b-b3f4-bbba-7609" name="Cyclops [150/170/190 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="31ea-673a-7d1d-8b0c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5057-ca34-d221-9d56" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -182,16 +207,19 @@
             <selectionEntry id="547a-d807-5442-8c10" name="Wild Cyclops" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="150.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e40a-8db7-c5c6-195b" name="Bound Cyclops" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="170.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7ec1-cc0d-fdd1-13cb" name="Allied Cyclops" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="190.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -207,6 +235,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -214,9 +243,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6617-5ad0-1f45-cbe3" name="Dragon [380/410/440 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="3.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="43bd-198f-38f9-4937" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5e9d-c84f-74ac-7e57" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -239,16 +272,19 @@
             <selectionEntry id="3e21-a58d-f9ab-e3b0" name="Wild Dragon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="380.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="39d6-1fc9-414d-1bd6" name="Bound Dragon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="410.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f91-1fec-a33b-76e9" name="Allied Dragon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="440.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -264,6 +300,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -279,6 +316,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -291,6 +329,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -303,6 +342,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -310,9 +350,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ff4-044a-e595-a1b7" name="Ghouls [85/95/105 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="26c9-5596-ea23-5088" name="Ghouls" hidden="false" targetId="7b72-6afa-c85b-64c1" type="profile"/>
       </infoLinks>
@@ -338,6 +382,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -359,6 +404,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -366,6 +412,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="85.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ae9e-2739-5689-b484" name="Bound Ghouls" hidden="false" collective="false" type="upgrade">
@@ -379,6 +426,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -386,6 +434,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58b1-de83-d5ce-5f03" name="Allied Ghouls" hidden="false" collective="false" type="upgrade">
@@ -399,6 +448,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -406,6 +456,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="105.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -418,6 +469,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="17.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -425,9 +477,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4fea-a33c-4fc3-b70b" name="Giant [253/283/313 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="3.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="67ff-6c49-1de3-34e7" name="Giant" hidden="false" targetId="e5bb-3c2b-9a60-9c05" type="profile"/>
         <infoLink id="cb89-14df-4900-c743" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -448,16 +504,19 @@
             <selectionEntry id="69bc-e6b8-ecbd-ab78" name="Wild Giant" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="253.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="735b-b165-3df7-5fe6" name="Bound Giant" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="283.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3ede-d6a0-25b7-5eb0" name="Allied Giant" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="313.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -473,6 +532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -488,6 +548,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -495,9 +556,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d456-6e73-d1fc-5db4" name="Giant Rats [46/56/66 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="fcb1-715e-dd6d-1648" name="Giant Rats" hidden="false" targetId="cd05-6e8f-63cf-f6ad" type="profile"/>
         <infoLink id="2af1-c96c-56d5-a957" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
@@ -523,6 +588,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -530,6 +596,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="46.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9ff-9571-4ea4-40e6" name="Bound Giant Rats" hidden="false" collective="false" type="upgrade">
@@ -543,6 +610,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -550,6 +618,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="56.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="48e8-ed6c-33e2-7806" name="Allied Giant Rats" hidden="false" collective="false" type="upgrade">
@@ -563,6 +632,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -570,6 +640,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="66.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -582,6 +653,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -589,9 +661,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="452a-2a19-4531-92b8" name="Giant Scorpions [57/67/77 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="41f0-23ba-bb43-390b" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
         <infoLink id="a718-0d20-0e0d-3d45" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
@@ -618,6 +694,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -625,6 +702,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="57.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f4d0-49aa-8e85-20c3" name="Bound Giant Scorpions" hidden="false" collective="false" type="upgrade">
@@ -638,6 +716,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -645,6 +724,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="67.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27b3-fd62-b1f5-fb6a" name="Allied Giant Scorpions" hidden="false" collective="false" type="upgrade">
@@ -658,6 +738,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -665,6 +746,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="77.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -677,6 +759,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="59.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -684,9 +767,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="051b-44ef-ec3d-a1c1" name="Giant Spiders [50/60/70 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="bcb1-41fa-2bc3-7fe0" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
         <infoLink id="d2e8-3189-34b5-3822" name="Giant Spiders" hidden="false" targetId="70ab-0608-068e-a498" type="profile"/>
@@ -712,6 +799,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -719,6 +807,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44f6-eaa3-c092-6ede" name="Bound Giant Spiders" hidden="false" collective="false" type="upgrade">
@@ -732,6 +821,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -739,6 +829,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5bf-349f-7dd0-f647" name="Allied Giant Spiders" hidden="false" collective="false" type="upgrade">
@@ -752,6 +843,7 @@
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -759,6 +851,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="70.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -771,6 +864,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="52.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -778,9 +872,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2846-5918-fd84-7e29" name="Gigantic Spider [218/238/258 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="8ffb-7b41-1748-a62a" name="Gigantic Spider" hidden="false" targetId="ca3a-b6cb-8358-d7d9" type="profile"/>
         <infoLink id="0d8b-3229-a256-b8c6" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -800,16 +898,19 @@
             <selectionEntry id="89a1-e66a-a003-4cd8" name="Wild Gigantic Spider" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="218.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c54e-49dc-5a0c-3fbc" name="Bound Gigantic Spider" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="238.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ee0-30cf-e562-3f38" name="Allied Gigantic Spider" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="258.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -825,6 +926,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -832,9 +934,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7835-8a79-e484-397e" name="Golem [64 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="9df5-9e0f-f770-8a7c" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="1912-83de-49d8-38e3" name="Golem" hidden="false" targetId="ec10-cee9-9e3f-9783" type="profile"/>
@@ -854,6 +960,7 @@
             <selectionEntry id="1897-fb06-b190-6c50" name="Bound Golem" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="64.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -869,6 +976,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -876,9 +984,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b90a-e799-9047-9183" name="Griffin [144/164/184 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="ba6c-b5a4-87d6-9244" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="b17f-aa01-9b6f-27b9" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -900,16 +1012,19 @@
             <selectionEntry id="a3bf-db9b-f57b-6e62" name="Wild Griffin" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="144.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b370-b36b-43ca-a71c" name="Bound Griffon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="164.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b331-fbf6-1c50-ebee" name="Allied Griffin" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="184.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -917,9 +1032,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="30d1-8869-3361-d27b" name="Hippogriff [138/159/179 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="1fae-240f-11ae-1659" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="794e-15ba-aeff-8c62" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -940,16 +1059,19 @@
             <selectionEntry id="70a7-aa27-b130-ad73" name="Wild Hippogriff" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="138.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c8c8-e773-51c3-6cee" name="Bound Hippogriff" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="159.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3a43-2059-fef8-b1b2" name="Allied Hippogriff" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="179.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -957,9 +1079,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1826-be4d-e802-d903" name="Hydra [182/202/222 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="50a9-c5bc-9431-4e0a" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="bd23-8ea6-af19-6925" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -980,16 +1106,19 @@
             <selectionEntry id="cb50-75bc-b388-29f5" name="Wild Hydra" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="182.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a1ee-e6d1-d095-f330" name="Bound Hydra" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="202.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed64-f50f-d38e-3488" name="Allied Hydra" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="222.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1006,6 +1135,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1021,6 +1151,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1028,9 +1159,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3c5b-7264-8586-c81c" name="Manticore [158/178/198 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="82a1-b369-5dad-45a8" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="c30c-22bf-14f9-b0a7" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1049,16 +1184,19 @@
             <selectionEntry id="944c-8f6d-0c3c-2775" name="Wild Manticore" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="158.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b02e-ae6c-1e3f-9414" name="Bound Manticore" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="178.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5f8a-a49e-21b5-2691" name="Allied Manticore" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="198.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1074,6 +1212,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1093,6 +1232,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da4b-100f-1b25-b303" name="Manticore" hidden="false" collective="false" type="upgrade">
@@ -1102,15 +1242,23 @@
               <infoLinks>
                 <infoLink id="53fc-6c57-de7f-c9d6" name="Manticore" hidden="false" targetId="3bd1-e1ac-0073-8b2f" type="profile"/>
               </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bdbd-2e9c-63ce-9620" name="Ogres [28/38/48 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="a08d-bc50-05c7-48a5" name="Frenzied Charge" hidden="false" targetId="1c49-276e-425d-0999" type="rule"/>
         <infoLink id="dbec-2695-bc32-575e" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1128,16 +1276,19 @@
             <selectionEntry id="10fd-618a-e4ea-206c" name="Wild" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95ed-5dcf-9a9f-723c" name="Bound" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="84ab-9d2d-9bd0-f9f9" name="Allied" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1162,6 +1313,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1169,6 +1321,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="49d4-9052-fe2a-c388" name="Ogres in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1185,6 +1338,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1192,6 +1346,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1208,6 +1363,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96a6-d255-dca8-5529" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -1216,6 +1372,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce2a-712b-0058-45d6" name="Warhammer" hidden="false" collective="false" type="upgrade">
@@ -1224,6 +1381,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c4b-eb71-1dbf-f127" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1232,6 +1390,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1251,6 +1410,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1258,9 +1418,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="71af-c82c-450e-2b37" name="Wild Swarms [75 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d22a-534c-0358-514b" name="New CategoryLink" hidden="false" targetId="c820-d327-811d-1144" primary="true"/>
       </categoryLinks>
@@ -1278,6 +1442,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="22d1-b18d-b1a9-e05c" name="Batswarm" hidden="false" collective="false" type="upgrade">
@@ -1288,6 +1453,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b3f8-e4f3-9d0f-6baa" name="Spiderswarm" hidden="false" collective="false" type="upgrade">
@@ -1296,6 +1462,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5baa-7f1c-6d03-a96e" name="Frogswarm" hidden="false" collective="false" type="upgrade">
@@ -1305,6 +1472,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3259-16f8-1a76-b829" name="Beeswarm" hidden="false" collective="false" type="upgrade">
@@ -1315,6 +1483,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3291-9eba-d0a4-e5d7" name="Serpentswarm" hidden="false" collective="false" type="upgrade">
@@ -1325,6 +1494,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1338,6 +1508,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1345,9 +1516,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5943-a398-3d77-7af7" name="Wyvern [160/180/200 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="8047-0ae2-5fde-30a9" name="Wyvern " hidden="false" targetId="c844-35e2-768e-50f8" type="profile"/>
         <infoLink id="e741-a542-0958-f574" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1367,16 +1542,19 @@
             <selectionEntry id="3692-feb9-6467-959f" name="Wild Wyvern" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="160.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dfe9-9eec-b034-aa25" name="Bound Wyvern" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="180.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8f81-0caf-1d01-ec4b" name="Allied Wyvern" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="200.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1393,6 +1571,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96dd-35c0-46c4-15f6" name="Beastly Breath" hidden="false" collective="false" type="upgrade">
@@ -1401,6 +1580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1417,6 +1597,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d229-e8a7-8781-1915" name="Venomous" hidden="false" collective="false" type="upgrade">
@@ -1425,6 +1606,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1432,9 +1614,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="853f-a790-4f4e-0d98" name="Allied Giant Treeman [204 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="ca7a-c26f-0c79-0909" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="d13a-f5db-2a1a-6350" name="Blundering" hidden="false" targetId="087e-dfda-76c2-09bf" type="rule"/>
@@ -1460,6 +1646,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="204.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1475,6 +1662,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1482,9 +1670,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6491-3e79-cfd5-76db" name="Allied Treemen/Dryads" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="8bc0-6f99-fbe7-77ca" name="Blundering" hidden="false" targetId="087e-dfda-76c2-09bf" type="rule"/>
         <infoLink id="4bb4-42a6-3f94-eca5" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1509,6 +1701,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="53.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f347-3d89-8a61-7e10" name="Additional Treemen/Dryads" hidden="false" collective="false" type="model">
@@ -1517,6 +1710,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="33.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1524,9 +1718,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="45c6-60cf-f892-7efa" name="Trolls [105/115 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="9a36-64d4-76ed-3e08" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5d10-c992-7ceb-8196" name="Regenerate" hidden="false" targetId="0a0c-ed4c-9647-4398" type="rule"/>
@@ -1548,6 +1746,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1561,11 +1760,13 @@
             <selectionEntry id="2270-2d2f-e43a-4d4f" name="Wild" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5c2-0b03-6640-007c" name="Bound" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1573,9 +1774,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cfc8-c933-eeab-5e21" name="Cave Bear" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="88c6-0967-6a45-8abc" name="Cave Bear" hidden="false" targetId="da16-d143-b468-26c3" type="profile"/>
         <infoLink id="2201-d7c9-fea8-e342" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1596,11 +1801,13 @@
             <selectionEntry id="8466-565c-872e-39ef" name="Wild Cave Bear" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="21e9-914d-c0a4-f6dd" name="Allied Were Bear" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="82.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1608,9 +1815,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="903f-9d10-4831-bf0f" name="Brontosaur [115/135 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2fcb-45a2-d98b-188f" name="Brontosaur" hidden="false" targetId="5ca4-7d22-6678-4dc5" type="profile"/>
         <infoLink id="eeea-e415-ab59-aba9" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1630,11 +1841,13 @@
             <selectionEntry id="6ee4-fa2e-f18a-e585" name="Wild Brontosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="115.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="93f4-cb20-966f-0aeb" name="Bound Brontosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="135.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1642,9 +1855,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4f7e-f547-4d5a-8c7c" name="Tyrannosaur [188/208 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="0a43-75c0-306c-dc81" name="Tyrannosaur" hidden="false" targetId="c74b-e0c7-6a3d-bc2a" type="profile"/>
         <infoLink id="ee39-5489-a196-f333" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1665,11 +1882,13 @@
             <selectionEntry id="2346-0528-6126-5d9f" name="Wild Tyrannosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="188.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c57-a04b-6fb8-7f01" name="Bound Tyrannosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="208.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1677,9 +1896,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3aff-bbec-a820-725d" name="Horned Dinosaur [122/142 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="fe58-085f-9e71-bc8e" name="Horned Dinosaur" hidden="false" targetId="68aa-6640-b9da-6ee0" type="profile"/>
         <infoLink id="307f-3fd4-9ab7-6ece" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
@@ -1700,11 +1923,13 @@
             <selectionEntry id="09d1-5c85-75f4-4881" name="Wild Horned Dinosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="122.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="12dd-9ea6-8083-cb4a" name="Bound Horned Dinosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="142.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1712,6 +1937,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -1722,7 +1948,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="9f01-a520-920a-bd90" name="Basilisk" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="9f01-a520-920a-bd90" name="Basilisk" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">4</characteristic>
@@ -1733,7 +1959,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV4, Baleful Glare, Dread</characteristic>
       </characteristics>
     </profile>
-    <profile id="2dbb-4ea1-5f93-dce3" name="Chimera" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="2dbb-4ea1-5f93-dce3" name="Chimera" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">4</characteristic>
@@ -1744,7 +1970,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD 2, 4xHTH SV4, 1xHTH SV10 Venomous, 3xFlaming Breath SV3 Fire, Dread</characteristic>
       </characteristics>
     </profile>
-    <profile id="0184-c48d-2234-cbf7" name="Cockatrice" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="0184-c48d-2234-cbf7" name="Cockatrice" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">4</characteristic>
@@ -1755,7 +1981,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH Attacks SV3, Baleful Glare, Dread, Flies</characteristic>
       </characteristics>
     </profile>
-    <profile id="fdd9-726d-86fe-ec2d" name="Cyclops" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="fdd9-726d-86fe-ec2d" name="Cyclops" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -1775,7 +2001,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Overhead, Fire Order to Shoot, D6 hits</characteristic>
       </characteristics>
     </profile>
-    <profile id="51fb-1d59-eff1-b671" name="Dragon" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="51fb-1d59-eff1-b671" name="Dragon" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">4</characteristic>
@@ -1786,7 +2012,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD3, Fast 6, 7xHTH SV6, 3xFlaming Breath SV3 Fire, Dread, Terror, Flies</characteristic>
       </characteristics>
     </profile>
-    <profile id="7b72-6afa-c85b-64c1" name="Ghouls" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="7b72-6afa-c85b-64c1" name="Ghouls" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1797,7 +2023,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHTH SV1</characteristic>
       </characteristics>
     </profile>
-    <profile id="e5bb-3c2b-9a60-9c05" name="Giant" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="e5bb-3c2b-9a60-9c05" name="Giant" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -1808,7 +2034,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD3, 5xHTH SV5, Dread, Terror, Blundering</characteristic>
       </characteristics>
     </profile>
-    <profile id="cd05-6e8f-63cf-f6ad" name="Giant Rats" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="cd05-6e8f-63cf-f6ad" name="Giant Rats" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1819,7 +2045,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHTH SV1 Venomous</characteristic>
       </characteristics>
     </profile>
-    <profile id="9cd1-3fa7-9244-5170" name="Giant Scorpions" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="9cd1-3fa7-9244-5170" name="Giant Scorpions" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1830,7 +2056,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHTH SV2, 1xHTH SV10, Venomous, Wound</characteristic>
       </characteristics>
     </profile>
-    <profile id="70ab-0608-068e-a498" name="Giant Spiders" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="70ab-0608-068e-a498" name="Giant Spiders" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1841,7 +2067,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV3, Wound</characteristic>
       </characteristics>
     </profile>
-    <profile id="ca3a-b6cb-8358-d7d9" name="Gigantic Spider" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="ca3a-b6cb-8358-d7d9" name="Gigantic Spider" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1852,7 +2078,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 6xHTH SV6, Dread, Terror</characteristic>
       </characteristics>
     </profile>
-    <profile id="ec10-cee9-9e3f-9783" name="Golem" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="ec10-cee9-9e3f-9783" name="Golem" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">3</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1863,7 +2089,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Slow 4, 3xHTH SV2, Dread</characteristic>
       </characteristics>
     </profile>
-    <profile id="61f2-9f86-a3d8-d5e8" name="Griffin" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="61f2-9f86-a3d8-d5e8" name="Griffin" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1874,7 +2100,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV3, Dread, Savage, Fast 6, Flies</characteristic>
       </characteristics>
     </profile>
-    <profile id="7ea6-624e-3017-99b2" name="Hippogriff" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="7ea6-624e-3017-99b2" name="Hippogriff" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1885,7 +2111,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV3, Dread, Fast 6, Flies</characteristic>
       </characteristics>
     </profile>
-    <profile id="6e13-9d18-f7c2-d272" name="Hydra" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="6e13-9d18-f7c2-d272" name="Hydra" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -1896,7 +2122,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 9xHTH SV2, Stubborn, Dread, Regenerate</characteristic>
       </characteristics>
     </profile>
-    <profile id="3bd1-e1ac-0073-8b2f" name="Manticore" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="3bd1-e1ac-0073-8b2f" name="Manticore" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -1907,7 +2133,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV4, Beastly breath, Dread</characteristic>
       </characteristics>
     </profile>
-    <profile id="c57c-29b1-6dce-2cb0" name="Ogres" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="c57c-29b1-6dce-2cb0" name="Ogres" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -1918,7 +2144,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 2xHTH, Frenzied Charge</characteristic>
       </characteristics>
     </profile>
-    <profile id="4c9f-6aab-32b0-d91d" name="Ogres in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="4c9f-6aab-32b0-d91d" name="Ogres in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -1929,7 +2155,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 2xHTH, Frenzied Charge</characteristic>
       </characteristics>
     </profile>
-    <profile id="e8bd-7b95-1cce-09a4" name="Wild Ratswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="e8bd-7b95-1cce-09a4" name="Wild Ratswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1940,7 +2166,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV1 Venomous</characteristic>
       </characteristics>
     </profile>
-    <profile id="3476-9800-ad47-8c84" name="Wild Batswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="3476-9800-ad47-8c84" name="Wild Batswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1951,7 +2177,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV1, Flies, Fast 7</characteristic>
       </characteristics>
     </profile>
-    <profile id="ed6e-31c3-36b2-839f" name="Wild Spiderswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="ed6e-31c3-36b2-839f" name="Wild Spiderswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1962,7 +2188,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">4xHTH SV0</characteristic>
       </characteristics>
     </profile>
-    <profile id="1611-c370-3e68-d00a" name="Wild Frogswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="1611-c370-3e68-d00a" name="Wild Frogswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1973,7 +2199,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV0, Dread</characteristic>
       </characteristics>
     </profile>
-    <profile id="5319-4ee6-a650-6292" name="Wild Beeswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="5319-4ee6-a650-6292" name="Wild Beeswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -1984,7 +2210,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV0, Venomous, Flies</characteristic>
       </characteristics>
     </profile>
-    <profile id="bb99-778c-b54b-3569" name="Wild Serpentswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="bb99-778c-b54b-3569" name="Wild Serpentswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">6</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -2083,7 +2309,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 3xHTH SV5, Dread, Stampede, Irresistable Charge</characteristic>
       </characteristics>
     </profile>
-    <profile id="c9d3-d13d-232c-c354" name="Manticore with Stinging Tail" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Humanoid model">
+    <profile id="c9d3-d13d-232c-c354" name="Manticore with Stinging Tail" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>

--- a/Monsters.cat
+++ b/Monsters.cat
@@ -35,12 +35,13 @@
         <infoLink id="94e4-ce18-68ed-b342" name="Baleful Glare" hidden="false" targetId="9855-31c9-3745-714d" type="rule"/>
         <infoLink id="6b20-a4aa-fd9f-8f91" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="8aa3-a9d1-fbb3-1524" name="Basilisk" hidden="false" targetId="9f01-a520-920a-bd90" type="profile"/>
+        <infoLink id="cb0e-2080-83ed-1788" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1bff-1c68-dd0b-e113" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5ceb-ccb3-bf30-8ef0" name="Model" hidden="false" collective="false" defaultSelectionEntryId="c5a7-8e57-be4d-8c80">
+        <selectionEntryGroup id="5ceb-ccb3-bf30-8ef0" name="Type" hidden="false" collective="false" defaultSelectionEntryId="c5a7-8e57-be4d-8c80">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f030-a978-95d2-b018" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12c9-38f4-e6c0-6a2c" type="min"/>
@@ -49,19 +50,19 @@
             <selectionEntry id="c5a7-8e57-be4d-8c80" name="Wild Basilisk" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="158.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f3a3-9d1c-83ee-c624" name="Bound Basilisk" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="178.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1e81-3fb8-f486-f5a1" name="Allied Basilisk" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="198.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -69,22 +70,24 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ba39-ac09-15fb-f789" name="Chimera [158/178/198 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="007f-9486-f0f3-1f73" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="2304-6feb-8524-6d85" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
-        <infoLink id="cada-7de5-03db-a170" name="Chimera [158/178/198 pts]" hidden="false" targetId="2dbb-4ea1-5f93-dce3" type="profile"/>
+        <infoLink id="cada-7de5-03db-a170" name="Chimera" hidden="false" targetId="2dbb-4ea1-5f93-dce3" type="profile"/>
         <infoLink id="6c00-7ceb-91f2-a6fc" name="Flaming Breath" hidden="false" targetId="37e8-d658-01a9-6916" type="rule"/>
         <infoLink id="5f75-c5bf-dd04-b0c8" name="Fire" hidden="false" targetId="b61d-3471-1ce6-6878" type="rule"/>
+        <infoLink id="2304-006a-75e9-35e5" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
+        <infoLink id="0c8a-5ad0-4053-448d" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="fae9-3dc9-bcea-0221" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="c1cd-beae-0714-4d9b" name="Model" hidden="false" collective="false" defaultSelectionEntryId="3a95-41d5-222d-e969">
+        <selectionEntryGroup id="c1cd-beae-0714-4d9b" name="Type" hidden="false" collective="false" defaultSelectionEntryId="3a95-41d5-222d-e969">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb6c-3e4e-4d7d-2107" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1536-eedf-05a0-f36a" type="min"/>
@@ -93,26 +96,26 @@
             <selectionEntry id="3a95-41d5-222d-e969" name="Wild Chimera" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="158.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8808-6e3a-105b-97fd" name="Bound Chimera" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="178.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18bd-1699-eadd-7ec2" name="Allied Chimera" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="198.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="30b7-95e9-ce1a-0fa0" name="Wings" hidden="false" collective="false">
+        <selectionEntryGroup id="30b7-95e9-ce1a-0fa0" name="Wings Upgrade" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="d222-327c-207d-8c57" name="Wings (Adds Flying Rule)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d222-327c-207d-8c57" name="Flying" hidden="false" collective="false" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="04db-3a96-0978-b10a" type="max"/>
               </constraints>
@@ -121,7 +124,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -129,7 +132,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b01e-a8c7-82df-f6d8" name="Cockatrice [157/177/197 pts]" hidden="false" collective="false" type="unit">
@@ -139,12 +142,13 @@
         <infoLink id="65ea-15ae-ae55-9028" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
         <infoLink id="577f-8759-cca9-87ec" name="Baleful Glare" hidden="false" targetId="9855-31c9-3745-714d" type="rule"/>
         <infoLink id="165c-a94f-a654-9899" name="Cockatrice" hidden="false" targetId="0184-c48d-2234-cbf7" type="profile"/>
+        <infoLink id="81a9-d22c-756b-1086" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="3e0d-83f5-1959-b5bc" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e4e1-ab28-2fae-85f7" name="Model" hidden="false" collective="false" defaultSelectionEntryId="9bd8-50f1-127a-f210">
+        <selectionEntryGroup id="e4e1-ab28-2fae-85f7" name="Type" hidden="false" collective="false" defaultSelectionEntryId="9bd8-50f1-127a-f210">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4884-16b1-763c-9696" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f138-a183-2475-e0bf" type="min"/>
@@ -153,19 +157,19 @@
             <selectionEntry id="9bd8-50f1-127a-f210" name="Wild Cockatrice" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="157.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f172-d87b-3cae-700e" name="Bound Cockatrice" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="177.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e24a-ce4c-dde1-1d35" name="Allied Cockatrice" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="197.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -173,7 +177,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5b3b-b3f4-bbba-7609" name="Cyclops [150/170/190 pts]" hidden="false" collective="false" type="unit">
@@ -181,12 +185,13 @@
         <infoLink id="31ea-673a-7d1d-8b0c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5057-ca34-d221-9d56" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="2b76-f1ee-6436-2a1f" name="Cyclops" hidden="false" targetId="fdd9-726d-86fe-ec2d" type="profile"/>
+        <infoLink id="67d8-e4ef-b956-b19b" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="d2db-df71-a8cc-c750" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4b9a-4e8d-a38d-34ac" name="Model" hidden="false" collective="false" defaultSelectionEntryId="547a-d807-5442-8c10">
+        <selectionEntryGroup id="4b9a-4e8d-a38d-34ac" name="Type" hidden="false" collective="false" defaultSelectionEntryId="547a-d807-5442-8c10">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff93-069f-f26e-5b29" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="688d-42de-8aab-f223" type="min"/>
@@ -195,19 +200,19 @@
             <selectionEntry id="547a-d807-5442-8c10" name="Wild Cyclops" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="150.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e40a-8db7-c5c6-195b" name="Bound Cyclops" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="170.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7ec1-cc0d-fdd1-13cb" name="Allied Cyclops" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="190.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -223,7 +228,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -231,7 +236,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6617-5ad0-1f45-cbe3" name="Dragon [380/410/440 pts]" hidden="false" collective="false" type="unit">
@@ -243,12 +248,14 @@
         <infoLink id="5c01-c415-74ea-61f9" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
         <infoLink id="98a8-5b1f-27ea-c1af" name="Flaming Breath" hidden="false" targetId="37e8-d658-01a9-6916" type="rule"/>
         <infoLink id="6f4d-fb56-fb2c-b458" name="Fire" hidden="false" targetId="b61d-3471-1ce6-6878" type="rule"/>
+        <infoLink id="149a-0947-9774-944b" name="MoD3" hidden="false" targetId="a8ca-ba71-db97-bc20" type="rule"/>
+        <infoLink id="25e0-1a1d-6554-765a" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="4c4c-9bb4-d040-080d" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4a92-1c5f-09d6-0769" name="Model" hidden="false" collective="false" defaultSelectionEntryId="3e21-a58d-f9ab-e3b0">
+        <selectionEntryGroup id="4a92-1c5f-09d6-0769" name="Type" hidden="false" collective="false" defaultSelectionEntryId="3e21-a58d-f9ab-e3b0">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0dd-47e7-f9d2-66e2" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc66-a61b-1d6a-3691" type="min"/>
@@ -257,24 +264,24 @@
             <selectionEntry id="3e21-a58d-f9ab-e3b0" name="Wild Dragon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="380.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="39d6-1fc9-414d-1bd6" name="Bound Dragon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="410.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f91-1fec-a33b-76e9" name="Allied Dragon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="440.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6572-7256-e5cb-036d" name="Baleful Glare" hidden="false" collective="false">
+        <selectionEntryGroup id="6572-7256-e5cb-036d" name="Add Baleful Glare" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="cbb7-0a88-6e3f-54f2" name="Baleful Glare" hidden="false" collective="false" type="upgrade">
               <constraints>
@@ -285,14 +292,14 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4c72-9b9d-c9e1-7001" name="Substitute Flaming Breath attacks for Beastly Breath" hidden="false" collective="false">
+        <selectionEntryGroup id="4c72-9b9d-c9e1-7001" name="Upgrade Flaming Breath to Beastly Breath" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="1387-82b5-f8a1-e1a2" name="Replace Flaming Breath with Beastly Breath" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1387-82b5-f8a1-e1a2" name="Beastly Breath" hidden="false" collective="false" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bdd-ce2d-7256-b17f" type="max"/>
               </constraints>
@@ -301,33 +308,33 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d638-877a-84ba-1d50" name="Upgrade Flaming Breath to 6X attacks" hidden="false" collective="false">
+        <selectionEntryGroup id="d638-877a-84ba-1d50" name="Upgrade Flaming Breath to 6x attacks" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="5835-f6bc-38bc-cb75" name="Upgrade Flaming Breath to 6X Attacks" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5835-f6bc-38bc-cb75" name="Flaming Breath 6x attacks" hidden="false" collective="false" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd12-1aec-a359-a046" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="876d-6239-2d0c-0b6e" name="Upgrade Flaming Breath to SV4" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="d39b-603b-d6b8-65bd" name="Upgrade Flaming Breath to SV4" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d39b-603b-d6b8-65bd" name="Flaming Breath SV4" hidden="false" collective="false" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0d9-4f39-ccb0-d009" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -335,7 +342,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="3.0"/>
+        <cost name=" order dice" typeId="orderDice" value="3.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ff4-044a-e595-a1b7" name="Ghouls [85/95/105 pts]" hidden="false" collective="false" type="unit">
@@ -364,7 +371,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -377,16 +384,16 @@
           <selectionEntries>
             <selectionEntry id="96c2-fc17-f664-3f4a" name="Wild Ghouls" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="dfaf-0c70-3f5b-d6bf" name="Wild Ghouls" hidden="false" collective="false">
+                <selectionEntryGroup id="dfaf-0c70-3f5b-d6bf" name="Choose between 5 and 10" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="313d-4b89-d9ec-81ae" name="Wild Ghouls" hidden="false" collective="false" type="model">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62af-0628-f2af-dd77" type="max"/>
+                        <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62af-0628-f2af-dd77" type="max"/>
                         <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1c8-8283-3d02-c68b" type="min"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -394,21 +401,21 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="85.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ae9e-2739-5689-b484" name="Bound Ghouls" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="9fae-0469-e2ef-4c96" name="Bound Ghouls" hidden="false" collective="false">
+                <selectionEntryGroup id="9fae-0469-e2ef-4c96" name="Choose between 5 and 10" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="5ebb-d5ec-92b1-859c" name="Bound Ghouls" hidden="false" collective="false" type="model">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="478e-4215-9249-c816" type="max"/>
                         <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d628-649c-7e30-a3ce" type="min"/>
+                        <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e94-5a13-cada-5fee" type="max"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -416,21 +423,21 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58b1-de83-d5ce-5f03" name="Allied Ghouls" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="ab02-4a0c-cdc8-9976" name="Allied Ghouls" hidden="false" collective="false">
+                <selectionEntryGroup id="ab02-4a0c-cdc8-9976" name="Choose between 5 and 10" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="8eb4-9aee-4516-86b5" name="Allied Ghouls" hidden="false" collective="false" type="model">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3994-6534-b202-c4fd" type="max"/>
                         <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fc5-f10d-29ec-ee21" type="min"/>
+                        <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2563-95ac-9d4d-52a6" type="max"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -438,20 +445,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="105.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="3dc7-83e8-0ced-479d" name="Additional Ghouls" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="1dc7-961f-5d4d-be1d" name="Additional Ghouls" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5379-0f8d-1d50-b32f" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="17.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -459,7 +453,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4fea-a33c-4fc3-b70b" name="Giant [253/283/313 pts]" hidden="false" collective="false" type="unit">
@@ -469,12 +463,13 @@
         <infoLink id="a4a0-36ff-b854-93ff" name="Terror" hidden="false" targetId="583a-fa53-11ff-7b40" type="rule"/>
         <infoLink id="b10a-3863-12a8-4341" name="Blundering" hidden="false" targetId="087e-dfda-76c2-09bf" type="rule"/>
         <infoLink id="dd78-3612-95f2-84d4" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="3a44-1ae4-c351-f4b8" name="MoD3" hidden="false" targetId="a8ca-ba71-db97-bc20" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="99cb-c539-e076-f008" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ecf1-7c06-19fd-5ce2" name="Models" hidden="false" collective="false" defaultSelectionEntryId="69bc-e6b8-ecbd-ab78">
+        <selectionEntryGroup id="ecf1-7c06-19fd-5ce2" name="Type" hidden="false" collective="false" defaultSelectionEntryId="69bc-e6b8-ecbd-ab78">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1646-4f8c-c7bd-77b7" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3d2-b1fe-1796-a59a" type="min"/>
@@ -483,19 +478,19 @@
             <selectionEntry id="69bc-e6b8-ecbd-ab78" name="Wild Giant" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="253.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="735b-b165-3df7-5fe6" name="Bound Giant" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="283.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3ede-d6a0-25b7-5eb0" name="Allied Giant" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="313.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -511,12 +506,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d303-f0ae-7a45-de8d" name="Beastly Breath" hidden="false" collective="false">
+        <selectionEntryGroup id="d303-f0ae-7a45-de8d" name="Beastly Breath Upgrade" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="bad1-15a9-fd3b-a09b" name="Beastly Breath" hidden="false" collective="false" type="upgrade">
               <constraints>
@@ -527,7 +522,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -535,7 +530,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="3.0"/>
+        <cost name=" order dice" typeId="orderDice" value="3.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d456-6e73-d1fc-5db4" name="Giant Rats [46/56/66 pts]" hidden="false" collective="false" type="unit">
@@ -555,16 +550,16 @@
           <selectionEntries>
             <selectionEntry id="5a11-9c74-f3a7-6798" name="Wild Giant Rats" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="7467-a8ce-82c4-fe54" name="Wild Giant Rats" hidden="false" collective="false">
+                <selectionEntryGroup id="7467-a8ce-82c4-fe54" name="Choose between 3 and 5" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="1c40-f54e-2084-b848" name="Wild Giant Rats" hidden="false" collective="false" type="model">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66e9-3023-6d04-601a" type="max"/>
+                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66e9-3023-6d04-601a" type="max"/>
                         <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f56e-231e-b87c-5d1e" type="min"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -572,21 +567,21 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="46.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9ff-9571-4ea4-40e6" name="Bound Giant Rats" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="0c9a-cd51-38b6-ce88" name="Bound Giant Rats" hidden="false" collective="false">
+                <selectionEntryGroup id="0c9a-cd51-38b6-ce88" name="Choose between 3 and 5" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="c640-a235-9d26-53fd" name="Bound Giant Rats" hidden="false" collective="false" type="model">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d50e-35ab-c650-7058" type="max"/>
+                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d50e-35ab-c650-7058" type="max"/>
                         <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25c3-e5e5-66c0-3f41" type="min"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -594,21 +589,21 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="56.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="48e8-ed6c-33e2-7806" name="Allied Giant Rats" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="f785-e64d-15d3-0e29" name="Allied Giant Rats" hidden="false" collective="false">
+                <selectionEntryGroup id="f785-e64d-15d3-0e29" name="Choose between 3 and 5" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="049e-3f7b-4649-cf79" name="Allied Giant Rats" hidden="false" collective="false" type="model">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aa7-c8b7-ffed-f26b" type="max"/>
+                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6aa7-c8b7-ffed-f26b" type="max"/>
                         <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e5b-26e6-2cd1-72ed" type="min"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -616,20 +611,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="66.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="b782-17da-9492-fe67" name="Additional Giant Rats" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="5c3a-6c7d-c31b-5da2" name="Additional Giant Rats" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78c3-01f1-864e-2eb1" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -637,7 +619,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="452a-2a19-4531-92b8" name="Giant Scorpions [57/67/77 pts]" hidden="false" collective="false" type="unit">
@@ -658,16 +640,16 @@
           <selectionEntries>
             <selectionEntry id="9cec-7929-0e33-855b" name="Wild Giant Scorpions" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="50bc-233d-7fb7-401d" name="Wild Giant Scorpions" hidden="false" collective="false">
+                <selectionEntryGroup id="50bc-233d-7fb7-401d" name="Choose between 1 and 3" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="f156-ca66-68b6-fce0" name="Wild Giant Scorpions" hidden="false" collective="false" type="model">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c32-38d9-d1a6-90b6" type="max"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c32-38d9-d1a6-90b6" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2185-6c64-997b-2bc9" type="min"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -675,21 +657,21 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="57.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f4d0-49aa-8e85-20c3" name="Bound Giant Scorpions" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="f555-a06e-7a42-1876" name="Bound Giant Scorpions" hidden="false" collective="false">
+                <selectionEntryGroup id="f555-a06e-7a42-1876" name="Choose between 1 and 3" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="c254-1479-93b6-3725" name="Bound Giant Scorpions" hidden="false" collective="false" type="model">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3e3-0f37-71d2-d213" type="max"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3e3-0f37-71d2-d213" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6450-4954-aee2-c331" type="min"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -697,21 +679,21 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="67.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="27b3-fd62-b1f5-fb6a" name="Allied Giant Scorpions" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="13d7-1b53-a13f-0b4d" name="Allied Giant Scorpions" hidden="false" collective="false">
+                <selectionEntryGroup id="13d7-1b53-a13f-0b4d" name="Choose between 1 and 3" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="3a05-4482-1b51-2ab7" name="Allied Giant Scorpions" hidden="false" collective="false" type="model">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaff-4778-a2c5-1c5e" type="max"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaff-4778-a2c5-1c5e" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bc6-cd99-72be-be76" type="min"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -719,20 +701,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="77.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="3bb4-f22c-e8fb-5fa7" name="Additional Giant Scorpions" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="8a92-3d23-a5f4-0c6f" name="Additional Giant Scorpions" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db8a-a41f-ab71-15f3" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="59.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -740,7 +709,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="051b-44ef-ec3d-a1c1" name="Giant Spiders [50/60/70 pts]" hidden="false" collective="false" type="unit">
@@ -752,7 +721,7 @@
         <categoryLink id="2c23-10cd-7182-7576" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5109-a1af-1cb3-58f7" name="Models" hidden="false" collective="false" defaultSelectionEntryId="b1bc-3d7e-70f8-a492">
+        <selectionEntryGroup id="5109-a1af-1cb3-58f7" name="Type" hidden="false" collective="false" defaultSelectionEntryId="b1bc-3d7e-70f8-a492">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbe5-d736-bfa0-8de6" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfa5-2334-59d7-2bf1" type="min"/>
@@ -760,16 +729,16 @@
           <selectionEntries>
             <selectionEntry id="b1bc-3d7e-70f8-a492" name="Wild Giant Spiders" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="8de6-6fde-aa49-1f2c" name="Wild Giant Spiders" hidden="false" collective="false">
+                <selectionEntryGroup id="8de6-6fde-aa49-1f2c" name="Choose between 1 and 3" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="bfa1-98e9-1117-c70e" name="Wild Giant Spiders" hidden="false" collective="false" type="model">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c3a-baab-25ee-fb12" type="max"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c3a-baab-25ee-fb12" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa1c-b2f6-ed24-6a7c" type="min"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -777,21 +746,21 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44f6-eaa3-c092-6ede" name="Bound Giant Spiders" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="0e50-96b0-ae4b-8785" name="Bound Giant Spiders" hidden="false" collective="false">
+                <selectionEntryGroup id="0e50-96b0-ae4b-8785" name="Choose between 1 and 3" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="17df-fcdd-d75d-3e6a" name="Bound Giant Spiders" hidden="false" collective="false" type="model">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="643b-ec8a-1c62-0170" type="max"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="643b-ec8a-1c62-0170" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b41c-d790-a3c4-826c" type="min"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -799,21 +768,21 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5bf-349f-7dd0-f647" name="Allied Giant Spiders" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="1281-d0a3-1712-5ca1" name="Allied Giant Spiders" hidden="false" collective="false">
+                <selectionEntryGroup id="1281-d0a3-1712-5ca1" name="Choose between 1 and 3" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="277e-9e5c-e7eb-b70f" name="Allied Giant Spiders" hidden="false" collective="false" type="model">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a22-4d5d-23e9-7691" type="max"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a22-4d5d-23e9-7691" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cb0-53dd-3963-307d" type="min"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -821,20 +790,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="70.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="29a8-2c33-055e-fef9" name="Additional Giant Spiders" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="f364-ce81-666d-7dbd" name="Additional Giant Spiders" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7d0-1cba-a596-9f04" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="52.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -842,7 +798,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2846-5918-fd84-7e29" name="Gigantic Spider [218/238/258 pts]" hidden="false" collective="false" type="unit">
@@ -851,12 +807,13 @@
         <infoLink id="0d8b-3229-a256-b8c6" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="3177-655c-60dc-545b" name="Terror" hidden="false" targetId="583a-fa53-11ff-7b40" type="rule"/>
         <infoLink id="1548-3c25-bfbd-8b54" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="10c3-470b-5a26-c7f3" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="08c7-f0bc-c16a-2304" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4fd6-045d-43c7-39c4" name="Model" hidden="false" collective="false" defaultSelectionEntryId="89a1-e66a-a003-4cd8">
+        <selectionEntryGroup id="4fd6-045d-43c7-39c4" name="Type" hidden="false" collective="false" defaultSelectionEntryId="89a1-e66a-a003-4cd8">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5762-04d8-c133-471a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e80-f477-f907-e19a" type="min"/>
@@ -865,19 +822,19 @@
             <selectionEntry id="89a1-e66a-a003-4cd8" name="Wild Gigantic Spider" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="218.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c54e-49dc-5a0c-3fbc" name="Bound Gigantic Spider" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="238.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ee0-30cf-e562-3f38" name="Allied Gigantic Spider" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="258.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -893,7 +850,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -901,21 +858,21 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7835-8a79-e484-397e" name="Golem [64 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="9df5-9e0f-f770-8a7c" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="1912-83de-49d8-38e3" name="Golem" hidden="false" targetId="ec10-cee9-9e3f-9783" type="profile"/>
-        <infoLink id="a177-2893-16c8-de3a" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+        <infoLink id="a177-2893-16c8-de3a" name="Slow 4" hidden="false" targetId="ade7-83de-c555-3df3" type="rule"/>
         <infoLink id="96f8-3846-6d66-8680" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="2bc8-02d7-6109-2e47" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="925d-1fa8-9bec-26a8" name="Model" hidden="false" collective="false" defaultSelectionEntryId="1897-fb06-b190-6c50">
+        <selectionEntryGroup id="925d-1fa8-9bec-26a8" name="Type" hidden="false" collective="false" defaultSelectionEntryId="1897-fb06-b190-6c50">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="534e-046c-8888-aa46" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ab8-215c-e5c7-7851" type="min"/>
@@ -924,12 +881,12 @@
             <selectionEntry id="1897-fb06-b190-6c50" name="Bound Golem" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="64.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9edb-9066-7a74-55a4" name="Choking Attacks" hidden="false" collective="false">
+        <selectionEntryGroup id="9edb-9066-7a74-55a4" name="Choking Attacks Upgrade" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="cb5a-4ce6-6b32-6cee" name="Choking Attacks" hidden="false" collective="false" type="upgrade">
               <constraints>
@@ -940,7 +897,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="3.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -948,7 +905,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b90a-e799-9047-9183" name="Griffin [144/164/184 pts]" hidden="false" collective="false" type="unit">
@@ -956,15 +913,16 @@
         <infoLink id="ba6c-b5a4-87d6-9244" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="b17f-aa01-9b6f-27b9" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="294d-1e58-b78f-9404" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
-        <infoLink id="d434-6606-de8f-45ea" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="d434-6606-de8f-45ea" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
         <infoLink id="a02a-2879-c602-de60" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
         <infoLink id="4bea-4093-d8cc-b1fc" name="Griffin" hidden="false" targetId="61f2-9f86-a3d8-d5e8" type="profile"/>
+        <infoLink id="6598-c39e-de16-9271" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="15a4-7846-cdb3-efbb" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="90b8-f4b3-f1d7-1885" name="Model" hidden="false" collective="false" defaultSelectionEntryId="a3bf-db9b-f57b-6e62">
+        <selectionEntryGroup id="90b8-f4b3-f1d7-1885" name="Type" hidden="false" collective="false" defaultSelectionEntryId="a3bf-db9b-f57b-6e62">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70dd-c203-32f6-533d" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1ec-1e63-bffd-5608" type="min"/>
@@ -973,19 +931,19 @@
             <selectionEntry id="a3bf-db9b-f57b-6e62" name="Wild Griffin" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="144.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b370-b36b-43ca-a71c" name="Bound Griffon" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="164.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b331-fbf6-1c50-ebee" name="Allied Griffin" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="184.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -993,22 +951,23 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="30d1-8869-3361-d27b" name="Hippogriff [138/159/179 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="1fae-240f-11ae-1659" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="794e-15ba-aeff-8c62" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="3a01-0b64-987a-cf3d" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="3a01-0b64-987a-cf3d" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
         <infoLink id="f5b2-a3fc-3d2b-50c7" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
         <infoLink id="131f-6bcc-d759-4126" name="Hippogriff" hidden="false" targetId="7ea6-624e-3017-99b2" type="profile"/>
+        <infoLink id="61bd-67ff-c851-f742" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f08c-6d2d-7dcf-a2ee" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6e98-7ce2-66ae-e058" name="Model" hidden="false" collective="false" defaultSelectionEntryId="70a7-aa27-b130-ad73">
+        <selectionEntryGroup id="6e98-7ce2-66ae-e058" name="Type" hidden="false" collective="false" defaultSelectionEntryId="70a7-aa27-b130-ad73">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55d5-b72d-cd1b-38ad" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7d6-0002-e9bb-41e9" type="min"/>
@@ -1017,19 +976,19 @@
             <selectionEntry id="70a7-aa27-b130-ad73" name="Wild Hippogriff" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="138.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c8c8-e773-51c3-6cee" name="Bound Hippogriff" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="159.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3a43-2059-fef8-b1b2" name="Allied Hippogriff" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="179.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1037,7 +996,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1826-be4d-e802-d903" name="Hydra [182/202/222 pts]" hidden="false" collective="false" type="unit">
@@ -1047,12 +1006,13 @@
         <infoLink id="a6e5-f411-63cd-0502" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
         <infoLink id="b026-d08c-8c71-e357" name="Regenerate" hidden="false" targetId="0a0c-ed4c-9647-4398" type="rule"/>
         <infoLink id="e234-84da-9d68-f0bd" name="Hydra" hidden="false" targetId="6e13-9d18-f7c2-d272" type="profile"/>
+        <infoLink id="8d33-f79f-e1e2-da64" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="cdfc-9e57-7aeb-562e" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="dde7-979d-fbff-bd7d" name="Model" hidden="false" collective="false" defaultSelectionEntryId="cb50-75bc-b388-29f5">
+        <selectionEntryGroup id="dde7-979d-fbff-bd7d" name="Type" hidden="false" collective="false" defaultSelectionEntryId="cb50-75bc-b388-29f5">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72fc-ba9c-e496-2a0e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65d7-f445-4d7d-e4fb" type="min"/>
@@ -1061,26 +1021,26 @@
             <selectionEntry id="cb50-75bc-b388-29f5" name="Wild Hydra" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="182.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a1ee-e6d1-d095-f330" name="Bound Hydra" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="202.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed64-f50f-d38e-3488" name="Allied Hydra" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="222.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="a9bd-62da-cc11-b3c5" name="Flaming Breath Upgrade" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="9928-29f4-9c99-a31a" name="Flaming Breath 3xAttacks SV3 Fire" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9928-29f4-9c99-a31a" name="Flaming Breath &amp; Fire" hidden="false" collective="false" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed6c-d06a-b9c5-51ae" type="max"/>
               </constraints>
@@ -1090,7 +1050,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1106,7 +1066,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1114,7 +1074,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3c5b-7264-8586-c81c" name="Manticore [158/178/198 pts]" hidden="false" collective="false" type="unit">
@@ -1122,12 +1082,13 @@
         <infoLink id="82a1-b369-5dad-45a8" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="c30c-22bf-14f9-b0a7" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="653e-1e86-e2b7-5d45" name="Beastly Breath" hidden="false" targetId="14ff-225a-4ec5-f56d" type="rule"/>
+        <infoLink id="5a7d-489e-eb87-9b2a" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8e2d-8d48-a0bd-06b9" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="105c-b572-2e3c-0709" name="Model" hidden="false" collective="false" defaultSelectionEntryId="944c-8f6d-0c3c-2775">
+        <selectionEntryGroup id="105c-b572-2e3c-0709" name="Type" hidden="false" collective="false" defaultSelectionEntryId="944c-8f6d-0c3c-2775">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f76-8562-1a43-06c0" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4eb-6c8f-c57a-530f" type="min"/>
@@ -1136,26 +1097,26 @@
             <selectionEntry id="944c-8f6d-0c3c-2775" name="Wild Manticore" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="158.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b02e-ae6c-1e3f-9414" name="Bound Manticore" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="178.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5f8a-a49e-21b5-2691" name="Allied Manticore" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="198.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="425a-2077-d156-f920" name="Wings Upgrade" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="ca51-bee0-ae11-0264" name="Give Wings Adding Flies Rule" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ca51-bee0-ae11-0264" name="Flies" hidden="false" collective="false" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e70f-a1ad-0e5d-d661" type="max"/>
               </constraints>
@@ -1164,12 +1125,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="2665-7ae0-c5f7-4a7c" name="Stinging Tale Upgrade" hidden="false" collective="false" defaultSelectionEntryId="da4b-100f-1b25-b303">
+        <selectionEntryGroup id="2665-7ae0-c5f7-4a7c" name="Stinging Tail Upgrade" hidden="false" collective="false" defaultSelectionEntryId="da4b-100f-1b25-b303">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f25d-c120-efed-b5fb" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f089-ffa4-05c7-0339" type="max"/>
@@ -1184,7 +1145,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da4b-100f-1b25-b303" name="Manticore" hidden="false" collective="false" type="upgrade">
@@ -1196,7 +1157,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1204,7 +1165,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bdbd-2e9c-63ce-9620" name="Ogres [28/38/48 pts]" hidden="false" collective="false" type="unit">
@@ -1216,7 +1177,7 @@
         <categoryLink id="f1be-ad19-d193-72ea" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e4bc-0e18-3bdf-e847" name="Level" hidden="false" collective="false" defaultSelectionEntryId="10fd-618a-e4ea-206c">
+        <selectionEntryGroup id="e4bc-0e18-3bdf-e847" name="Type" hidden="false" collective="false" defaultSelectionEntryId="10fd-618a-e4ea-206c">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3fd-5172-3d06-24dd" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c152-30ad-3f0f-1668" type="min"/>
@@ -1225,32 +1186,32 @@
             <selectionEntry id="10fd-618a-e4ea-206c" name="Wild" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95ed-5dcf-9a9f-723c" name="Bound" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="84ab-9d2d-9bd0-f9f9" name="Allied" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="efe5-5384-c1a2-e0aa" name="Models" hidden="false" collective="false" defaultSelectionEntryId="691a-b83b-08b9-20b4">
+        <selectionEntryGroup id="efe5-5384-c1a2-e0aa" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="691a-b83b-08b9-20b4">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="179c-9a04-ca1c-0d12" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3636-cdff-bad9-6615" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="691a-b83b-08b9-20b4" name="Ogres" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="691a-b83b-08b9-20b4" name="Ogres (no armour)" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="2309-c48e-3e4b-b73a" name="Ogres" hidden="false" collective="false">
+                <selectionEntryGroup id="2309-c48e-3e4b-b73a" name="Choose between 1 and 3" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="b67a-b7a4-da47-2cc8" name="Ogres" hidden="false" collective="false" type="model">
                       <constraints>
@@ -1262,7 +1223,31 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="b0d1-fa3f-9a7b-d04b" name="Promote one Ogre to Chieftain" hidden="true" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="691a-b83b-08b9-20b4" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b67a-b7a4-da47-2cc8" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <selectionEntries>
+                    <selectionEntry id="8d1e-0011-e9eb-5c87" name="Ogre Chieftain (no armour)" hidden="false" collective="false" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34db-2f95-85a2-d80b" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="06b7-391d-4ddc-372c" name="Ogre Chieftain" hidden="false" targetId="46fb-de84-d662-097d" type="profile"/>
+                        <infoLink id="0924-10ff-a2ee-7a14" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1270,12 +1255,12 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="49d4-9052-fe2a-c388" name="Ogres in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="3f66-db48-7401-3b97" name="Ogres in Light Armour" hidden="false" collective="false">
+                <selectionEntryGroup id="3f66-db48-7401-3b97" name="Choose between 1 and 3" hidden="false" collective="false">
                   <selectionEntries>
                     <selectionEntry id="c27a-073b-e87b-e932" name="Ogres in Light Armour" hidden="false" collective="false" type="upgrade">
                       <constraints>
@@ -1287,7 +1272,31 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="d23d-fe1d-a69b-01d7" name="Promote one Ogre to Chieftain in Light Armour" hidden="true" collective="false">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditions>
+                        <condition field="selections" scope="49d4-9052-fe2a-c388" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c27a-073b-e87b-e932" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <selectionEntries>
+                    <selectionEntry id="9656-ca2c-bb28-12d6" name="Chieftain in Light Armour" hidden="true" collective="false" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfb5-05bb-18da-a7f5" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="98f1-b675-20e3-117e" name="Ogre Chieftain in Light Armour" hidden="false" targetId="f004-a3ca-4a39-903d" type="profile"/>
+                        <infoLink id="123d-e937-72fc-b4d9" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1295,7 +1304,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1312,7 +1321,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96a6-d255-dca8-5529" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -1321,7 +1330,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce2a-712b-0058-45d6" name="Warhammer" hidden="false" collective="false" type="upgrade">
@@ -1330,7 +1339,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c4b-eb71-1dbf-f127" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1339,7 +1348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1359,7 +1368,7 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1367,7 +1376,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="71af-c82c-450e-2b37" name="Wild Swarms [75 pts]" hidden="false" collective="false" type="unit">
@@ -1375,7 +1384,7 @@
         <categoryLink id="d22a-534c-0358-514b" name="New CategoryLink" hidden="false" targetId="c820-d327-811d-1144" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="be55-2e48-bc08-19dd" name="Type of Swarm" hidden="false" collective="false">
+        <selectionEntryGroup id="be55-2e48-bc08-19dd" name="Type of Swarm" hidden="false" collective="false" defaultSelectionEntryId="22d1-b18d-b1a9-e05c">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34a4-f163-19df-464b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce96-53c2-2786-2d69" type="min"/>
@@ -1388,18 +1397,18 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="22d1-b18d-b1a9-e05c" name="Batswarm" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="327c-451d-13cc-01cd" name="Wild Batswarm" hidden="false" targetId="3476-9800-ad47-8c84" type="profile"/>
                 <infoLink id="fc1f-3c89-912a-83ad" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
-                <infoLink id="ecd5-eac9-d36f-402d" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+                <infoLink id="ecd5-eac9-d36f-402d" name="Fast 7" hidden="false" targetId="fd29-829f-3cd9-1841" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b3f8-e4f3-9d0f-6baa" name="Spiderswarm" hidden="false" collective="false" type="upgrade">
@@ -1408,7 +1417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5baa-7f1c-6d03-a96e" name="Frogswarm" hidden="false" collective="false" type="upgrade">
@@ -1418,7 +1427,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3259-16f8-1a76-b829" name="Beeswarm" hidden="false" collective="false" type="upgrade">
@@ -1429,32 +1438,32 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3291-9eba-d0a4-e5d7" name="Serpentswarm" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="bf66-ec4e-f7d1-969c" name="Wild Serpentswarm" hidden="false" targetId="bb99-778c-b54b-3569" type="profile"/>
                 <infoLink id="e8d2-778b-134d-02fe" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
-                <infoLink id="5030-4d2b-b44f-0414" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+                <infoLink id="5030-4d2b-b44f-0414" name="Slow 4" hidden="false" targetId="ade7-83de-c555-3df3" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="a983-1da1-f11f-77d1" name="Models" hidden="false" collective="false" defaultSelectionEntryId="f480-9523-63fa-f20b">
+        <selectionEntryGroup id="a983-1da1-f11f-77d1" name="Choose between 3 and 5" hidden="false" collective="false" defaultSelectionEntryId="f480-9523-63fa-f20b">
           <selectionEntries>
-            <selectionEntry id="f480-9523-63fa-f20b" name="Number of Swarms" hidden="false" collective="false" type="model">
+            <selectionEntry id="f480-9523-63fa-f20b" name="Swarms" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4441-42d6-b838-f55c" type="min"/>
                 <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bcc-5bec-862d-6439" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1462,7 +1471,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5943-a398-3d77-7af7" name="Wyvern [160/180/200 pts]" hidden="false" collective="false" type="unit">
@@ -1471,12 +1480,13 @@
         <infoLink id="e741-a542-0958-f574" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="e4a4-a2e2-4289-dcf6" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="459a-e1f9-6a0f-5dbc" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
+        <infoLink id="1645-86d0-2ae7-98fb" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ee8b-b103-dc3d-bc4e" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5108-2ad0-b948-1697" name="Model" hidden="false" collective="false" defaultSelectionEntryId="3692-feb9-6467-959f">
+        <selectionEntryGroup id="5108-2ad0-b948-1697" name="Type" hidden="false" collective="false" defaultSelectionEntryId="3692-feb9-6467-959f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2773-2d17-3997-1b8a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="491d-55ee-c4f5-2572" type="min"/>
@@ -1485,19 +1495,19 @@
             <selectionEntry id="3692-feb9-6467-959f" name="Wild Wyvern" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="160.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dfe9-9eec-b034-aa25" name="Bound Wyvern" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="180.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8f81-0caf-1d01-ec4b" name="Allied Wyvern" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="200.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1514,7 +1524,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96dd-35c0-46c4-15f6" name="Beastly Breath" hidden="false" collective="false" type="upgrade">
@@ -1523,7 +1533,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1540,7 +1550,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d229-e8a7-8781-1915" name="Venomous" hidden="false" collective="false" type="upgrade">
@@ -1549,7 +1559,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1557,7 +1567,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="853f-a790-4f4e-0d98" name="Allied Giant Treeman [204 pts]" hidden="false" collective="false" type="unit">
@@ -1567,30 +1577,29 @@
         <infoLink id="23fb-59ae-1fb1-4d3a" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
         <infoLink id="642e-9d82-ae69-d7f3" name="Woodsman" hidden="false" targetId="e1f3-7817-0e4e-5cb9" type="rule"/>
         <infoLink id="6992-98f9-89d8-3def" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
-        <infoLink id="ca2b-3728-2f54-9c51" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="ca2b-3728-2f54-9c51" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
         <infoLink id="72e7-6ebb-a444-9ecc" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
+        <infoLink id="daea-c6d3-cf66-2667" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="7215-de58-47be-42ba" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4ede-95ed-6c45-af30" name="Giant Treeman" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2fa-1f55-20f2-a503" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf36-baa2-fcfd-a694" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f81b-0f10-7007-c9c5" name="Giant Treeman" hidden="false" targetId="8131-c371-7d0a-189b" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="204.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="c6d6-6532-b462-b9f0" name="Model" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="0eed-b0a4-60f4-aa30" name="Giant Treeman" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e52d-9541-2e93-d86c" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="118e-e682-c830-64b0" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="a54c-865c-537a-7372" name="Giant Treeman" hidden="false" targetId="8131-c371-7d0a-189b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="204.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
         <selectionEntryGroup id="9505-3e5f-fa20-828f" name="Give Treeman Rock to Hurl" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="2ef6-1aaf-5d22-8490" name="Rock to Hurl" hidden="false" collective="false" type="upgrade">
@@ -1602,7 +1611,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1610,27 +1619,27 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6491-3e79-cfd5-76db" name="Allied Treemen/Dryads" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="8bc0-6f99-fbe7-77ca" name="Blundering" hidden="false" targetId="087e-dfda-76c2-09bf" type="rule"/>
         <infoLink id="4bb4-42a6-3f94-eca5" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="92de-e4f7-0e56-a33a" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+        <infoLink id="92de-e4f7-0e56-a33a" name="Slow 4" hidden="false" targetId="ade7-83de-c555-3df3" type="rule"/>
         <infoLink id="5355-be96-bfa3-52a9" name="Woodsman" hidden="false" targetId="e1f3-7817-0e4e-5cb9" type="rule"/>
         <infoLink id="7f72-d386-639b-77d3" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
-        <infoLink id="acd6-4bb7-abc3-e1e3" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="acd6-4bb7-abc3-e1e3" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ffd5-4b94-abca-9e24" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="9cbd-c835-1d32-e337" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="9cbd-c835-1d32-e337" name="Chose between 1 and 3" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="b86d-bf3e-e0b6-7008" name="Treemen/Dryad" hidden="false" collective="false" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cae1-f9d3-4572-d755" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cae1-f9d3-4572-d755" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a450-d39e-95f7-4c44" type="min"/>
               </constraints>
               <infoLinks>
@@ -1638,16 +1647,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="53.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f347-3d89-8a61-7e10" name="Additional Treemen/Dryads" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2dcf-5727-1ecb-1ba1" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="33.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1655,7 +1655,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="45c6-60cf-f892-7efa" name="Trolls [105/115 pts]" hidden="false" collective="false" type="unit">
@@ -1668,7 +1668,7 @@
         <categoryLink id="9e47-15c6-4fc8-5d68" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="cfb8-daa5-aeff-3a51" name="Models" hidden="false" collective="false" defaultSelectionEntryId="20df-0d9b-69c5-6e8e">
+        <selectionEntryGroup id="cfb8-daa5-aeff-3a51" name="Choose between 3 and 5" hidden="false" collective="false" defaultSelectionEntryId="20df-0d9b-69c5-6e8e">
           <selectionEntries>
             <selectionEntry id="20df-0d9b-69c5-6e8e" name="Trolls" hidden="false" collective="false" type="model">
               <constraints>
@@ -1680,12 +1680,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="18c6-1678-7be7-fff7" name="Level" hidden="false" collective="false" defaultSelectionEntryId="2270-2d2f-e43a-4d4f">
+        <selectionEntryGroup id="18c6-1678-7be7-fff7" name="Type" hidden="false" collective="false" defaultSelectionEntryId="2270-2d2f-e43a-4d4f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8ff-ced3-621c-7bd8" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd79-25f1-70b6-c87d" type="min"/>
@@ -1694,13 +1694,13 @@
             <selectionEntry id="2270-2d2f-e43a-4d4f" name="Wild" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b5c2-0b03-6640-007c" name="Bound" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1708,7 +1708,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cfc8-c933-eeab-5e21" name="Cave Bear" hidden="false" collective="false" type="unit">
@@ -1723,7 +1723,7 @@
         <categoryLink id="470e-6966-9ba9-ed81" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ea09-eb2c-4f79-d024" name="Model" hidden="false" collective="false" defaultSelectionEntryId="8466-565c-872e-39ef">
+        <selectionEntryGroup id="ea09-eb2c-4f79-d024" name="Type" hidden="false" collective="false" defaultSelectionEntryId="8466-565c-872e-39ef">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23e8-0f65-f81e-97b4" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="501f-d709-5a73-7129" type="max"/>
@@ -1732,13 +1732,13 @@
             <selectionEntry id="8466-565c-872e-39ef" name="Wild Cave Bear" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="21e9-914d-c0a4-f6dd" name="Allied Were Bear" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="82.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1746,7 +1746,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="903f-9d10-4831-bf0f" name="Brontosaur [115/135 pts]" hidden="false" collective="false" type="unit">
@@ -1755,12 +1755,13 @@
         <infoLink id="eeea-e415-ab59-aba9" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="8ac3-5d17-8dc8-26aa" name="Blundering" hidden="false" targetId="087e-dfda-76c2-09bf" type="rule"/>
         <infoLink id="3125-c599-1559-1572" name="Stampede" hidden="false" targetId="45b3-c028-8c8c-43ae" type="rule"/>
+        <infoLink id="e7bf-5ac5-e540-8935" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="47e9-8217-b4db-86ec" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ff84-1867-6415-542c" name="Model" hidden="false" collective="false" defaultSelectionEntryId="6ee4-fa2e-f18a-e585">
+        <selectionEntryGroup id="ff84-1867-6415-542c" name="Type" hidden="false" collective="false" defaultSelectionEntryId="6ee4-fa2e-f18a-e585">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3e7-1e13-ec81-0987" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17a0-fb21-e440-b4c4" type="min"/>
@@ -1769,13 +1770,13 @@
             <selectionEntry id="6ee4-fa2e-f18a-e585" name="Wild Brontosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="115.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="93f4-cb20-966f-0aeb" name="Bound Brontosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="135.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1783,7 +1784,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4f7e-f547-4d5a-8c7c" name="Tyrannosaur [188/208 pts]" hidden="false" collective="false" type="unit">
@@ -1793,12 +1794,13 @@
         <infoLink id="53b6-9935-fe52-9e2c" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="ec28-5026-2111-db2f" name="Terror" hidden="false" targetId="583a-fa53-11ff-7b40" type="rule"/>
         <infoLink id="50ae-9dfe-5339-cd72" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+        <infoLink id="2896-ceea-330c-531c" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1a38-d44e-2431-d417" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="0726-c986-4790-8062" name="Model" hidden="false" collective="false" defaultSelectionEntryId="2346-0528-6126-5d9f">
+        <selectionEntryGroup id="0726-c986-4790-8062" name="Type" hidden="false" collective="false" defaultSelectionEntryId="2346-0528-6126-5d9f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ae6-a498-a770-fa6b" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc06-c039-8d87-a347" type="max"/>
@@ -1807,13 +1809,13 @@
             <selectionEntry id="2346-0528-6126-5d9f" name="Wild Tyrannosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="188.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c57-a04b-6fb8-7f01" name="Bound Tyrannosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="208.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1821,7 +1823,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3aff-bbec-a820-725d" name="Horned Dinosaur [122/142 pts]" hidden="false" collective="false" type="unit">
@@ -1831,12 +1833,13 @@
         <infoLink id="963c-4041-0593-1788" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
         <infoLink id="4608-8d6f-7015-522f" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
         <infoLink id="c0c4-1275-cd5b-1e84" name="Stampede" hidden="false" targetId="45b3-c028-8c8c-43ae" type="rule"/>
+        <infoLink id="1f2a-1eb8-2c3c-bc4f" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ad60-59c4-e79f-ac04" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="549b-a9e6-10a9-45ee" name="Model" hidden="false" collective="false" defaultSelectionEntryId="09d1-5c85-75f4-4881">
+        <selectionEntryGroup id="549b-a9e6-10a9-45ee" name="Type" hidden="false" collective="false" defaultSelectionEntryId="09d1-5c85-75f4-4881">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31ba-4653-6608-364e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb7d-c34d-f3d1-cfed" type="min"/>
@@ -1845,13 +1848,13 @@
             <selectionEntry id="09d1-5c85-75f4-4881" name="Wild Horned Dinosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="122.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="12dd-9ea6-8083-cb4a" name="Bound Horned Dinosaur" hidden="false" collective="false" type="model">
               <costs>
                 <cost name="pts" typeId="points" value="142.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1859,14 +1862,14 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedRules>
     <rule id="7bb1-5921-1762-f0fe" name="Choking Attacks" hidden="false">
       <description>
-A target hit by a choking attack either from shooting or HTH gets no armour bonus or cover bonus to its RES.</description>
+A target hit by a choking attack either from shooting or HtH gets no armour bonus or cover bonus to its RES.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
@@ -1878,7 +1881,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">10</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV4, Baleful Glare, Dread</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHtH SV4, Baleful Glare, Dread</characteristic>
       </characteristics>
     </profile>
     <profile id="2dbb-4ea1-5f93-dce3" name="Chimera" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -1889,7 +1892,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">9</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD 2, 4xHTH SV4, 1xHTH SV10 Venomous, 3xFlaming Breath SV3 Fire, Dread</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD 2, 4xHtH SV4, 1xHtH SV10 Venomous, 3xFlaming Breath SV3 Fire, Dread</characteristic>
       </characteristics>
     </profile>
     <profile id="0184-c48d-2234-cbf7" name="Cockatrice" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -1900,7 +1903,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">10</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH Attacks SV3, Baleful Glare, Dread, Flies</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHtH Attacks SV3, Baleful Glare, Dread, Flies</characteristic>
       </characteristics>
     </profile>
     <profile id="fdd9-726d-86fe-ec2d" name="Cyclops" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -1911,10 +1914,10 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">12</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">4</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV4, Dread</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHtH SV4, Dread</characteristic>
       </characteristics>
     </profile>
-    <profile id="04da-20b3-5a4a-f90c" name="Rock- Hurled by a Monstrosity" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="04da-20b3-5a4a-f90c" name="Rock - Hurled by a Monstrosity" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">10-20&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -1931,7 +1934,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">15</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD3, Fast 6, 7xHTH SV6, 3xFlaming Breath SV3 Fire, Dread, Terror, Flies</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD3, Fast 6, 7xHtH SV6, 3xFlaming Breath SV3 Fire, Dread, Terror, Flies</characteristic>
       </characteristics>
     </profile>
     <profile id="7b72-6afa-c85b-64c1" name="Ghouls" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -1942,7 +1945,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="e5bb-3c2b-9a60-9c05" name="Giant" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -1953,7 +1956,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">13</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD3, 5xHTH SV5, Dread, Terror, Blundering</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD3, 5xHtH SV5, Dread, Terror, Blundering</characteristic>
       </characteristics>
     </profile>
     <profile id="cd05-6e8f-63cf-f6ad" name="Giant Rats" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -1964,7 +1967,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">4</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHTH SV1 Venomous</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHtH SV1 Venomous</characteristic>
       </characteristics>
     </profile>
     <profile id="9cd1-3fa7-9244-5170" name="Giant Scorpions" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -1975,7 +1978,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHTH SV2, 1xHTH SV10, Venomous, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">2xHtH SV2, 1xHtH SV10, Venomous, Wound</characteristic>
       </characteristics>
     </profile>
     <profile id="70ab-0608-068e-a498" name="Giant Spiders" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -1986,7 +1989,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV3, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHtH SV3, Wound</characteristic>
       </characteristics>
     </profile>
     <profile id="ca3a-b6cb-8358-d7d9" name="Gigantic Spider" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -1997,7 +2000,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">13</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 6xHTH SV6, Dread, Terror</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 6xHtH SV6, Dread, Terror</characteristic>
       </characteristics>
     </profile>
     <profile id="ec10-cee9-9e3f-9783" name="Golem" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2008,7 +2011,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">13</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">10</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Slow 4, 3xHTH SV2, Dread</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Slow 4, 3xHtH SV2, Dread</characteristic>
       </characteristics>
     </profile>
     <profile id="61f2-9f86-a3d8-d5e8" name="Griffin" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2019,7 +2022,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">10</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV3, Dread, Savage, Fast 6, Flies</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHtH SV3, Dread, Savage, Fast 6, Flies</characteristic>
       </characteristics>
     </profile>
     <profile id="7ea6-624e-3017-99b2" name="Hippogriff" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2030,7 +2033,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">10</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV3, Dread, Fast 6, Flies</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHtH SV3, Dread, Fast 6, Flies</characteristic>
       </characteristics>
     </profile>
     <profile id="6e13-9d18-f7c2-d272" name="Hydra" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2041,7 +2044,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">9</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 9xHTH SV2, Stubborn, Dread, Regenerate</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 9xHtH SV2, Stubborn, Dread, Regenerate</characteristic>
       </characteristics>
     </profile>
     <profile id="3bd1-e1ac-0073-8b2f" name="Manticore" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2052,7 +2055,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">12</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV4, Beastly breath, Dread</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHtH SV4, Beastly breath, Dread</characteristic>
       </characteristics>
     </profile>
     <profile id="c57c-29b1-6dce-2cb0" name="Ogres" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2063,7 +2066,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">8</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 2xHTH, Frenzied Charge</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 2xHtH, Frenzied Charge</characteristic>
       </characteristics>
     </profile>
     <profile id="4c9f-6aab-32b0-d91d" name="Ogres in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2074,7 +2077,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">8(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 2xHTH, Frenzied Charge</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 2xHtH, Frenzied Charge</characteristic>
       </characteristics>
     </profile>
     <profile id="e8bd-7b95-1cce-09a4" name="Wild Ratswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2085,7 +2088,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV1 Venomous</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHtH SV1 Venomous</characteristic>
       </characteristics>
     </profile>
     <profile id="3476-9800-ad47-8c84" name="Wild Batswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2096,7 +2099,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV1, Flies, Fast 7</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHtH SV1, Flies, Fast 7</characteristic>
       </characteristics>
     </profile>
     <profile id="ed6e-31c3-36b2-839f" name="Wild Spiderswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2107,7 +2110,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">4xHTH SV0</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">4xHtH SV0</characteristic>
       </characteristics>
     </profile>
     <profile id="1611-c370-3e68-d00a" name="Wild Frogswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2118,7 +2121,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV0, Dread</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHtH SV0, Dread</characteristic>
       </characteristics>
     </profile>
     <profile id="5319-4ee6-a650-6292" name="Wild Beeswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2129,7 +2132,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHTH SV0, Venomous, Flies</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">3xHtH SV0, Venomous, Flies</characteristic>
       </characteristics>
     </profile>
     <profile id="bb99-778c-b54b-3569" name="Wild Serpentswarm" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2140,7 +2143,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">4xHTH SV0, Venomous, Slow 4</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">4xHtH SV0, Venomous, Slow 4</characteristic>
       </characteristics>
     </profile>
     <profile id="c844-35e2-768e-50f8" name="Wyvern " hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2151,7 +2154,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">10</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV3 Venomous, Beastly Breath, Dread, Flies</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHtH SV3 Venomous, Beastly Breath, Dread, Flies</characteristic>
       </characteristics>
     </profile>
     <profile id="8131-c371-7d0a-189b" name="Giant Treeman" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2162,7 +2165,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">12</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">2</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV4, Blundering, Slow 4, Woodsman, Stubborn, Tough, Dread</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHtH SV4, Blundering, Slow 4, Woodsman, Stubborn, Tough, Dread</characteristic>
       </characteristics>
     </profile>
     <profile id="e5f9-9f0b-73eb-76e7" name="Treeman/Dryad" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2173,7 +2176,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">8</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">2</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 2xHTH SV3, Blundering, Slow 4, Woodsman, Stubborn, Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 2xHtH SV3, Blundering, Slow 4, Woodsman, Stubborn, Tough</characteristic>
       </characteristics>
     </profile>
     <profile id="5ff3-ad2b-6639-78da" name="Trolls" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2184,7 +2187,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">4</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 3xHTH SV2, Chunder, Regenerate</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 3xHtH SV2, Chunder, Regenerate</characteristic>
       </characteristics>
     </profile>
     <profile id="da16-d143-b468-26c3" name="Cave Bear" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2195,7 +2198,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">8</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">2</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 3xHTH SV3, Irresistable Charge, Frenzied Charge, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 3xHtH SV3, Irresistable Charge, Frenzied Charge, Wound</characteristic>
       </characteristics>
     </profile>
     <profile id="5ca4-7d22-6678-4dc5" name="Brontosaur" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2206,7 +2209,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">12</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV3, Blundering, Stampede</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHtH SV3, Blundering, Stampede</characteristic>
       </characteristics>
     </profile>
     <profile id="c74b-e0c7-6a3d-bc2a" name="Tyrannosaur" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2217,7 +2220,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">12</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV5, Dread, Terror, Irresistable Charge</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHtH SV5, Dread, Terror, Irresistable Charge</characteristic>
       </characteristics>
     </profile>
     <profile id="68aa-6640-b9da-6ee0" name="Horned Dinosaur" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2228,7 +2231,7 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">12</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 3xHTH SV5, Dread, Stampede, Irresistable Charge</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 3xHtH SV5, Dread, Stampede, Irresistable Charge</characteristic>
       </characteristics>
     </profile>
     <profile id="c9d3-d13d-232c-c354" name="Manticore with Stinging Tail" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2239,7 +2242,29 @@ A target hit by a choking attack either from shooting or HTH gets no armour bonu
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">12</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHTH SV4, Beastly breath, Dread, 1xHTH SV10 Venomous</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, MOD2, 5xHtH SV4, Beastly breath, Dread, 1xHtH SV10 Venomous</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="46fb-de84-d662-097d" name="Ogre Chieftain" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+      <characteristics>
+        <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
+        <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
+        <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61">5</characteristic>
+        <characteristic name="Res" typeId="d916-9ec8-dd33-7873">8</characteristic>
+        <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
+        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Large, 2xHtH, Frenzied Charge</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="f004-a3ca-4a39-903d" name="Ogre Chieftain in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+      <characteristics>
+        <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
+        <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
+        <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61">5</characteristic>
+        <characteristic name="Res" typeId="d916-9ec8-dd33-7873">8(9)</characteristic>
+        <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
+        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Large, 2xHtH, Frenzied Charge</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Olympians.cat
+++ b/Olympians.cat
@@ -17,15 +17,19 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4b29-f094-4487-eb77" name="Centaurs [108 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="facd-b0c6-863b-759e" type="max"/>
+      </constraints>
       <infoLinks>
         <infoLink id="6d56-3a8a-443b-e633" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="5b20-0eb3-f58b-f834" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="5b20-0eb3-f58b-f834" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+        <infoLink id="2db5-6d13-0eae-920e" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="d742-57c8-8c5b-70d6" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b381-37f6-ad7f-417b" name="Models" hidden="false" collective="false" defaultSelectionEntryId="684a-90a9-5fc1-8251">
+        <selectionEntryGroup id="b381-37f6-ad7f-417b" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="684a-90a9-5fc1-8251">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c143-4351-6cc7-d897" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a92-99bb-61fe-cc58" type="max"/>
@@ -45,7 +49,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1f6c-92bc-a542-b088" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -55,11 +59,10 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="841d-9c5c-7f76-2b6c" name="Centaur champion" hidden="false" targetId="8dfe-4fec-07ad-440f" type="profile"/>
-                        <infoLink id="5d9a-3390-2fa0-ee41" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="44.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -67,7 +70,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fed1-4788-3778-d1c3" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -84,7 +87,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6d65-1bb4-924d-33ab" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -94,11 +97,10 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="07a1-ca16-f3c4-4bf4" name="Centaur champion in Light Armour" hidden="false" targetId="e706-13b3-102a-3ff8" type="profile"/>
-                        <infoLink id="455a-aa4a-a1de-5434" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="46.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -106,7 +108,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc5f-1cad-533c-b3a5" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -123,7 +125,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="36.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e5dc-b593-096e-f370" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -133,11 +135,10 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="6c81-e114-06d3-98c7" name="Centaur champion in Medium Armour" hidden="false" targetId="c3be-b711-1ec0-2f25" type="profile"/>
-                        <infoLink id="04e6-fd33-811d-7cf5" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="48.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -145,12 +146,12 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="cfb2-6a81-54d7-4953" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="ce97-4f6e-fdce-154b">
+        <selectionEntryGroup id="cfb2-6a81-54d7-4953" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="ce97-4f6e-fdce-154b">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6bf-d683-9d7e-bfd4" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f17-ce97-5316-4521" type="max"/>
@@ -162,7 +163,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8659-e294-65da-e09d" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -178,7 +179,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0f4-3f97-65d3-cc5c" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -194,7 +195,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ccf-43bb-e01b-8e9f" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -210,7 +211,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55b8-b817-7be1-bd04" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -226,7 +227,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -249,7 +250,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -265,7 +266,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -273,10 +274,17 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8ea4-dd34-63f1-1949" name="Harpies [150 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aed8-20bb-7fea-8b7d" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="68bb-941f-d9be-5201" name="Fast 10" hidden="false" targetId="0034-82ae-f695-d446" type="rule"/>
+        <infoLink id="844b-aa2e-f1d2-10a8" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="8333-5201-5ef4-5f8e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="4a1e-a520-cd6f-58be" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
@@ -290,13 +298,12 @@
                 <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d93-e823-83d6-da9d" type="min"/>
               </constraints>
               <infoLinks>
-                <infoLink id="e1cf-8f75-7e23-79be" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
                 <infoLink id="4680-43f9-af57-74dd" name="Harpies" hidden="false" targetId="123c-4128-929e-77ab" type="profile"/>
-                <infoLink id="58ec-7389-1aa8-7f17" name="Rocks (HTH)" hidden="false" targetId="88d0-6821-ceff-0382" type="profile"/>
+                <infoLink id="58ec-7389-1aa8-7f17" name="Rocks (HtH)" hidden="false" targetId="88d0-6821-ceff-0382" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -312,7 +319,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -335,7 +342,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -343,18 +350,18 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1cf2-13c4-d6c2-a87c" name="Amazon Cavalry [75 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="72d9-bd60-6bcc-e9cc" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="72d9-bd60-6bcc-e9cc" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="b0a7-5917-ccd1-2b15" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
+        <categoryLink id="b10e-e07f-f3c3-51c7" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="655f-b258-4f69-2249" name="Models" hidden="false" collective="false" defaultSelectionEntryId="47a9-0504-2509-8aff">
+        <selectionEntryGroup id="655f-b258-4f69-2249" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="47a9-0504-2509-8aff">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95ef-c49e-66eb-9def" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2509-f6b1-55f9-7252" type="max"/>
@@ -374,7 +381,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d2b1-3769-9188-ee98" name="Amazon Cavalry Leader" hidden="false" collective="false" type="model">
@@ -388,7 +395,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="33.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -396,7 +403,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f68-9b78-71d3-fe73" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -413,7 +420,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ce00-03e7-d2be-a4e5" name="Amazon Cavalry Leader" hidden="false" collective="false" type="model">
@@ -427,7 +434,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="35.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -435,7 +442,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -451,12 +458,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="40af-648f-0646-ee66" name="Bow upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="40af-648f-0646-ee66" name="Bow Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbbc-7321-7acc-f706" type="max"/>
           </constraints>
@@ -474,12 +481,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="7cb9-b03c-af35-74dd" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="33ed-c421-9f5f-f233">
+        <selectionEntryGroup id="7cb9-b03c-af35-74dd" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="33ed-c421-9f5f-f233">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8177-2cc0-5abe-f640" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a622-af94-8325-80bc" type="min"/>
@@ -491,7 +498,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e0a7-eb58-36e3-3df4" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -500,7 +507,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -508,7 +515,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dddc-a18c-2b9c-5157" name="Amazon Archers [72 pts]" hidden="false" collective="false" type="unit">
@@ -536,7 +543,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="37d2-67c2-4301-fe42" name="Amazon Archer Leader" hidden="false" collective="false" type="model">
@@ -550,7 +557,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -558,7 +565,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="edc1-772f-abcf-ff39" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -575,7 +582,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="08a0-19a2-2b4d-7bd2" name="Amazon Archer Leader" hidden="false" collective="false" type="model">
@@ -589,7 +596,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -597,12 +604,12 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="eaf8-8c09-6a20-c3eb" name="HTH Weapons" hidden="false" collective="false">
+        <selectionEntryGroup id="eaf8-8c09-6a20-c3eb" name="HtH Weapons" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="413d-feb9-a587-06c1" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d91e-f996-8da0-b987" type="min"/>
@@ -614,7 +621,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87b4-91df-44ff-c7d2" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -623,7 +630,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -639,7 +646,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -656,7 +663,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee7d-cc9b-1fb5-521e" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -672,7 +679,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -680,7 +687,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="405c-428f-c19e-d4b8" name="Amazon Warrior [77 pts]" hidden="false" collective="false" type="unit">
@@ -708,7 +715,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b2ca-1fb5-ac9b-55a3" name="Amazon Warrior Leader" hidden="false" collective="false" type="model">
@@ -722,7 +729,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -730,7 +737,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc31-9f8a-2ef9-ab1d" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -747,7 +754,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4331-be6f-a01b-5d23" name="Amazon Warrior Leader" hidden="false" collective="false" type="model">
@@ -761,7 +768,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -769,12 +776,12 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="b779-9848-9897-e963" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="748b-2939-ce06-3bc1">
+        <selectionEntryGroup id="b779-9848-9897-e963" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="748b-2939-ce06-3bc1">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="867a-3333-8c8b-5c5a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a96-6526-6c71-7032" type="min"/>
@@ -786,7 +793,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c730-e02f-6b6b-def5" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -795,7 +802,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f58c-efbe-33e3-aa6a" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -804,7 +811,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -812,7 +819,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d1e5-7b9c-70d2-9356" name="Peltast [67 pts]" hidden="false" collective="false" type="unit">
@@ -820,7 +827,7 @@
         <categoryLink id="f96a-0da1-16cb-8807" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b16d-1476-744a-a543" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="dea1-c75f-4108-c061">
+        <selectionEntryGroup id="b16d-1476-744a-a543" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="dea1-c75f-4108-c061">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0ea-d7ac-c1c0-9456" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="103c-0ec0-975d-2e07" type="min"/>
@@ -839,13 +846,13 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dea1-c75f-4108-c061" name="Daggers" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -862,7 +869,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f7f-7277-0b9d-804c" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -878,7 +885,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c396-7a82-7391-93f8" name="Javelin" hidden="false" collective="false" type="upgrade">
@@ -887,7 +894,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -912,7 +919,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f3dd-d202-b517-9d76" name="Peltast Leader" hidden="false" collective="false" type="model">
@@ -926,7 +933,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -934,7 +941,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="28b6-05ee-3a6c-de1d" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -951,7 +958,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8e71-f7d7-47ef-be27" name="Peltast Leader" hidden="false" collective="false" type="model">
@@ -965,7 +972,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -973,7 +980,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -981,7 +988,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ca9d-82e1-bcde-c147" name="Hoplites [82 pts]" hidden="false" collective="false" type="unit">
@@ -1006,7 +1013,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2137-fb2b-2d44-5821" name="Hoplite" hidden="false" collective="false" type="model">
@@ -1019,7 +1026,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1035,7 +1042,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1043,10 +1050,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0ff7-a68e-abb3-2793" name="Hoplite Guard [92 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20b4-97c4-56ed-fe1d" type="max"/>
+      </constraints>
       <infoLinks>
         <infoLink id="01c2-4a31-14bb-12f7" name="Shieldwall" hidden="false" targetId="93f9-d132-d71b-ab39" type="rule"/>
         <infoLink id="b441-a7c3-0271-9a78" name="Disciplined" hidden="false" targetId="0056-a41e-408e-1673" type="rule"/>
@@ -1068,7 +1078,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4802-8d10-9390-f7bd" name="Hoplite Guard" hidden="false" collective="false" type="model">
@@ -1081,7 +1091,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1098,7 +1108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3812-552b-cd66-1ac4" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1107,7 +1117,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1123,7 +1133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1131,7 +1141,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d60c-560f-d373-3699" name="Greek Hero Charioteer [160 pts]" hidden="false" collective="false" type="unit">
@@ -1141,13 +1151,46 @@
       <infoLinks>
         <infoLink id="973d-e1ca-a878-b437" name="Chariot With Hero and Crew, pulled by two horses" hidden="false" targetId="6b6c-1e55-2b94-9b68" type="profile"/>
         <infoLink id="4534-958c-9176-ce20" name="Horse" hidden="false" targetId="1319-8d6e-7092-4ce8" type="profile"/>
+        <infoLink id="a772-ff3b-2ce9-9b8e" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="72d4-0580-4ca6-5710" name="Tough 2" hidden="false" targetId="487f-dc82-bce1-c0f6" type="rule"/>
+        <infoLink id="55bd-6513-dbb9-09b6" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+        <infoLink id="d86c-9bbc-29bb-b2b7" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="dffd-9266-0730-0f05" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="f2c2-c262-44a5-64d3" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6781-a4a0-0426-f707" name="Greek Crew" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3304-23e2-fe81-2a04" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00eb-97b6-334d-22be" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="637b-4de9-2652-ba5c" name="Greek Charioteer crew" hidden="false" targetId="bfd9-42ff-e18a-7e81" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ee3e-0c9e-60d9-5710" name="Greek Hero" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfe1-f3dd-7d36-f988" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d30f-2755-373b-5d56" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="ef0a-166a-578d-527b" name="Greek Hero (chariot - on foot)" hidden="false" targetId="09bf-39d0-5fa5-217c" type="profile"/>
+            <infoLink id="c25e-eb13-21e2-008d" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="160.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="adf2-c8d0-3337-471e" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="136f-f183-588f-ccd9">
+        <selectionEntryGroup id="adf2-c8d0-3337-471e" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="136f-f183-588f-ccd9">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2138-fee4-3488-c41a" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faac-3934-a73a-9d85" type="min"/>
@@ -1159,7 +1202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd24-795a-5245-caa0" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1168,7 +1211,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53e8-5fbe-f804-2ca5" name="Long Spear" hidden="false" collective="false" type="upgrade">
@@ -1177,7 +1220,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1197,38 +1240,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="4a09-a586-0b2b-fdab" name="Models" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="bd9d-5fde-f703-5e12" name="Greek Hero" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f27-b583-8bf3-96e0" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15fb-b85b-ac6b-5c1d" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="0b21-a127-4d56-962b" name="Greek Hero (chariot - on foot)" hidden="false" targetId="09bf-39d0-5fa5-217c" type="profile"/>
-                <infoLink id="beda-c8bb-ac45-5c00" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="160.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2c3b-17ee-f65b-61d8" name="Greek Crew" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fa9-2b08-fc82-8cbe" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51af-a6a4-fa09-5783" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="d2f0-0661-7766-c2ff" name="Greek Charioteer crew" hidden="false" targetId="bfd9-42ff-e18a-7e81" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1244,7 +1256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1261,7 +1273,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="029f-b0f4-dffa-2cdb" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1270,7 +1282,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1287,7 +1299,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e947-afcf-5c76-9739" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1296,7 +1308,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8165-59f6-47ef-77dd" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1305,7 +1317,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1321,7 +1333,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1337,111 +1349,44 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="0cba-1325-c23e-4c28" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66d0-1ea7-8eed-b3b3" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="d5ea-b3f4-21fe-287e" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4b18-55a3-ce1e-f167" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="015e-62a6-4767-b1bc" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5511-aaca-35d0-5fe9" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="91d4-3d5e-5589-2c74" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4f03-a2ca-f25d-dfc2" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7af5-a407-8410-d9f4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c755-bf58-9f95-21a6" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9433-9b02-3de8-0a9c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="509b-ccce-d3c1-c4f2" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2693-7a93-cf46-3dd2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="89ee-f4e3-a0e0-dd57" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="452e-f376-7443-e70a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0a7e-7b6f-8d4d-34d5" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="5ff4-cf2b-e019-3c61" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a4e6-d616-6bf5-4399" name="Greek Hero [85 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="d616-2963-757b-0562" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="7d43-8ea1-1e69-297e" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="77d4-95f9-b227-4ffb" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="bcb8-3c86-0c0b-c5be" name="Greek Hero" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33ce-1c69-9bba-39d6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2c2-0905-a872-0e4d" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="1847-23fa-ba13-aba6" name="Greek Hero (on foot)" hidden="false" targetId="a2db-6172-f7da-45d3" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="85.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6db7-711e-8437-bb46" name="model" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="7f4d-0ffb-9890-72f4" name="Greek Hero" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea2b-098f-f250-d719" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6789-1d68-79de-2dc5" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="f177-c6ce-00bc-2ca0" name="Greek Hero (on foot)" hidden="false" targetId="a2db-6172-f7da-45d3" type="profile"/>
-                <infoLink id="86b3-d4d5-e44e-1a4d" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="85.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
         <selectionEntryGroup id="558c-fa55-0570-7b26" name="Hero Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="a9e5-eaa0-7261-cd9e">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c69a-1d67-99db-a286" type="min"/>
@@ -1454,7 +1399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f4b2-0e1b-2414-f81e" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1463,7 +1408,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6bc1-f1d2-1cae-5fe0" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1472,7 +1417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1489,7 +1434,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df86-aee5-fd04-7711" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1498,7 +1443,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1514,7 +1459,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1530,12 +1475,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e9a5-8e13-a66b-5793" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="271a-1d90-9c5c-ec32">
+        <selectionEntryGroup id="e9a5-8e13-a66b-5793" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="271a-1d90-9c5c-ec32">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b40c-8543-24fe-66ee" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74fe-1bd3-4c1c-105f" type="min"/>
@@ -1547,7 +1492,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d81-3619-85f7-39e3" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1556,7 +1501,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="be9f-4181-78b5-f67d" name="Long Spear" hidden="false" collective="false" type="upgrade">
@@ -1565,58 +1510,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9d56-33b2-5034-86b8" name="Magic Weapon" hidden="false" collective="false" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="af8d-3187-aeaa-31cb" name="Magic Weapon HTH" hidden="false" collective="false">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4547-e5aa-82d7-06ef" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="6822-71c5-10b6-3e58" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="6818-e377-0188-c41a" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="20cb-0cb3-281f-4a3f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="396d-9d17-0e66-2ea5" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="5b87-a3c4-5532-a79b" name="War Bringer" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="ac1b-1950-c393-c1a4" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="5b16-68c9-4178-3044" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="ea79-db84-691a-742a" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1632,57 +1526,18 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6586-968f-967c-db55" name="Ranged Magic Weapons" hidden="false" collective="false" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="dc33-cd6f-5c7e-9d9b" name="Ranged Magic Weapons" hidden="false" collective="false">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc39-833f-6a84-a59d" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="c008-7ae8-de33-6287" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="80c1-fa86-4178-b650" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="14cc-4860-dbe0-9d97" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="e13b-4def-bfc6-b8d9" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="bc8f-2270-db7f-c3d2" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="e31e-54b7-7037-1d2f" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="92c7-2dfc-540c-406d" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9944-6808-c090-b071" name="Greek Seer [57 pts]" hidden="false" collective="false" type="unit">
@@ -1693,83 +1548,23 @@
         <categoryLink id="1098-544b-99e2-0a58" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="f54f-b180-736b-7f67" name="Wizard" hidden="false" targetId="wizard unit" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="91b3-0f8e-4720-9fdf" name="Greek Seer with Sword" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce42-83bd-3f1f-9533" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9205-0464-18fc-62bb" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="b8bb-46a7-6c7d-027d" name="Greek Seer" hidden="false" targetId="e657-7c82-1e67-6637" type="profile"/>
+            <infoLink id="99e5-32a1-0582-8cf5" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="57.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="9118-ac36-451b-63a2" name="Models" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="3fbf-1f32-bdf9-a1ca" name="Greek Seer with Sword" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c625-26af-861b-c6ff" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa14-1754-f786-025d" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="c7bc-e195-5803-01de" name="Greek Seer" hidden="false" targetId="e657-7c82-1e67-6637" type="profile"/>
-                <infoLink id="e20f-9bff-b0db-039d" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="57.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="2fb5-c6c2-966b-090d" name="Attendants or Nymphs" hidden="false" collective="false">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e9e-547c-e09e-3b0b" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae2e-9506-62ee-d47f" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="c8d1-c214-cc62-cd77" name="Attendant with Sword" hidden="false" collective="false" type="model">
-                  <selectionEntryGroups>
-                    <selectionEntryGroup id="80e2-a087-7e92-6023" name="Attendants" hidden="false" collective="false">
-                      <selectionEntries>
-                        <selectionEntry id="c0c5-e356-dd80-f4b0" name="Attendants" hidden="false" collective="false" type="model">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5bd-bd75-fd3c-9e2c" type="max"/>
-                          </constraints>
-                          <infoLinks>
-                            <infoLink id="aaad-a239-9e17-77fc" name="Attendants" hidden="false" targetId="4b5a-041c-4b86-004a" type="profile"/>
-                          </infoLinks>
-                          <costs>
-                            <cost name="pts" typeId="points" value="10.0"/>
-                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                  <costs>
-                    <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="2c94-48f3-1c28-c3a4" name="Nymphs" hidden="false" collective="false" type="unit">
-                  <selectionEntryGroups>
-                    <selectionEntryGroup id="cd63-d570-39d0-10a7" name="Nymphs" hidden="false" collective="false">
-                      <selectionEntries>
-                        <selectionEntry id="7492-29c6-1476-f7b2" name="Nymphs" hidden="false" collective="false" type="model">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe59-77f3-ed49-8a12" type="max"/>
-                          </constraints>
-                          <infoLinks>
-                            <infoLink id="dcdf-f166-e109-a531" name="Nymphs" hidden="false" targetId="c2fb-fb61-9688-0c7e" type="profile"/>
-                          </infoLinks>
-                          <costs>
-                            <cost name="pts" typeId="points" value="18.0"/>
-                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                  <costs>
-                    <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-        </selectionEntryGroup>
         <selectionEntryGroup id="95e0-6978-9a3c-2aef" name="Magic Level" hidden="false" collective="false" defaultSelectionEntryId="1eda-12aa-5a00-49db">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1140-aed7-a5e9-dc9b" type="max"/>
@@ -1782,7 +1577,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fe1f-2ccb-1de9-69ce" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -1791,7 +1586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f652-48eb-158d-9fb4" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -1800,7 +1595,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1816,7 +1611,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1833,7 +1628,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f1bb-ea8e-dc08-2316" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1842,7 +1637,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1859,7 +1654,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ef3a-f4be-bf0f-2e42" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1868,7 +1663,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d8d6-541b-2519-1eaa" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1877,7 +1672,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ee0-a4da-27da-d4ee" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1886,7 +1681,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf0e-31e9-9e83-8275" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1895,7 +1690,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10be-89e3-d278-3d00" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1904,7 +1699,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a559-7b6d-31ea-fbd1" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1913,7 +1708,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4fbc-c531-ebed-7517" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1922,7 +1717,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d7b9-a07d-114b-42b0" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1931,7 +1726,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8ace-64db-3ba2-beaa" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1940,7 +1735,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf86-4221-aa7d-f913" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1949,7 +1744,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d46-75cc-3c7b-01f2" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1958,7 +1753,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee5e-6fa8-a8b9-8385" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1967,7 +1762,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0eaa-1117-e30b-5225" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1976,7 +1771,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1992,7 +1787,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87e6-d673-2db2-d2dd" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2004,7 +1799,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="574d-699d-eb15-4460" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2016,7 +1811,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="218c-171a-3ec5-4bd5" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2028,7 +1823,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0dbb-1a6b-1de1-a241" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2040,7 +1835,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f5d4-6afe-2529-0f68" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2052,7 +1847,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0345-cfff-89bb-a7d9" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2064,7 +1859,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0544-ada4-b675-be92" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2076,7 +1871,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73e8-b412-ab50-f86c" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2088,7 +1883,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="925c-b3cb-0b5e-1cd8" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2100,7 +1895,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="772d-10ba-11b7-6b3d" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2112,7 +1907,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9f4-1ca2-ed5d-ea53" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2124,7 +1919,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eb80-c966-5cf6-760d" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2136,7 +1931,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f7df-dc43-ac87-3c31" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2148,85 +1943,74 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f0ad-059e-420a-ee8b" name="Magic Weapon " hidden="false" collective="false">
+        <selectionEntryGroup id="8226-c0b2-34b9-9aeb" name="Attendants or Nymphs" hidden="false" collective="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afad-9476-26f5-d88b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05f0-0eea-0019-0ad9" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ff6a-d4c5-d3b7-f056" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="6557-9b7d-3e11-00be" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
+            <selectionEntry id="9292-49fd-fc65-dba5" name="Attendant with Sword" hidden="false" collective="false" type="model">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="9aec-43ef-e176-d8dc" name="Attendants" hidden="false" collective="false">
+                  <selectionEntries>
+                    <selectionEntry id="4dbe-4f0e-ce3c-4085" name="Attendants" hidden="false" collective="false" type="model">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dd3-14d8-578d-a956" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="ef36-0986-7cbe-ae32" name="Attendants" hidden="false" targetId="4b5a-041c-4b86-004a" type="profile"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="867e-0330-18c2-14d2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7cdf-c8b5-d5d5-a952" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
+            <selectionEntry id="2d45-fae4-5281-ff74" name="Nymphs" hidden="false" collective="false" type="unit">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="43e1-7314-7735-9394" name="Nymphs" hidden="false" collective="false">
+                  <selectionEntries>
+                    <selectionEntry id="e4b8-09a9-ef2a-3633" name="Nymphs" hidden="false" collective="false" type="model">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c63a-d4d7-41cd-2285" type="max"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="cb3b-2fd0-3318-6c2a" name="Nymphs" hidden="false" targetId="c2fb-fb61-9688-0c7e" type="profile"/>
+                        <infoLink id="1bed-54bb-2c4a-3cde" name="Spirit" hidden="false" targetId="78d3-886d-5fc6-bac4" type="rule"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="cd06-9456-6fed-6727" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1374-4583-7daa-9e3e" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b356-d987-f633-0729" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5f21-d667-db5c-a1d1" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="504a-aca5-ddc1-55cb" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="41b2-24f3-911d-56d9" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="98ce-3cb0-1c26-22c4" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b834-54e3-8e89-2e85" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="db70-0686-6ad7-54de" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7bf8-7b53-17e5-b127" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="39ff-9691-d557-e540" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a25e-e608-b473-48ab" name="Greek Lord (on foot) [108 pts]" hidden="false" collective="false" type="unit">
@@ -2249,7 +2033,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="76.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b9d-f87a-5da3-a7e1" name="Hoplite Bodyguard" hidden="false" collective="false" type="model">
@@ -2262,7 +2046,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2279,7 +2063,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="75b3-f044-42ad-23d9" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2288,7 +2072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55d5-2ec9-d047-2767" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2297,7 +2081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2313,7 +2097,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2329,7 +2113,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2346,7 +2130,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98df-555a-7a9b-89cb" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -2355,7 +2139,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2372,7 +2156,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebf0-6d1b-b097-bb73" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2381,7 +2165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2397,96 +2181,62 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="aa98-f8e0-2ff6-bba5" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f52a-f636-53f6-99b2" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="fd5d-94f2-4e9c-91cc" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5fe7-43d0-2301-78c3" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ec7d-4152-4ede-8027" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="58aa-c218-d0cc-0292" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3d94-dd96-0692-bc85" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1f09-0a52-1e8a-b4c5" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="10a7-7fd7-33d4-b458" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8972-5797-7abb-34ef" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a756-aa39-cb3f-193c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="df05-8b70-6a04-e70d" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3165-bee5-dd88-fc56" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1b20-5422-7d2e-cf7b" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ac68-40d2-f38d-85f2" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7398-3fd1-437c-6b53" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="175a-e669-d260-e13a" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="75b5-c473-3303-4a2b" name="Greek Lord in Chariot [160 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="bb2a-6035-55ad-ff42" name="Chariot with Greek Lord and Crew, pulled by two horses" hidden="false" targetId="2db3-9b45-d996-8813" type="profile"/>
         <infoLink id="0aae-3177-e9fb-2a12" name="Horse" hidden="false" targetId="1319-8d6e-7092-4ce8" type="profile"/>
+        <infoLink id="dd99-55c8-3d1f-b2cd" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+        <infoLink id="2caf-7a74-b7a3-2fdc" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="94f4-a58b-4e1a-175c" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="bcd3-5a11-892c-87f6" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="f7fa-2b6e-5562-fcd3" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="e763-f1c5-b8f0-d0a6" name="Greek Crew" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e22c-e65b-50b1-1974" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2fa-ae64-235e-6156" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="53b0-ddc7-43d9-2277" name="Greek Charioteer crew" hidden="false" targetId="bfd9-42ff-e18a-7e81" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="603a-bd04-9155-2546" name="Greek Lord" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="636f-f6a6-3e18-6180" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84dd-6320-0436-9ef6" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="514e-78e4-c525-03f1" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+            <infoLink id="b6e8-a09b-23e6-1a6a" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
+            <infoLink id="fb53-c6cb-f18a-3872" name="Greek Lord (chariot - on foot)" hidden="false" targetId="76eb-e6c5-95ac-3da3" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="160.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="6b38-b72a-e9b2-18a7" name="Divine Intervention" hidden="false" collective="false">
           <constraints>
@@ -2499,12 +2249,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="427f-d5b7-f886-68e3" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="2ae1-cca1-0680-fc1f">
+        <selectionEntryGroup id="427f-d5b7-f886-68e3" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="2ae1-cca1-0680-fc1f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aec7-fa57-2da2-e1e5" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd11-5c65-2697-401c" type="min"/>
@@ -2516,7 +2266,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4548-811e-d803-1608" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2525,7 +2275,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7eeb-2813-a7ff-9d13" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2534,7 +2284,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2557,7 +2307,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2573,7 +2323,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2590,7 +2340,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="798f-9529-11d3-3844" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -2599,7 +2349,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2616,7 +2366,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="17e1-f91a-3e53-5239" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2625,122 +2375,23 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="1cba-5fa0-ab1c-9fa0" name="Models" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="a1c8-5f99-31bf-581e" name="Greek Lord" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51cc-2cf9-a97c-d174" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86a1-a6b5-113f-9ab9" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="01b2-2da5-57d1-fa92" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                <infoLink id="4acc-d7ed-2892-7785" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
-                <infoLink id="8d9f-6dc1-3a44-67c2" name="Greek Lord (chariot - on foot)" hidden="false" targetId="76eb-e6c5-95ac-3da3" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="160.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d6b0-5018-894f-fa44" name="Greek Crew" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cca-ea12-8e30-4519" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11a2-6a23-9252-fa80" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="6d70-1564-3920-c182" name="Greek Charioteer crew" hidden="false" targetId="bfd9-42ff-e18a-7e81" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="8206-b791-1772-7ba1" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="165c-a67b-3527-8231" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="fbcb-0340-ab52-1663" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="dcb7-e356-287d-70fe" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ea77-e77c-046f-21e4" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c630-1619-025f-c147" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ad22-777d-1392-ab07" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d15e-8978-6767-9766" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2c16-07b6-164f-ba4a" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bbf2-d007-2274-1da7" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="58cc-80ac-cd62-e905" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="22d2-f240-2bd7-8967" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2db2-b1f9-e255-56ae" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bd64-eaf7-6498-9fb2" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1993-b9d7-6983-818d" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4ae8-2344-62ff-baa2" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3602-5a81-c94e-f598" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedProfiles>
-    <profile id="8dfe-4fec-07ad-440f" name="Centaur champion" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="8dfe-4fec-07ad-440f" name="Centaur Champion" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">7</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">6</characteristic>
@@ -2748,7 +2399,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 8, 2x HTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 8, 2x HtH</characteristic>
       </characteristics>
     </profile>
     <profile id="546a-9c69-d05c-b7e7" name="Centaur" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2759,7 +2410,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e"> Fast 8, 2xHTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e"> Fast 8, 2xHtH</characteristic>
       </characteristics>
     </profile>
     <profile id="123c-4128-929e-77ab" name="Harpies" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2770,7 +2421,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">9</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Flies, Fast 10, 2xHTH SV1, 1xDrop SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Flies, Fast 10, 2xHtH SV1, 1xDrop SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="a1e1-39d5-5ab6-5df3" name="Amazon Cavalry Leader" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2781,7 +2432,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 8</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 8</characteristic>
       </characteristics>
     </profile>
     <profile id="8eb5-7cfa-4759-5315" name="Amazon Cavalry" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2803,7 +2454,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="f684-ab6f-e6bb-b9d2" name="Amazon Archer" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2825,7 +2476,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="dd52-b105-0d18-3a44" name="Amazon Warrior" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2847,7 +2498,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="7df4-69d2-67d3-5e6d" name="Peltast" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2869,7 +2520,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Shieldwall</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Shieldwall</characteristic>
       </characteristics>
     </profile>
     <profile id="7ce2-38f6-22d9-b66c" name="Hoplite" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2891,7 +2542,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Shieldwall, Disciplined</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Shieldwall, Disciplined</characteristic>
       </characteristics>
     </profile>
     <profile id="bd44-d12d-1887-4fb0" name="Hoplite Guard" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2913,7 +2564,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[6(8)]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">9</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough 2], Hero, 3xHTH, [Wound]</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Hero, 3xHtH, [Wound X]</characteristic>
       </characteristics>
     </profile>
     <profile id="bfd9-42ff-e18a-7e81" name="Greek Charioteer crew" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2946,7 +2597,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">10</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough, Fast 8, Irresistible Charge</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough 1, Fast 8, Irresistible Charge</characteristic>
       </characteristics>
     </profile>
     <profile id="a2db-6172-f7da-45d3" name="Greek Hero (on foot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2957,7 +2608,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">9</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 2, Hero, 3xHTH, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="e657-7c82-1e67-6637" name="Greek Seer" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2968,7 +2619,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Wound, Magic Level X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Wound, Magic Level X</characteristic>
       </characteristics>
     </profile>
     <profile id="4b5a-041c-4b86-004a" name="Attendants" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2990,10 +2641,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">3</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Spirit, 1xHTH SV1, Exchange of Missiles SV1.</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Spirit, 1xHtH SV1, Exchange of Missiles SV1.</characteristic>
       </characteristics>
     </profile>
-    <profile id="d20b-2fbd-a90d-4346" name="Greek Lord (on foot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="d20b-2fbd-a90d-4346" name="Greek Lord" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3001,7 +2652,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Command, Follow, 3xHTH, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="a5a3-1835-c0a9-ae66" name="Hoplite Bodyguard" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3023,7 +2674,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">10</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough, Fast 8, Irresistible Charge</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough 1, Fast 8, Irresistible Charge</characteristic>
       </characteristics>
     </profile>
     <profile id="76eb-e6c5-95ac-3da3" name="Greek Lord (chariot - on foot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3034,7 +2685,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[5(7)]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough], Command, Follow, 3xHTH, [Wound]</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, Follow, 3xHtH, [Wound X]</characteristic>
       </characteristics>
     </profile>
     <profile id="a2b6-44c7-47b6-fc0c" name="Peltast in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3056,7 +2707,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="0d34-1120-1f0f-c69b" name="Amazon Warrior in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3078,7 +2729,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="473c-659b-b0e6-436f" name="Amazon Archer Leader in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3089,7 +2740,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1</characteristic>
       </characteristics>
     </profile>
     <profile id="0e28-0cb2-aa5a-a921" name="Amazon Archer in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3111,7 +2762,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 8</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 8</characteristic>
       </characteristics>
     </profile>
     <profile id="3794-1392-85ff-0b94" name="Amazon Cavalry in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3133,7 +2784,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 8, 2xHTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 8, 2xHtH</characteristic>
       </characteristics>
     </profile>
     <profile id="686c-1f40-1d1d-8a91" name="Centaur in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -3144,10 +2795,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 8, 2xHTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 8, 2xHtH</characteristic>
       </characteristics>
     </profile>
-    <profile id="e706-13b3-102a-3ff8" name="Centaur champion in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="e706-13b3-102a-3ff8" name="Centaur Champion in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">7</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">6</characteristic>
@@ -3155,10 +2806,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 8, 2x HTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 8, 2x HtH</characteristic>
       </characteristics>
     </profile>
-    <profile id="c3be-b711-1ec0-2f25" name="Centaur champion in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="c3be-b711-1ec0-2f25" name="Centaur Champion in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">7</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">6</characteristic>
@@ -3166,7 +2817,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 8, 2x HTH</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 8, 2x HtH</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Olympians.cat
+++ b/Olympians.cat
@@ -166,7 +166,7 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8659-e294-65da-e09d" name="Swords" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8659-e294-65da-e09d" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="2">
                   <repeats>
@@ -175,23 +175,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="be48-a0a0-6c5f-0343" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c0f4-3f97-65d3-cc5c" name="Axes" hidden="false" collective="false" type="upgrade">
-              <modifiers>
-                <modifier type="increment" field="points" value="2">
-                  <repeats>
-                    <repeat field="selections" scope="4b29-f094-4487-eb77" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
-              <infoLinks>
-                <infoLink id="5fbe-89a9-e3d3-a138" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="be48-a0a0-6c5f-0343" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -290,7 +274,7 @@
         <categoryLink id="4a1e-a520-cd6f-58be" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b74c-acf1-4a00-5556" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="b74c-acf1-4a00-5556" name="Choose 3 to 5" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="270e-4926-b0f5-b917" name="Harpies with rocks" hidden="false" collective="false" type="model">
               <constraints>
@@ -492,9 +476,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a622-af94-8325-80bc" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="33ed-c421-9f5f-f233" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="33ed-c421-9f5f-f233" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="e493-4b3e-5ba9-9cf9" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="e493-4b3e-5ba9-9cf9" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -615,9 +599,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d91e-f996-8da0-b987" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4f3d-9073-4b13-19bf" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4f3d-9073-4b13-19bf" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="43bf-9db9-15ea-54bb" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="43bf-9db9-15ea-54bb" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -787,9 +771,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a96-6526-6c71-7032" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="748b-2939-ce06-3bc1" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="748b-2939-ce06-3bc1" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="cde8-28e8-c74d-820c" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="cde8-28e8-c74d-820c" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -833,7 +817,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="103c-0ec0-975d-2e07" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="e799-b5bc-fc15-9fb8" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="e799-b5bc-fc15-9fb8" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1">
                   <repeats>
@@ -842,7 +826,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="44f6-0acd-fb5d-7a12" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="44f6-0acd-fb5d-7a12" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1000,7 +984,7 @@
         <categoryLink id="5558-f90c-50b3-d2b9" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="bfce-2eff-07f1-f4cb" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="bfce-2eff-07f1-f4cb" name="Choose 4 to 9" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="8d17-7b4b-a35a-ae27" name="Hoplite Leader" hidden="false" collective="false" type="model">
               <constraints>
@@ -1065,7 +1049,7 @@
         <categoryLink id="4e81-9ace-813b-834c" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="eafe-4623-2744-586c" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="eafe-4623-2744-586c" name="Choose 4 to 9" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="c783-cd1a-2137-39dc" name="Hoplite Guard Leader" hidden="false" collective="false" type="model">
               <constraints>
@@ -1074,7 +1058,7 @@
               </constraints>
               <infoLinks>
                 <infoLink id="e9b8-9a1a-9c31-ae9a" name="Hoplite Guard Leader" hidden="false" targetId="bb67-1d20-93c2-8fb1" type="profile"/>
-                <infoLink id="cb17-dcb9-0f1d-6325" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+                <infoLink id="cb17-dcb9-0f1d-6325" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
@@ -1196,9 +1180,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faac-3934-a73a-9d85" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="136f-f183-588f-ccd9" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="136f-f183-588f-ccd9" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="4447-d3f5-97a0-ff05" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="4447-d3f5-97a0-ff05" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1486,9 +1470,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74fe-1bd3-4c1c-105f" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="271a-1d90-9c5c-ec32" name="Sword" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="271a-1d90-9c5c-ec32" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="cebc-c5fc-a205-0478" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="cebc-c5fc-a205-0478" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1542,7 +1526,7 @@
     </selectionEntry>
     <selectionEntry id="9944-6808-c090-b071" name="Greek Seer [57 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="f5d4-2073-01a6-9983" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+        <infoLink id="f5d4-2073-01a6-9983" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1098-544b-99e2-0a58" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
@@ -2057,9 +2041,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce17-cc8e-be91-e833" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="961a-954d-256f-8957" name="Swords" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="961a-954d-256f-8957" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="d31d-9e42-7364-10f9" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="d31d-9e42-7364-10f9" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2260,9 +2244,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd11-5c65-2697-401c" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="2ae1-cca1-0680-fc1f" name="Swords" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2ae1-cca1-0680-fc1f" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="996d-304b-abe6-9fee" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="996d-304b-abe6-9fee" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>

--- a/Olympians.cat
+++ b/Olympians.cat
@@ -17,9 +17,6 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4b29-f094-4487-eb77" name="Centaurs [108 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="6d56-3a8a-443b-e633" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5b20-0eb3-f58b-f834" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
@@ -48,7 +45,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1f6c-92bc-a542-b088" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -62,7 +59,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="44.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -70,7 +67,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fed1-4788-3778-d1c3" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -87,7 +84,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6d65-1bb4-924d-33ab" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -101,7 +98,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="46.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -109,7 +106,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc5f-1cad-533c-b3a5" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -126,7 +123,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="36.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e5dc-b593-096e-f370" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -140,7 +137,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="48.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -148,7 +145,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -165,7 +162,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8659-e294-65da-e09d" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -181,7 +178,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0f4-3f97-65d3-cc5c" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -197,7 +194,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ccf-43bb-e01b-8e9f" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -213,7 +210,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55b8-b817-7be1-bd04" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -229,7 +226,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -252,7 +249,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -268,7 +265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -276,13 +273,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8ea4-dd34-63f1-1949" name="Harpies [150 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="8333-5201-5ef4-5f8e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="4a1e-a520-cd6f-58be" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
@@ -302,7 +296,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -318,7 +312,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -341,7 +335,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -349,13 +343,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1cf2-13c4-d6c2-a87c" name="Amazon Cavalry [75 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="72d9-bd60-6bcc-e9cc" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -383,7 +374,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d2b1-3769-9188-ee98" name="Amazon Cavalry Leader" hidden="false" collective="false" type="model">
@@ -397,7 +388,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="33.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -405,7 +396,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f68-9b78-71d3-fe73" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -422,7 +413,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ce00-03e7-d2be-a4e5" name="Amazon Cavalry Leader" hidden="false" collective="false" type="model">
@@ -436,7 +427,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="35.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -444,7 +435,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -460,7 +451,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -483,7 +474,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -500,7 +491,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e0a7-eb58-36e3-3df4" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -509,7 +500,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -517,13 +508,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dddc-a18c-2b9c-5157" name="Amazon Archers [72 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="92f7-1bc1-3605-3c1e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -548,7 +536,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="37d2-67c2-4301-fe42" name="Amazon Archer Leader" hidden="false" collective="false" type="model">
@@ -562,7 +550,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -570,7 +558,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="edc1-772f-abcf-ff39" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -587,7 +575,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="08a0-19a2-2b4d-7bd2" name="Amazon Archer Leader" hidden="false" collective="false" type="model">
@@ -601,7 +589,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -609,7 +597,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -626,7 +614,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87b4-91df-44ff-c7d2" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -635,7 +623,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -651,7 +639,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -668,7 +656,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee7d-cc9b-1fb5-521e" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -684,7 +672,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -692,13 +680,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="405c-428f-c19e-d4b8" name="Amazon Warrior [77 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="4efa-2b8c-ee61-efcf" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -723,7 +708,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b2ca-1fb5-ac9b-55a3" name="Amazon Warrior Leader" hidden="false" collective="false" type="model">
@@ -737,7 +722,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -745,7 +730,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc31-9f8a-2ef9-ab1d" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -762,7 +747,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4331-be6f-a01b-5d23" name="Amazon Warrior Leader" hidden="false" collective="false" type="model">
@@ -776,7 +761,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -784,7 +769,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -801,7 +786,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c730-e02f-6b6b-def5" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -810,7 +795,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f58c-efbe-33e3-aa6a" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -819,7 +804,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -827,13 +812,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d1e5-7b9c-70d2-9356" name="Peltast [67 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="f96a-0da1-16cb-8807" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -857,13 +839,13 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dea1-c75f-4108-c061" name="Daggers" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -880,7 +862,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f7f-7277-0b9d-804c" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -896,7 +878,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c396-7a82-7391-93f8" name="Javelin" hidden="false" collective="false" type="upgrade">
@@ -905,7 +887,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -930,7 +912,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f3dd-d202-b517-9d76" name="Peltast Leader" hidden="false" collective="false" type="model">
@@ -944,7 +926,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -952,7 +934,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="28b6-05ee-3a6c-de1d" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -969,7 +951,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8e71-f7d7-47ef-be27" name="Peltast Leader" hidden="false" collective="false" type="model">
@@ -983,7 +965,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -991,7 +973,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -999,13 +981,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ca9d-82e1-bcde-c147" name="Hoplites [82 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="2ae1-694c-cae3-8bfb" name="Shieldwall" hidden="false" targetId="93f9-d132-d71b-ab39" type="rule"/>
         <infoLink id="ce89-2730-d206-62e7" name="Long Spears" hidden="false" targetId="8c77-0a0d-0097-c499" type="profile"/>
@@ -1027,7 +1006,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2137-fb2b-2d44-5821" name="Hoplite" hidden="false" collective="false" type="model">
@@ -1040,7 +1019,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1056,7 +1035,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1064,13 +1043,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0ff7-a68e-abb3-2793" name="Hoplite Guard [92 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="01c2-4a31-14bb-12f7" name="Shieldwall" hidden="false" targetId="93f9-d132-d71b-ab39" type="rule"/>
         <infoLink id="b441-a7c3-0271-9a78" name="Disciplined" hidden="false" targetId="0056-a41e-408e-1673" type="rule"/>
@@ -1092,7 +1068,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4802-8d10-9390-f7bd" name="Hoplite Guard" hidden="false" collective="false" type="model">
@@ -1105,7 +1081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1122,7 +1098,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3812-552b-cd66-1ac4" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1131,7 +1107,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1147,7 +1123,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1155,13 +1131,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d60c-560f-d373-3699" name="Greek Hero Charioteer [160 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e2a-0340-0c74-298d" type="max"/>
       </constraints>
@@ -1186,7 +1159,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd24-795a-5245-caa0" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1195,7 +1168,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53e8-5fbe-f804-2ca5" name="Long Spear" hidden="false" collective="false" type="upgrade">
@@ -1204,7 +1177,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1224,7 +1197,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1242,7 +1215,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="160.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c3b-17ee-f65b-61d8" name="Greek Crew" hidden="false" collective="false" type="upgrade">
@@ -1255,7 +1228,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1271,7 +1244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1288,7 +1261,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="029f-b0f4-dffa-2cdb" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1297,7 +1270,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1314,7 +1287,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e947-afcf-5c76-9739" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1323,7 +1296,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8165-59f6-47ef-77dd" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1332,7 +1305,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1348,7 +1321,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1364,7 +1337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1380,7 +1353,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="015e-62a6-4767-b1bc" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1389,7 +1362,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91d4-3d5e-5589-2c74" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1398,7 +1371,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7af5-a407-8410-d9f4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1407,7 +1380,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9433-9b02-3de8-0a9c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1416,7 +1389,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2693-7a93-cf46-3dd2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1425,7 +1398,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="452e-f376-7443-e70a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1434,7 +1407,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1442,13 +1415,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a4e6-d616-6bf5-4399" name="Greek Hero [85 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="7d43-8ea1-1e69-297e" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="77d4-95f9-b227-4ffb" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1467,7 +1437,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="85.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1484,7 +1454,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f4b2-0e1b-2414-f81e" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1493,7 +1463,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6bc1-f1d2-1cae-5fe0" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1502,7 +1472,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1519,7 +1489,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df86-aee5-fd04-7711" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1528,7 +1498,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1544,7 +1514,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1560,7 +1530,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1577,7 +1547,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d81-3619-85f7-39e3" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1586,7 +1556,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="be9f-4181-78b5-f67d" name="Long Spear" hidden="false" collective="false" type="upgrade">
@@ -1595,7 +1565,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9d56-33b2-5034-86b8" name="Magic Weapon" hidden="false" collective="false" type="upgrade">
@@ -1611,7 +1581,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="20cb-0cb3-281f-4a3f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1620,7 +1590,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5b87-a3c4-5532-a79b" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1629,7 +1599,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5b16-68c9-4178-3044" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1638,7 +1608,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1646,7 +1616,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1662,7 +1632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6586-968f-967c-db55" name="Ranged Magic Weapons" hidden="false" collective="false" type="upgrade">
@@ -1678,7 +1648,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="14cc-4860-dbe0-9d97" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1687,7 +1657,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="bc8f-2270-db7f-c3d2" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1696,7 +1666,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1704,7 +1674,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1712,13 +1682,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9944-6808-c090-b071" name="Greek Seer [57 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="f5d4-2073-01a6-9983" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
@@ -1740,7 +1707,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="57.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1764,7 +1731,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="10.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -1772,7 +1739,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2c94-48f3-1c28-c3a4" name="Nymphs" hidden="false" collective="false" type="unit">
@@ -1788,7 +1755,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="18.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -1796,7 +1763,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -1815,7 +1782,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fe1f-2ccb-1de9-69ce" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -1824,7 +1791,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f652-48eb-158d-9fb4" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -1833,7 +1800,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1849,7 +1816,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1866,7 +1833,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f1bb-ea8e-dc08-2316" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1875,7 +1842,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1892,7 +1859,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ef3a-f4be-bf0f-2e42" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1901,7 +1868,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d8d6-541b-2519-1eaa" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1910,7 +1877,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ee0-a4da-27da-d4ee" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1919,7 +1886,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf0e-31e9-9e83-8275" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1928,7 +1895,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10be-89e3-d278-3d00" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1937,7 +1904,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a559-7b6d-31ea-fbd1" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1946,7 +1913,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4fbc-c531-ebed-7517" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1955,7 +1922,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d7b9-a07d-114b-42b0" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1964,7 +1931,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8ace-64db-3ba2-beaa" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1973,7 +1940,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf86-4221-aa7d-f913" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1982,7 +1949,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d46-75cc-3c7b-01f2" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1991,7 +1958,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee5e-6fa8-a8b9-8385" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2000,7 +1967,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0eaa-1117-e30b-5225" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2009,7 +1976,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2025,7 +1992,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87e6-d673-2db2-d2dd" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2037,7 +2004,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="574d-699d-eb15-4460" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2049,7 +2016,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="218c-171a-3ec5-4bd5" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2061,7 +2028,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0dbb-1a6b-1de1-a241" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2073,7 +2040,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f5d4-6afe-2529-0f68" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2085,7 +2052,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0345-cfff-89bb-a7d9" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2097,7 +2064,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0544-ada4-b675-be92" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2109,7 +2076,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73e8-b412-ab50-f86c" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2121,7 +2088,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="925c-b3cb-0b5e-1cd8" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2133,7 +2100,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="772d-10ba-11b7-6b3d" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2145,7 +2112,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9f4-1ca2-ed5d-ea53" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2157,7 +2124,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eb80-c966-5cf6-760d" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2169,7 +2136,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f7df-dc43-ac87-3c31" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2181,7 +2148,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2197,7 +2164,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="867e-0330-18c2-14d2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2206,7 +2173,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd06-9456-6fed-6727" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2215,7 +2182,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b356-d987-f633-0729" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2224,7 +2191,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="504a-aca5-ddc1-55cb" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2233,7 +2200,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98ce-3cb0-1c26-22c4" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2242,7 +2209,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db70-0686-6ad7-54de" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2251,7 +2218,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2259,13 +2226,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a25e-e608-b473-48ab" name="Greek Lord (on foot) [108 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="9913-338f-39a1-d10d" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="2933-ff18-cd5c-a919" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -2285,7 +2249,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="76.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b9d-f87a-5da3-a7e1" name="Hoplite Bodyguard" hidden="false" collective="false" type="model">
@@ -2298,7 +2262,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2315,7 +2279,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="75b3-f044-42ad-23d9" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2324,7 +2288,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55d5-2ec9-d047-2767" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2333,7 +2297,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2349,7 +2313,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2365,7 +2329,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2382,7 +2346,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98df-555a-7a9b-89cb" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -2391,7 +2355,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2408,7 +2372,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebf0-6d1b-b097-bb73" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2417,7 +2381,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2433,7 +2397,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2449,7 +2413,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ec7d-4152-4ede-8027" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2458,7 +2422,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d94-dd96-0692-bc85" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2467,7 +2431,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10a7-7fd7-33d4-b458" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2476,7 +2440,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a756-aa39-cb3f-193c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2485,7 +2449,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3165-bee5-dd88-fc56" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2494,7 +2458,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac68-40d2-f38d-85f2" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2503,7 +2467,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2511,13 +2475,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="75b5-c473-3303-4a2b" name="Greek Lord in Chariot [160 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="bb2a-6035-55ad-ff42" name="Chariot with Greek Lord and Crew, pulled by two horses" hidden="false" targetId="2db3-9b45-d996-8813" type="profile"/>
         <infoLink id="0aae-3177-e9fb-2a12" name="Horse" hidden="false" targetId="1319-8d6e-7092-4ce8" type="profile"/>
@@ -2538,7 +2499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2555,7 +2516,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4548-811e-d803-1608" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2564,7 +2525,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7eeb-2813-a7ff-9d13" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2573,7 +2534,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2596,7 +2557,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2612,7 +2573,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2629,7 +2590,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="798f-9529-11d3-3844" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -2638,7 +2599,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2655,7 +2616,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="17e1-f91a-3e53-5239" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2664,7 +2625,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2683,7 +2644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="160.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d6b0-5018-894f-fa44" name="Greek Crew" hidden="false" collective="false" type="model">
@@ -2696,7 +2657,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2712,7 +2673,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ea77-e77c-046f-21e4" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2721,7 +2682,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad22-777d-1392-ab07" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2730,7 +2691,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c16-07b6-164f-ba4a" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2739,7 +2700,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58cc-80ac-cd62-e905" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2748,7 +2709,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2db2-b1f9-e255-56ae" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2757,7 +2718,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1993-b9d7-6983-818d" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2766,7 +2727,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2774,7 +2735,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Olympians.cat
+++ b/Olympians.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c443-9f03-53ab-b315" name="Olympians" revision="1" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c443-9f03-53ab-b315" name="Olympians" revision="2" battleScribeVersion="2.02" authorName="the3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="5603-81f3-5a9e-eea9" name="Centaurs" hidden="false" collective="false" targetId="4b29-f094-4487-eb77" type="selectionEntry"/>
     <entryLink id="2b37-6ff6-a421-0732" name="Harpies" hidden="false" collective="false" targetId="8ea4-dd34-63f1-1949" type="selectionEntry"/>
@@ -17,6 +17,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4b29-f094-4487-eb77" name="Centaurs [108 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="6d56-3a8a-443b-e633" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5b20-0eb3-f58b-f834" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
@@ -45,6 +48,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1f6c-92bc-a542-b088" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -58,6 +62,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="44.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -65,6 +70,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fed1-4788-3778-d1c3" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -81,6 +87,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6d65-1bb4-924d-33ab" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -94,6 +101,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="46.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -101,6 +109,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc5f-1cad-533c-b3a5" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -117,6 +126,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="36.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e5dc-b593-096e-f370" name="Centaur Champion" hidden="false" collective="false" type="model">
@@ -130,6 +140,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="48.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -137,6 +148,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -153,6 +165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8659-e294-65da-e09d" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -168,6 +181,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0f4-3f97-65d3-cc5c" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -183,6 +197,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ccf-43bb-e01b-8e9f" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -198,6 +213,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55b8-b817-7be1-bd04" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -213,6 +229,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -235,6 +252,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -250,6 +268,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -257,9 +276,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8ea4-dd34-63f1-1949" name="Harpies [150 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="8333-5201-5ef4-5f8e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="false"/>
         <categoryLink id="4a1e-a520-cd6f-58be" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
@@ -279,6 +302,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -294,6 +318,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -316,6 +341,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -323,9 +349,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1cf2-13c4-d6c2-a87c" name="Amazon Cavalry [75 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="72d9-bd60-6bcc-e9cc" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
       </infoLinks>
@@ -353,6 +383,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d2b1-3769-9188-ee98" name="Amazon Cavalry Leader" hidden="false" collective="false" type="model">
@@ -366,6 +397,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="33.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -373,6 +405,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f68-9b78-71d3-fe73" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -389,6 +422,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ce00-03e7-d2be-a4e5" name="Amazon Cavalry Leader" hidden="false" collective="false" type="model">
@@ -402,6 +436,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="35.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -409,6 +444,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -424,6 +460,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -446,6 +483,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -462,6 +500,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e0a7-eb58-36e3-3df4" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -470,6 +509,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -477,9 +517,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="dddc-a18c-2b9c-5157" name="Amazon Archers [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="92f7-1bc1-3605-3c1e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -504,6 +548,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="37d2-67c2-4301-fe42" name="Amazon Archer Leader" hidden="false" collective="false" type="model">
@@ -517,6 +562,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -524,6 +570,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="edc1-772f-abcf-ff39" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -540,6 +587,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="08a0-19a2-2b4d-7bd2" name="Amazon Archer Leader" hidden="false" collective="false" type="model">
@@ -553,6 +601,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -560,6 +609,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -576,6 +626,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87b4-91df-44ff-c7d2" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -584,6 +635,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -599,6 +651,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -615,6 +668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee7d-cc9b-1fb5-521e" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -630,6 +684,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -637,9 +692,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="405c-428f-c19e-d4b8" name="Amazon Warrior [77 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="4efa-2b8c-ee61-efcf" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -664,6 +723,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b2ca-1fb5-ac9b-55a3" name="Amazon Warrior Leader" hidden="false" collective="false" type="model">
@@ -677,6 +737,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -684,6 +745,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fc31-9f8a-2ef9-ab1d" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -700,6 +762,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4331-be6f-a01b-5d23" name="Amazon Warrior Leader" hidden="false" collective="false" type="model">
@@ -713,6 +776,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -720,6 +784,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -736,6 +801,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c730-e02f-6b6b-def5" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -744,6 +810,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f58c-efbe-33e3-aa6a" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -752,6 +819,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -759,9 +827,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d1e5-7b9c-70d2-9356" name="Peltast [67 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="f96a-0da1-16cb-8807" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -785,11 +857,13 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dea1-c75f-4108-c061" name="Daggers" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -806,6 +880,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f7f-7277-0b9d-804c" name="Slings" hidden="false" collective="false" type="upgrade">
@@ -821,6 +896,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c396-7a82-7391-93f8" name="Javelin" hidden="false" collective="false" type="upgrade">
@@ -829,6 +905,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -853,6 +930,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f3dd-d202-b517-9d76" name="Peltast Leader" hidden="false" collective="false" type="model">
@@ -866,6 +944,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -873,6 +952,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="28b6-05ee-3a6c-de1d" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -889,6 +969,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8e71-f7d7-47ef-be27" name="Peltast Leader" hidden="false" collective="false" type="model">
@@ -902,6 +983,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -909,6 +991,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -916,9 +999,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ca9d-82e1-bcde-c147" name="Hoplites [82 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2ae1-694c-cae3-8bfb" name="Shieldwall" hidden="false" targetId="93f9-d132-d71b-ab39" type="rule"/>
         <infoLink id="ce89-2730-d206-62e7" name="Long Spears" hidden="false" targetId="8c77-0a0d-0097-c499" type="profile"/>
@@ -940,6 +1027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2137-fb2b-2d44-5821" name="Hoplite" hidden="false" collective="false" type="model">
@@ -952,6 +1040,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -967,6 +1056,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -974,9 +1064,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0ff7-a68e-abb3-2793" name="Hopolite Guard [92 pts]" hidden="false" collective="false" type="unit">
+    <selectionEntry id="0ff7-a68e-abb3-2793" name="Hoplite Guard [92 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="01c2-4a31-14bb-12f7" name="Shieldwall" hidden="false" targetId="93f9-d132-d71b-ab39" type="rule"/>
         <infoLink id="b441-a7c3-0271-9a78" name="Disciplined" hidden="false" targetId="0056-a41e-408e-1673" type="rule"/>
@@ -998,6 +1092,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4802-8d10-9390-f7bd" name="Hoplite Guard" hidden="false" collective="false" type="model">
@@ -1010,6 +1105,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1026,6 +1122,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3812-552b-cd66-1ac4" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1034,6 +1131,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1049,6 +1147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1056,9 +1155,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d60c-560f-d373-3699" name="Greek Hero Charioteer [160 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e2a-0340-0c74-298d" type="max"/>
       </constraints>
@@ -1083,6 +1186,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd24-795a-5245-caa0" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1091,6 +1195,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53e8-5fbe-f804-2ca5" name="Long Spear" hidden="false" collective="false" type="upgrade">
@@ -1099,6 +1204,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1118,6 +1224,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1135,6 +1242,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="160.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c3b-17ee-f65b-61d8" name="Greek Crew" hidden="false" collective="false" type="upgrade">
@@ -1147,6 +1255,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1162,6 +1271,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1178,6 +1288,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="029f-b0f4-dffa-2cdb" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1186,6 +1297,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1202,6 +1314,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e947-afcf-5c76-9739" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1210,6 +1323,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8165-59f6-47ef-77dd" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1218,6 +1332,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1233,6 +1348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1248,6 +1364,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1263,6 +1380,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="015e-62a6-4767-b1bc" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1271,6 +1389,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91d4-3d5e-5589-2c74" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1279,6 +1398,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7af5-a407-8410-d9f4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1287,6 +1407,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9433-9b02-3de8-0a9c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1295,6 +1416,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2693-7a93-cf46-3dd2" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1303,6 +1425,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="452e-f376-7443-e70a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1311,6 +1434,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1318,9 +1442,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a4e6-d616-6bf5-4399" name="Greek Hero [85 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="7d43-8ea1-1e69-297e" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="77d4-95f9-b227-4ffb" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1339,6 +1467,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="85.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1355,6 +1484,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f4b2-0e1b-2414-f81e" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1363,6 +1493,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6bc1-f1d2-1cae-5fe0" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1371,6 +1502,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1387,6 +1519,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df86-aee5-fd04-7711" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1395,6 +1528,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1410,6 +1544,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1425,6 +1560,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1441,6 +1577,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d81-3619-85f7-39e3" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1449,6 +1586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="be9f-4181-78b5-f67d" name="Long Spear" hidden="false" collective="false" type="upgrade">
@@ -1457,6 +1595,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9d56-33b2-5034-86b8" name="Magic Weapon" hidden="false" collective="false" type="upgrade">
@@ -1472,6 +1611,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="20cb-0cb3-281f-4a3f" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1480,6 +1620,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5b87-a3c4-5532-a79b" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1488,6 +1629,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5b16-68c9-4178-3044" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1496,6 +1638,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1503,6 +1646,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1518,6 +1662,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6586-968f-967c-db55" name="Ranged Magic Weapons" hidden="false" collective="false" type="upgrade">
@@ -1533,6 +1678,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="14cc-4860-dbe0-9d97" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1541,6 +1687,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="bc8f-2270-db7f-c3d2" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1549,6 +1696,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1556,6 +1704,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1563,9 +1712,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9944-6808-c090-b071" name="Greek Seer [57 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="f5d4-2073-01a6-9983" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
@@ -1587,6 +1740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="57.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1610,6 +1764,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="10.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -1617,6 +1772,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2c94-48f3-1c28-c3a4" name="Nymphs" hidden="false" collective="false" type="unit">
@@ -1632,6 +1788,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="18.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -1639,6 +1796,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -1657,6 +1815,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fe1f-2ccb-1de9-69ce" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -1665,6 +1824,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f652-48eb-158d-9fb4" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -1673,6 +1833,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1688,6 +1849,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1704,6 +1866,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f1bb-ea8e-dc08-2316" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1712,6 +1875,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1728,6 +1892,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ef3a-f4be-bf0f-2e42" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1736,6 +1901,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d8d6-541b-2519-1eaa" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1744,6 +1910,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ee0-a4da-27da-d4ee" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1752,6 +1919,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf0e-31e9-9e83-8275" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1760,6 +1928,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10be-89e3-d278-3d00" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1768,6 +1937,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a559-7b6d-31ea-fbd1" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1776,6 +1946,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4fbc-c531-ebed-7517" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1784,6 +1955,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d7b9-a07d-114b-42b0" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1792,6 +1964,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8ace-64db-3ba2-beaa" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1800,6 +1973,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cf86-4221-aa7d-f913" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1808,6 +1982,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d46-75cc-3c7b-01f2" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1816,6 +1991,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee5e-6fa8-a8b9-8385" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1824,6 +2000,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0eaa-1117-e30b-5225" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1832,6 +2009,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1847,6 +2025,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87e6-d673-2db2-d2dd" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1858,6 +2037,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="574d-699d-eb15-4460" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1869,6 +2049,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="218c-171a-3ec5-4bd5" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1880,6 +2061,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0dbb-1a6b-1de1-a241" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1891,6 +2073,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f5d4-6afe-2529-0f68" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1902,6 +2085,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0345-cfff-89bb-a7d9" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1913,6 +2097,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0544-ada4-b675-be92" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1924,6 +2109,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73e8-b412-ab50-f86c" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1935,6 +2121,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="925c-b3cb-0b5e-1cd8" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1946,6 +2133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="772d-10ba-11b7-6b3d" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1957,6 +2145,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9f4-1ca2-ed5d-ea53" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1968,6 +2157,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eb80-c966-5cf6-760d" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1979,6 +2169,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f7df-dc43-ac87-3c31" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1990,6 +2181,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2005,6 +2197,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="867e-0330-18c2-14d2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2013,6 +2206,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd06-9456-6fed-6727" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2021,6 +2215,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b356-d987-f633-0729" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2029,6 +2224,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="504a-aca5-ddc1-55cb" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2037,6 +2233,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98ce-3cb0-1c26-22c4" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2045,6 +2242,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db70-0686-6ad7-54de" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2053,6 +2251,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2060,9 +2259,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a25e-e608-b473-48ab" name="Greek Lord (on foot) [108 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9913-338f-39a1-d10d" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="2933-ff18-cd5c-a919" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -2082,6 +2285,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="76.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b9d-f87a-5da3-a7e1" name="Hoplite Bodyguard" hidden="false" collective="false" type="model">
@@ -2094,6 +2298,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2110,6 +2315,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="75b3-f044-42ad-23d9" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2118,6 +2324,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="55d5-2ec9-d047-2767" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2126,6 +2333,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2141,6 +2349,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2156,6 +2365,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2172,6 +2382,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98df-555a-7a9b-89cb" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -2180,6 +2391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2196,6 +2408,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebf0-6d1b-b097-bb73" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2204,6 +2417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2219,6 +2433,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2234,6 +2449,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ec7d-4152-4ede-8027" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2242,6 +2458,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d94-dd96-0692-bc85" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2250,6 +2467,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10a7-7fd7-33d4-b458" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2258,6 +2476,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a756-aa39-cb3f-193c" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2266,6 +2485,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3165-bee5-dd88-fc56" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2274,6 +2494,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac68-40d2-f38d-85f2" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2282,6 +2503,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2289,9 +2511,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="75b5-c473-3303-4a2b" name="Greek Lord in Chariot [160 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="bb2a-6035-55ad-ff42" name="Chariot with Greek Lord and Crew, pulled by two horses" hidden="false" targetId="2db3-9b45-d996-8813" type="profile"/>
         <infoLink id="0aae-3177-e9fb-2a12" name="Horse" hidden="false" targetId="1319-8d6e-7092-4ce8" type="profile"/>
@@ -2312,6 +2538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2328,6 +2555,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4548-811e-d803-1608" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2336,6 +2564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7eeb-2813-a7ff-9d13" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2344,6 +2573,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2366,6 +2596,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2381,6 +2612,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2397,6 +2629,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="798f-9529-11d3-3844" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -2405,6 +2638,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2421,6 +2655,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="17e1-f91a-3e53-5239" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -2429,6 +2664,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2447,6 +2683,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="160.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d6b0-5018-894f-fa44" name="Greek Crew" hidden="false" collective="false" type="model">
@@ -2459,6 +2696,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2474,6 +2712,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ea77-e77c-046f-21e4" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2482,6 +2721,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ad22-777d-1392-ab07" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2490,6 +2730,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c16-07b6-164f-ba4a" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2498,6 +2739,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58cc-80ac-cd62-e905" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2506,6 +2748,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2db2-b1f9-e255-56ae" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2514,6 +2757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1993-b9d7-6983-818d" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2522,6 +2766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2529,6 +2774,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Olympians.cat
+++ b/Olympians.cat
@@ -191,7 +191,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="5fbe-89a9-e3d3-a138" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="5fbe-89a9-e3d3-a138" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>

--- a/Orcs.cat
+++ b/Orcs.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="048c-0297-6af4-d584" name="Orcs" revision="1" battleScribeVersion="2.02" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="048c-0297-6af4-d584" name="Orcs" revision="2" battleScribeVersion="2.02" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="8a3b-c7ba-275b-f90a" name="Orc Chieftain [95 pts]" hidden="false" collective="false" targetId="782e-229e-cefd-31f5" type="selectionEntry"/>
     <entryLink id="6c83-5f2b-a031-77cf" name="Orc Chieftain Boar Rider [136 pts]" hidden="false" collective="false" targetId="e332-00ba-1c22-d3dc" type="selectionEntry"/>
@@ -16,6 +16,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="782e-229e-cefd-31f5" name="Orc Chieftain [95 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="72c4-1d15-8e4a-a1a8" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="22ab-a8a5-88c4-69d2" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -45,6 +48,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="71.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="22cb-d2e0-78ba-b0a5" name="Orc Bodyguard in Light Armour" hidden="false" collective="false" type="model">
@@ -57,6 +61,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -64,6 +69,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c350-15e9-c8ad-55ac" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -80,6 +86,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="81.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fa3b-ed0b-f01f-da1a" name="Orc Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -92,6 +99,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -99,6 +107,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -115,6 +124,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce01-4393-ee92-5b1c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -123,6 +133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -139,6 +150,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f2e-8f11-9ab6-ba41" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -147,6 +159,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8be1-087b-5bf4-da64" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -155,6 +168,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -171,6 +185,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="65d0-c55a-45c5-b521" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -179,6 +194,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ffb-3b01-02df-8e97" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -187,6 +203,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bdac-1823-d46b-046d" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -195,6 +212,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db07-6a90-6377-33b7" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -210,6 +228,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8224-0d9e-ad75-d6c7" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -225,6 +244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -247,6 +267,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -269,6 +290,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -284,6 +306,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af9f-b698-93b0-617d" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -292,6 +315,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a015-e212-8d4e-5cc7" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -300,6 +324,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ff7-52f7-3285-cb57" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -308,6 +333,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="afee-7c20-bf72-b379" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -316,6 +342,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="01cc-4d7b-dada-85c1" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -324,6 +351,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="40ce-66d1-cf0b-72b5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -332,6 +360,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -339,9 +368,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e332-00ba-1c22-d3dc" name="Orc Chieftain Boar Rider [136 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="7135-41db-ccb4-8cf1" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="3b39-9ecb-7965-8e20" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -373,6 +406,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="86.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d3a2-dbbd-6302-1699" name="Orc Bodyguard in Light Armour" hidden="false" collective="false" type="model">
@@ -385,6 +419,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -392,6 +427,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c7e9-36af-775c-227b" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -408,6 +444,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="96.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fe68-c865-4d3e-4e86" name="Orc Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -420,6 +457,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -427,6 +465,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -443,6 +482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2b16-780a-da64-0220" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -451,6 +491,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -467,6 +508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9727-7111-4415-a13f" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -475,6 +517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c87-803d-c81f-2694" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -483,6 +526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -499,6 +543,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1232-1b53-c2b6-57f2" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -507,6 +552,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a96b-c9db-a090-8c24" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -515,6 +561,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f47-e87f-b915-fd72" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -523,6 +570,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e49d-73c2-890b-e156" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -538,6 +586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e009-f8df-7e28-108c" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -553,6 +602,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -575,6 +625,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -590,6 +641,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8662-f304-1eda-5b73" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -598,6 +650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bbc1-3e69-6f77-0f1e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -606,6 +659,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="28f0-2e30-9282-7204" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -614,6 +668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e6a3-2ce8-277e-83d0" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -622,6 +677,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="59e5-71ec-e493-c9dc" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -630,6 +686,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1cc5-9098-5821-51ab" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -638,6 +695,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -645,9 +703,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8507-c9fb-4724-e2b5" name="Orc Shaman [57 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64bb-c692-2a23-a111" type="max"/>
       </constraints>
@@ -671,6 +733,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="57.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -686,6 +749,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -702,6 +766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a6b8-4549-e050-eac3" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -710,6 +775,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3e13-a469-4ff8-c0ef" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -718,6 +784,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -734,6 +801,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5e0a-b73d-5608-1121" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -742,6 +810,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="871f-7b0a-926b-2a3a" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -750,6 +819,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ebe-7e78-78f8-64f1" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -758,6 +828,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -774,6 +845,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3714-2a9e-7cfe-9237" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -782,6 +854,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -804,6 +877,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -819,6 +893,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bb1b-60aa-77af-6ba8" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -830,6 +905,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="35de-ccec-aa7c-571e" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -841,6 +917,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f4e-9379-01b9-8012" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -852,6 +929,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="25fc-5262-b57b-504c" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -863,6 +941,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd22-fb0d-2f2b-d47d" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -874,6 +953,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a719-0c26-eb2a-a1a8" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -885,6 +965,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b2b-1791-fff2-2a7f" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -896,6 +977,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="558c-aa93-02d5-71cd" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -907,6 +989,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="86e1-f96b-ac75-0901" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -918,6 +1001,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d80-f96f-3e3a-37e8" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -929,6 +1013,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f3fe-4da9-f6c8-f78b" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -940,6 +1025,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="38de-402c-219a-a530" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -951,6 +1037,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="185a-1e6e-8e33-6727" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -962,6 +1049,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -978,6 +1066,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4cb0-76d8-380f-d4a3" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -986,6 +1075,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffae-f734-831b-bdfd" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -994,6 +1084,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36ba-0094-fd70-ac0e" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1002,6 +1093,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="234b-af38-71cc-6ec4" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1010,6 +1102,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6b9b-0ed1-1097-f045" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1018,6 +1111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="763a-5285-de0a-8c9e" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1026,6 +1120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f842-2cac-9fc1-2772" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1034,6 +1129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95d7-a0fd-6dc3-2084" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1042,6 +1138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e8e6-7b3a-c94e-c93f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1050,6 +1147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e64-0bb0-61cf-6681" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1058,6 +1156,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee66-ea01-7ede-1b58" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1066,6 +1165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cfd7-4611-5c3b-527d" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1074,6 +1174,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6cba-be22-a307-5db2" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1082,6 +1183,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1097,6 +1199,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a019-fe19-0cda-8997" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1105,6 +1208,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3a7c-c0d6-079d-8817" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1113,6 +1217,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eebc-69f8-0ab0-fc6e" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1121,6 +1226,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db73-f0d4-671f-801b" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1129,6 +1235,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5b05-0230-8877-91bb" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1137,6 +1244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b132-9671-d791-32e5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1145,6 +1253,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1152,9 +1261,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8c52-ad3f-0992-e671" name="Orc Champion [75 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="fef6-9812-1714-e337" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
       </infoLinks>
@@ -1174,6 +1287,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="75.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="68b3-5fa5-8c3d-b213" name="Orc Champion in Medium Armour" hidden="false" collective="false" type="model">
@@ -1182,6 +1296,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="85.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1198,6 +1313,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f1fa-5d20-cc10-8388" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1206,6 +1322,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f32-937c-9a36-1b66" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1214,6 +1331,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96bf-e41f-1571-3914" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1222,6 +1340,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c74-d39f-d468-79a2" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -1230,6 +1349,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eeb3-30f3-1118-a4cd" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1238,6 +1358,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1253,6 +1374,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1269,6 +1391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f35-73d6-7425-97cf" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1277,6 +1400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1293,6 +1417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c4cc-b00f-db38-a08b" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1301,6 +1426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="71ac-bc83-2f82-7242" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1309,6 +1435,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1324,6 +1451,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1340,11 +1468,13 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b105-3767-8397-70af" name="Ferocious Charge" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1360,6 +1490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b9a7-5334-e57f-fb70" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1368,6 +1499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c06d-b05d-4c19-4d80" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1376,6 +1508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ba2e-6620-1079-e32b" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1384,6 +1517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2d80-7247-4690-206a" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1392,6 +1526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4f3e-acf8-9ceb-302b" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1400,6 +1535,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2ed7-c97a-254a-1bae" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1408,6 +1544,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1415,9 +1552,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ce3-888a-1952-2f6d" name="Orc Warriors [70 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="a936-7b02-7e17-ffac" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1440,6 +1581,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1456,6 +1598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8aa4-c2ce-3652-ed25" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1464,6 +1607,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="46ae-166e-ee54-0523" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1479,6 +1623,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1496,6 +1641,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="22.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f093-e625-e8c5-88e7" name="Orc Warrior" hidden="false" collective="false" type="model">
@@ -1508,6 +1654,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1515,9 +1662,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="776f-bb6e-cb3e-3f0d" name="Orc Archers [70 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="6bee-e46f-7111-ba2c" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
@@ -1537,6 +1688,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="300a-d660-da96-fa35" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -1552,6 +1704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1577,6 +1730,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e079-23a6-3b93-5149" name="Orc Archers" hidden="false" collective="false" type="model">
@@ -1589,6 +1743,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1596,6 +1751,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="688f-00f4-af7f-64f4" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1613,6 +1769,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1574-9d4a-84bc-576a" name="Orc Archers in Light Armour" hidden="false" collective="false" type="model">
@@ -1625,6 +1782,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1632,6 +1790,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1654,6 +1813,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1661,9 +1821,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="617f-5069-cbec-cae2" name="Trolls [105 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="07d2-3a27-f61a-dd55" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5dab-bfc8-0154-afb5" name="Regenerate" hidden="false" targetId="0a0c-ed4c-9647-4398" type="rule"/>
@@ -1685,6 +1849,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1692,9 +1857,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cecf-a6e9-be27-a87a" name="Orc Guard [70 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="3b6a-cb8e-2401-f837" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1717,6 +1886,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1733,6 +1903,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8fd3-5df9-dc6c-5595" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1748,6 +1919,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1509-0615-1264-194b" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1756,6 +1928,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a2b4-9aad-7d80-33b6" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1764,6 +1937,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b67d-f6c9-ad8d-c689" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1772,6 +1946,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1797,6 +1972,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5ce9-04d5-4601-b1d8" name="Orc Guard in Light Armour" hidden="false" collective="false" type="model">
@@ -1809,6 +1985,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1816,6 +1993,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4973-5f15-bbfd-cff6" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1833,6 +2011,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2f50-2e85-7c16-62ca" name="Orc Guard in Medium Armour" hidden="false" collective="false" type="model">
@@ -1845,6 +2024,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1852,6 +2032,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1859,9 +2040,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9e88-a067-9011-aaec" name="Orc Boar Riders [85 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="9da8-ecfe-e655-c06b" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
         <infoLink id="d7d4-c5d7-31a6-9b80" name="Ferocious Charge" hidden="false" targetId="7ef8-77c6-28f8-c3e3" type="rule"/>
@@ -1883,6 +2068,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eca3-44f9-40d3-8f7c" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1891,6 +2077,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c7d6-9071-bac5-02a6" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1899,6 +2086,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1923,6 +2111,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="35.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="359d-8fb4-9855-0812" name="Orc Boar Rider in Light Armour" hidden="false" collective="false" type="model">
@@ -1935,6 +2124,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1942,6 +2132,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36e1-1c18-bf8b-8422" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1958,6 +2149,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="37.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8590-8aea-5f04-8508" name="Orc Boar Rider in Medium Armour" hidden="false" collective="false" type="model">
@@ -1970,6 +2162,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1977,6 +2170,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1984,9 +2178,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8409-5df8-64c6-07ee" name="Orc Boar Chariot [101 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="00e1-5920-a31f-3350" name="Boars" hidden="false" targetId="20f8-c95a-aeb0-4345" type="profile"/>
       </infoLinks>
@@ -2006,6 +2204,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="399b-ce13-7300-0217" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2014,6 +2213,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="122a-8a4e-f9e5-28a4" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2022,6 +2222,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2044,6 +2245,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2059,6 +2261,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2075,6 +2278,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2094,6 +2298,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="91.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2101,9 +2306,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3e4b-e953-ca97-44e9" name="Orc Stone Thrower [84 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5516-869c-892b-9c00" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2130,6 +2339,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2137,6 +2347,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="695b-6764-9cc9-7f88" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2155,6 +2366,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2162,6 +2374,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2178,6 +2391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53f6-0980-fa25-499e" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -2186,6 +2400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2202,6 +2417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ede-54a6-021e-8a4d" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2210,6 +2426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2217,9 +2434,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f424-904a-5733-500a" name="Orc Bolt Thrower [60 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9e53-2bf0-052e-5430" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2246,6 +2467,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2253,6 +2475,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d8e-cd2c-cb87-c973" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2271,6 +2494,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2278,6 +2502,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2294,6 +2519,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e204-5103-00e0-299e" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2302,6 +2528,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="51.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2318,6 +2545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="52a4-d766-b9d5-86ee" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2326,6 +2554,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2333,6 +2562,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Orcs.cat
+++ b/Orcs.cat
@@ -185,9 +185,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="65d0-c55a-45c5-b521" name="Axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="65d0-c55a-45c5-b521" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="f081-6f49-2a72-34e4" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="f081-6f49-2a72-34e4" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -473,9 +473,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1232-1b53-c2b6-57f2" name="Axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1232-1b53-c2b6-57f2" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="04c6-3103-8d52-d702" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="04c6-3103-8d52-d702" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -659,9 +659,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5e0a-b73d-5608-1121" name="Axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="5e0a-b73d-5608-1121" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="3e5c-2b06-6cc7-ea6c" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="3e5c-2b06-6cc7-ea6c" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1105,9 +1105,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="f1fa-5d20-cc10-8388" name="Axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="f1fa-5d20-cc10-8388" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="d436-8917-8c5d-34c6" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="d436-8917-8c5d-34c6" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1635,9 +1635,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1509-0615-1264-194b" name="Axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="1509-0615-1264-194b" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="2bce-18a9-4351-27c9" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="2bce-18a9-4351-27c9" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1790,9 +1790,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c7d6-9071-bac5-02a6" name="Axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c7d6-9071-bac5-02a6" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="73b7-d870-9df3-c1dc" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="73b7-d870-9df3-c1dc" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1949,9 +1949,9 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="122a-8a4e-f9e5-28a4" name="Axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="122a-8a4e-f9e5-28a4" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="ffc2-4530-705e-f621" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="ffc2-4530-705e-f621" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2127,9 +2127,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7248-30e2-0a04-189b" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="c001-9fa9-b678-f8a8" name="Axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="c001-9fa9-b678-f8a8" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="d7a4-8e0b-24f8-e495" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="d7a4-8e0b-24f8-e495" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2254,9 +2254,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af20-8955-3647-156b" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="b1a9-52ed-a4bb-ad2e" name="Axe" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b1a9-52ed-a4bb-ad2e" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="5634-cf44-817f-2648" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+                <infoLink id="5634-cf44-817f-2648" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>

--- a/Orcs.cat
+++ b/Orcs.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="048c-0297-6af4-d584" name="Orcs" revision="2" battleScribeVersion="2.02" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="048c-0297-6af4-d584" name="Orcs" revision="3" battleScribeVersion="2.02" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="8a3b-c7ba-275b-f90a" name="Orc Chieftain [95 pts]" hidden="false" collective="false" targetId="782e-229e-cefd-31f5" type="selectionEntry"/>
     <entryLink id="6c83-5f2b-a031-77cf" name="Orc Chieftain Boar Rider [136 pts]" hidden="false" collective="false" targetId="e332-00ba-1c22-d3dc" type="selectionEntry"/>
@@ -16,9 +16,6 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="782e-229e-cefd-31f5" name="Orc Chieftain [95 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="72c4-1d15-8e4a-a1a8" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="22ab-a8a5-88c4-69d2" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -48,7 +45,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="71.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="22cb-d2e0-78ba-b0a5" name="Orc Bodyguard in Light Armour" hidden="false" collective="false" type="model">
@@ -61,7 +58,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -69,7 +66,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c350-15e9-c8ad-55ac" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -86,7 +83,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="81.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fa3b-ed0b-f01f-da1a" name="Orc Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -99,7 +96,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -107,7 +104,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -124,7 +121,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce01-4393-ee92-5b1c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -133,7 +130,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -150,7 +147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f2e-8f11-9ab6-ba41" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -159,7 +156,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8be1-087b-5bf4-da64" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -168,7 +165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -185,7 +182,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="65d0-c55a-45c5-b521" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -194,7 +191,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ffb-3b01-02df-8e97" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -203,7 +200,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bdac-1823-d46b-046d" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -212,7 +209,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db07-6a90-6377-33b7" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -228,7 +225,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8224-0d9e-ad75-d6c7" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -244,7 +241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -267,7 +264,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -290,7 +287,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -306,7 +303,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="af9f-b698-93b0-617d" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -315,7 +312,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a015-e212-8d4e-5cc7" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -324,7 +321,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ff7-52f7-3285-cb57" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -333,7 +330,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="afee-7c20-bf72-b379" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -342,7 +339,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="01cc-4d7b-dada-85c1" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -351,7 +348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="40ce-66d1-cf0b-72b5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -360,7 +357,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -368,13 +365,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e332-00ba-1c22-d3dc" name="Orc Chieftain Boar Rider [136 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="7135-41db-ccb4-8cf1" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="3b39-9ecb-7965-8e20" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
@@ -406,7 +400,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="86.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d3a2-dbbd-6302-1699" name="Orc Bodyguard in Light Armour" hidden="false" collective="false" type="model">
@@ -419,7 +413,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -427,7 +421,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c7e9-36af-775c-227b" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -444,7 +438,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="96.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fe68-c865-4d3e-4e86" name="Orc Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -457,7 +451,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -465,7 +459,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -482,7 +476,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2b16-780a-da64-0220" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -491,7 +485,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -508,7 +502,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9727-7111-4415-a13f" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -517,7 +511,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c87-803d-c81f-2694" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -526,7 +520,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -543,7 +537,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1232-1b53-c2b6-57f2" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -552,7 +546,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a96b-c9db-a090-8c24" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -561,7 +555,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f47-e87f-b915-fd72" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -570,7 +564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e49d-73c2-890b-e156" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -586,7 +580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e009-f8df-7e28-108c" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -602,7 +596,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -625,7 +619,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -641,7 +635,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8662-f304-1eda-5b73" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -650,7 +644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bbc1-3e69-6f77-0f1e" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -659,7 +653,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="28f0-2e30-9282-7204" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -668,7 +662,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e6a3-2ce8-277e-83d0" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -677,7 +671,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="59e5-71ec-e493-c9dc" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -686,7 +680,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1cc5-9098-5821-51ab" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -695,7 +689,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -703,18 +697,15 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8507-c9fb-4724-e2b5" name="Orc Shaman [57 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64bb-c692-2a23-a111" type="max"/>
       </constraints>
       <infoLinks>
-        <infoLink id="305b-1581-722d-0c32" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+        <infoLink id="305b-1581-722d-0c32" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="7bf6-bb56-e738-5bca" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
@@ -733,7 +724,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="57.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -749,7 +740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -766,7 +757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a6b8-4549-e050-eac3" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -775,7 +766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3e13-a469-4ff8-c0ef" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -784,7 +775,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -801,7 +792,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5e0a-b73d-5608-1121" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -810,7 +801,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="871f-7b0a-926b-2a3a" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -819,7 +810,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ebe-7e78-78f8-64f1" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -828,7 +819,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -845,7 +836,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3714-2a9e-7cfe-9237" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -854,7 +845,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -877,7 +868,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -893,7 +884,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bb1b-60aa-77af-6ba8" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -905,7 +896,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="35de-ccec-aa7c-571e" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -917,7 +908,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f4e-9379-01b9-8012" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -929,7 +920,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="25fc-5262-b57b-504c" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -941,7 +932,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd22-fb0d-2f2b-d47d" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -953,7 +944,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a719-0c26-eb2a-a1a8" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -965,7 +956,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b2b-1791-fff2-2a7f" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -977,7 +968,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="558c-aa93-02d5-71cd" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -989,7 +980,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="86e1-f96b-ac75-0901" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1001,7 +992,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d80-f96f-3e3a-37e8" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1013,7 +1004,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f3fe-4da9-f6c8-f78b" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1025,7 +1016,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="38de-402c-219a-a530" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1037,7 +1028,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="185a-1e6e-8e33-6727" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1049,7 +1040,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1066,7 +1057,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4cb0-76d8-380f-d4a3" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1075,7 +1066,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffae-f734-831b-bdfd" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1084,7 +1075,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36ba-0094-fd70-ac0e" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1093,7 +1084,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="234b-af38-71cc-6ec4" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1102,7 +1093,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6b9b-0ed1-1097-f045" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1111,7 +1102,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="763a-5285-de0a-8c9e" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1120,7 +1111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f842-2cac-9fc1-2772" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1129,7 +1120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95d7-a0fd-6dc3-2084" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1138,7 +1129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e8e6-7b3a-c94e-c93f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1147,7 +1138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e64-0bb0-61cf-6681" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1156,7 +1147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee66-ea01-7ede-1b58" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1165,7 +1156,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cfd7-4611-5c3b-527d" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1174,7 +1165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6cba-be22-a307-5db2" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1183,7 +1174,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1199,7 +1190,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a019-fe19-0cda-8997" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1208,7 +1199,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3a7c-c0d6-079d-8817" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1217,7 +1208,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eebc-69f8-0ab0-fc6e" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1226,7 +1217,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db73-f0d4-671f-801b" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1235,7 +1226,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5b05-0230-8877-91bb" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1244,7 +1235,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b132-9671-d791-32e5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1253,7 +1244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1261,13 +1252,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8c52-ad3f-0992-e671" name="Orc Champion [75 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="fef6-9812-1714-e337" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
       </infoLinks>
@@ -1287,7 +1275,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="75.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="68b3-5fa5-8c3d-b213" name="Orc Champion in Medium Armour" hidden="false" collective="false" type="model">
@@ -1296,7 +1284,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="85.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1313,7 +1301,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f1fa-5d20-cc10-8388" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1322,7 +1310,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f32-937c-9a36-1b66" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1331,7 +1319,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96bf-e41f-1571-3914" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1340,7 +1328,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c74-d39f-d468-79a2" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -1349,7 +1337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eeb3-30f3-1118-a4cd" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1358,7 +1346,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1374,7 +1362,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1391,7 +1379,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f35-73d6-7425-97cf" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1400,7 +1388,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1417,7 +1405,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c4cc-b00f-db38-a08b" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1426,7 +1414,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="71ac-bc83-2f82-7242" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1435,7 +1423,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1451,7 +1439,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1468,13 +1456,13 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b105-3767-8397-70af" name="Ferocious Charge" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1490,7 +1478,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b9a7-5334-e57f-fb70" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1499,7 +1487,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c06d-b05d-4c19-4d80" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1508,7 +1496,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ba2e-6620-1079-e32b" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1517,7 +1505,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2d80-7247-4690-206a" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1526,7 +1514,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4f3e-acf8-9ceb-302b" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1535,7 +1523,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2ed7-c97a-254a-1bae" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1544,7 +1532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1552,13 +1540,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ce3-888a-1952-2f6d" name="Orc Warriors [70 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="a936-7b02-7e17-ffac" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1581,7 +1566,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1598,7 +1583,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8aa4-c2ce-3652-ed25" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1607,7 +1592,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="46ae-166e-ee54-0523" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1623,7 +1608,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1641,7 +1626,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="22.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f093-e625-e8c5-88e7" name="Orc Warrior" hidden="false" collective="false" type="model">
@@ -1654,7 +1639,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1662,13 +1647,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="776f-bb6e-cb3e-3f0d" name="Orc Archers [70 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="6bee-e46f-7111-ba2c" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
@@ -1688,7 +1670,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="300a-d660-da96-fa35" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -1704,7 +1686,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1730,7 +1712,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e079-23a6-3b93-5149" name="Orc Archers" hidden="false" collective="false" type="model">
@@ -1743,7 +1725,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1751,7 +1733,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="688f-00f4-af7f-64f4" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1769,7 +1751,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1574-9d4a-84bc-576a" name="Orc Archers in Light Armour" hidden="false" collective="false" type="model">
@@ -1782,7 +1764,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1790,7 +1772,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1813,7 +1795,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1821,13 +1803,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="617f-5069-cbec-cae2" name="Trolls [105 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="07d2-3a27-f61a-dd55" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="5dab-bfc8-0154-afb5" name="Regenerate" hidden="false" targetId="0a0c-ed4c-9647-4398" type="rule"/>
@@ -1849,7 +1828,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1857,13 +1836,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cecf-a6e9-be27-a87a" name="Orc Guard [70 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="3b6a-cb8e-2401-f837" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1886,7 +1862,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1903,7 +1879,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8fd3-5df9-dc6c-5595" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1919,7 +1895,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1509-0615-1264-194b" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1928,7 +1904,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a2b4-9aad-7d80-33b6" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1937,7 +1913,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b67d-f6c9-ad8d-c689" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1946,7 +1922,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1972,7 +1948,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5ce9-04d5-4601-b1d8" name="Orc Guard in Light Armour" hidden="false" collective="false" type="model">
@@ -1985,7 +1961,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1993,7 +1969,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4973-5f15-bbfd-cff6" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2011,7 +1987,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2f50-2e85-7c16-62ca" name="Orc Guard in Medium Armour" hidden="false" collective="false" type="model">
@@ -2024,7 +2000,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2032,7 +2008,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2040,17 +2016,14 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9e88-a067-9011-aaec" name="Orc Boar Riders [85 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="9da8-ecfe-e655-c06b" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
         <infoLink id="d7d4-c5d7-31a6-9b80" name="Ferocious Charge" hidden="false" targetId="7ef8-77c6-28f8-c3e3" type="rule"/>
-        <infoLink id="9318-dfbc-1d83-3cf0" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="9318-dfbc-1d83-3cf0" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="2841-fec9-1940-7589" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
@@ -2068,7 +2041,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eca3-44f9-40d3-8f7c" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2077,7 +2050,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c7d6-9071-bac5-02a6" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2086,7 +2059,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2111,7 +2084,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="35.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="359d-8fb4-9855-0812" name="Orc Boar Rider in Light Armour" hidden="false" collective="false" type="model">
@@ -2124,7 +2097,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2132,7 +2105,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36e1-1c18-bf8b-8422" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2149,7 +2122,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="37.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8590-8aea-5f04-8508" name="Orc Boar Rider in Medium Armour" hidden="false" collective="false" type="model">
@@ -2162,7 +2135,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2170,7 +2143,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2178,13 +2151,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8409-5df8-64c6-07ee" name="Orc Boar Chariot [101 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="00e1-5920-a31f-3350" name="Boars" hidden="false" targetId="20f8-c95a-aeb0-4345" type="profile"/>
       </infoLinks>
@@ -2204,7 +2174,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="399b-ce13-7300-0217" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2213,7 +2183,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="122a-8a4e-f9e5-28a4" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2222,7 +2192,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2245,7 +2215,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2261,7 +2231,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2278,7 +2248,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2298,7 +2268,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="91.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2306,13 +2276,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3e4b-e953-ca97-44e9" name="Orc Stone Thrower [84 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="5516-869c-892b-9c00" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2339,7 +2306,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2347,7 +2314,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="695b-6764-9cc9-7f88" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2366,7 +2333,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2374,7 +2341,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2391,7 +2358,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53f6-0980-fa25-499e" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -2400,7 +2367,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2417,7 +2384,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ede-54a6-021e-8a4d" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2426,7 +2393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2434,13 +2401,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f424-904a-5733-500a" name="Orc Bolt Thrower [60 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="9e53-2bf0-052e-5430" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -2467,7 +2431,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2475,7 +2439,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d8e-cd2c-cb87-c973" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2494,7 +2458,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2502,7 +2466,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2519,7 +2483,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e204-5103-00e0-299e" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -2528,7 +2492,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="51.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2545,7 +2509,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="52a4-d766-b9d5-86ee" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2554,7 +2518,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2562,7 +2526,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Orcs.cat
+++ b/Orcs.cat
@@ -1311,7 +1311,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5c9-ed12-562f-801b" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="2f27-50dc-0ad8-32db" name="Swords" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2f27-50dc-0ad8-32db" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="301f-3671-a754-7c61" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
@@ -1610,7 +1610,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a791-9ba6-791e-389c" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8172-f549-ae1a-adc3" name="Swords" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8172-f549-ae1a-adc3" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="bcc7-bbd0-daaa-e7a3" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
@@ -1772,7 +1772,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7336-356a-cbbe-ad3b" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8358-fe8e-b3ed-727d" name="Swords" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8358-fe8e-b3ed-727d" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="d2d9-d5e4-e302-4be5" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
@@ -1931,7 +1931,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e7c-7d73-18f0-12a1" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="28a6-f165-16e0-f008" name="Swords" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="28a6-f165-16e0-f008" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="664a-f18e-9cbb-6bc5" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>

--- a/Orcs.cat
+++ b/Orcs.cat
@@ -170,21 +170,12 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c4f5-6c79-46ee-5514" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="ccb5-bd1d-dab4-6cf1">
+        <selectionEntryGroup id="c4f5-6c79-46ee-5514" name="Weapons" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d7a-03c1-e772-2bf5" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18db-790d-0393-8d9f" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ccb5-bd1d-dab4-6cf1" name="Sword" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e991-550b-e7f2-b360" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="65d0-c55a-45c5-b521" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="f081-6f49-2a72-34e4" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
@@ -458,21 +449,12 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f3d7-4575-06ae-e6de" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="1fd9-348b-c3e0-1404">
+        <selectionEntryGroup id="f3d7-4575-06ae-e6de" name="Weapons" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eded-b247-54a7-ae97" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd76-660a-7d11-a7d2" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="1fd9-348b-c3e0-1404" name="Sword" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8ec1-5972-9404-2adf" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="1232-1b53-c2b6-57f2" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="04c6-3103-8d52-d702" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
@@ -644,21 +626,12 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="dfb1-f938-5d48-b322" name="Bodyguard Weapons" hidden="false" collective="false" defaultSelectionEntryId="8b4b-434c-4bb7-0f8f">
+        <selectionEntryGroup id="dfb1-f938-5d48-b322" name="Bodyguard Weapons" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0ca-7b36-48d5-2ae3" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0109-5a01-a412-9b19" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8b4b-434c-4bb7-0f8f" name="Sword" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d1f7-f6a6-488f-cd49" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="5e0a-b73d-5608-1121" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="3e5c-2b06-6cc7-ea6c" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
@@ -1090,21 +1063,12 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4378-53a7-1e55-4c56" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="2a09-db8e-d297-77a4">
+        <selectionEntryGroup id="4378-53a7-1e55-4c56" name="Weapons" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfee-e549-0625-9dc6" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0054-3b10-787b-6549" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="2a09-db8e-d297-77a4" name="Sword" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7920-3c3d-9809-f9ec" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="f1fa-5d20-cc10-8388" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="d436-8917-8c5d-34c6" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
@@ -1386,7 +1350,7 @@
     </selectionEntry>
     <selectionEntry id="776f-bb6e-cb3e-3f0d" name="Orc Archers [70 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="6bee-e46f-7111-ba2c" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+        <infoLink id="6bee-e46f-7111-ba2c" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="34e7-e2a1-7020-4a7f" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
@@ -1635,15 +1599,6 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="1509-0615-1264-194b" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="2bce-18a9-4351-27c9" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="a2b4-9aad-7d80-33b6" name="Huge Swords" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="f767-8e26-9787-9f63" name="Huge Sword" hidden="false" targetId="41c3-e1df-53b7-ed79" type="profile"/>
@@ -1790,15 +1745,6 @@
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="c7d6-9071-bac5-02a6" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="73b7-d870-9df3-c1dc" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
         <selectionEntryGroup id="2712-a517-a1ee-031d" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="e3ed-db9d-d9ff-2a0a">
@@ -1922,10 +1868,14 @@
           <infoLinks>
             <infoLink id="142d-0fad-40b7-bb5b" name="Boars" hidden="false" targetId="20f8-c95a-aeb0-4345" type="profile"/>
           </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b53a-337a-e24a-1c8b" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="122a-8a4e-f9e5-28a4">
+        <selectionEntryGroup id="b53a-337a-e24a-1c8b" name="HtH Weapons" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15a3-377c-af25-fa87" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e7c-7d73-18f0-12a1" type="min"/>
@@ -1943,15 +1893,6 @@
             <selectionEntry id="399b-ce13-7300-0217" name="Spears" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="47f1-afaa-0b94-0fd9" name="Spear" hidden="false" targetId="c79a-48d1-9b48-2c68" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="122a-8a4e-f9e5-28a4" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ffc2-4530-705e-f621" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2028,6 +1969,7 @@
         <infoLink id="9286-a953-47b6-bde3" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="6eff-0ec0-2940-632c" name="Overhead" hidden="false" targetId="7751-622a-b896-4874" type="rule"/>
         <infoLink id="3b95-e677-3dbc-d789" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+        <infoLink id="b841-f14e-ec12-ae26" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5516-869c-892b-9c00" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
@@ -2116,32 +2058,6 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="1527-e280-295f-d961" name="Crew HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="4ede-54a6-021e-8a4d">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec1c-5f66-4993-ac0b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7248-30e2-0a04-189b" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="c001-9fa9-b678-f8a8" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="d7a4-8e0b-24f8-e495" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4ede-54a6-021e-8a4d" name="Sword" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b6f9-f0c8-e62e-3244" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
                 <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -2248,7 +2164,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="b1ed-b6a8-780a-37dd" name="Crew HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="52a4-d766-b9d5-86ee">
+        <selectionEntryGroup id="b1ed-b6a8-780a-37dd" name="Crew HtH Weapons" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cc1-f2d7-11f4-ef7f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af20-8955-3647-156b" type="min"/>
@@ -2257,15 +2173,6 @@
             <selectionEntry id="b1a9-52ed-a4bb-ad2e" name="Sword or Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="5634-cf44-817f-2648" name="Sword or Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="orderDice" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="52a4-d766-b9d5-86ee" name="Sword" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1056-cf09-3e9e-9dff" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>

--- a/Orcs.cat
+++ b/Orcs.cat
@@ -187,7 +187,7 @@
             </selectionEntry>
             <selectionEntry id="65d0-c55a-45c5-b521" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="f081-6f49-2a72-34e4" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="f081-6f49-2a72-34e4" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -475,7 +475,7 @@
             </selectionEntry>
             <selectionEntry id="1232-1b53-c2b6-57f2" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="04c6-3103-8d52-d702" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="04c6-3103-8d52-d702" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -661,7 +661,7 @@
             </selectionEntry>
             <selectionEntry id="5e0a-b73d-5608-1121" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="3e5c-2b06-6cc7-ea6c" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="3e5c-2b06-6cc7-ea6c" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1107,7 +1107,7 @@
             </selectionEntry>
             <selectionEntry id="f1fa-5d20-cc10-8388" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="d436-8917-8c5d-34c6" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="d436-8917-8c5d-34c6" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1637,7 +1637,7 @@
             </selectionEntry>
             <selectionEntry id="1509-0615-1264-194b" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="2bce-18a9-4351-27c9" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="2bce-18a9-4351-27c9" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1792,7 +1792,7 @@
             </selectionEntry>
             <selectionEntry id="c7d6-9071-bac5-02a6" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="73b7-d870-9df3-c1dc" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="73b7-d870-9df3-c1dc" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1951,7 +1951,7 @@
             </selectionEntry>
             <selectionEntry id="122a-8a4e-f9e5-28a4" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="ffc2-4530-705e-f621" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="ffc2-4530-705e-f621" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2129,7 +2129,7 @@
           <selectionEntries>
             <selectionEntry id="c001-9fa9-b678-f8a8" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="d7a4-8e0b-24f8-e495" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="d7a4-8e0b-24f8-e495" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2256,7 +2256,7 @@
           <selectionEntries>
             <selectionEntry id="b1a9-52ed-a4bb-ad2e" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="5634-cf44-817f-2648" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="5634-cf44-817f-2648" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>

--- a/Orcs.cat
+++ b/Orcs.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="048c-0297-6af4-d584" name="Orcs" revision="3" battleScribeVersion="2.02" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="048c-0297-6af4-d584" name="Orcs" revision="4" battleScribeVersion="2.02" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="8a3b-c7ba-275b-f90a" name="Orc Chieftain [95 pts]" hidden="false" collective="false" targetId="782e-229e-cefd-31f5" type="selectionEntry"/>
     <entryLink id="6c83-5f2b-a031-77cf" name="Orc Chieftain Boar Rider [136 pts]" hidden="false" collective="false" targetId="e332-00ba-1c22-d3dc" type="selectionEntry"/>
@@ -25,7 +25,7 @@
         <categoryLink id="2cfe-2876-dd99-2cb7" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b581-65f4-62c0-a0b8" name="models" hidden="false" collective="false" defaultSelectionEntryId="126c-07a9-8603-c091">
+        <selectionEntryGroup id="b581-65f4-62c0-a0b8" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="126c-07a9-8603-c091">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b06a-28c6-66f2-e146" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="deea-9161-fca9-7c99" type="min"/>
@@ -45,7 +45,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="71.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="22cb-d2e0-78ba-b0a5" name="Orc Bodyguard in Light Armour" hidden="false" collective="false" type="model">
@@ -58,7 +58,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -66,7 +66,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c350-15e9-c8ad-55ac" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -83,7 +83,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="81.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fa3b-ed0b-f01f-da1a" name="Orc Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -96,7 +96,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -104,7 +104,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -121,7 +121,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce01-4393-ee92-5b1c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -130,7 +130,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -147,7 +147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f2e-8f11-9ab6-ba41" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -156,7 +156,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8be1-087b-5bf4-da64" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -165,7 +165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -182,7 +182,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="65d0-c55a-45c5-b521" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -191,7 +191,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ffb-3b01-02df-8e97" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -200,7 +200,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bdac-1823-d46b-046d" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -209,7 +209,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db07-6a90-6377-33b7" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -225,7 +225,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8224-0d9e-ad75-d6c7" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -241,7 +241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -250,7 +250,7 @@
           <selectionEntries>
             <selectionEntry id="6c4c-ae44-17c5-3b0d" name="Ferocious Charge" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="782e-229e-cefd-31f5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -260,11 +260,11 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="187f-d031-2d3d-f758" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="5d35-19d8-81fc-bdbd" name="Ferocious Charge" hidden="false" targetId="7ef8-77c6-28f8-c3e3" type="rule"/>
+                <infoLink id="3e7d-4e89-f8ec-f6ec" name="Ferocious Charge" hidden="false" targetId="c2ce-a18c-2d45-d817" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -287,100 +287,33 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="8e90-4185-2447-66aa" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7702-fa94-23e4-d116" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="a4f5-59ad-cb00-2a1c" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="589c-9868-0dc1-01ed" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="af9f-b698-93b0-617d" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="6cf0-7da8-cf3c-1d0d" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a015-e212-8d4e-5cc7" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bdcd-3319-38f2-8b82" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0ff7-52f7-3285-cb57" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="15bc-a3f0-7806-6a2e" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="afee-7c20-bf72-b379" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bbe4-4986-baef-98b7" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="01cc-4d7b-dada-85c1" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="560c-2118-ba07-e94d" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="40ce-66d1-cf0b-72b5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="eeb5-f799-c024-458b" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="95d5-a681-4777-c926" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e332-00ba-1c22-d3dc" name="Orc Chieftain Boar Rider [136 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="7135-41db-ccb4-8cf1" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
         <infoLink id="3b39-9ecb-7965-8e20" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
-        <infoLink id="f766-2217-d8ec-0b66" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-        <infoLink id="e03e-df48-8188-c32a" name="Ferocious Charge" hidden="false" targetId="7ef8-77c6-28f8-c3e3" type="rule"/>
+        <infoLink id="f766-2217-d8ec-0b66" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
+        <infoLink id="98ba-8695-9a40-9cdb" name="Ferocious Charge" hidden="false" targetId="c2ce-a18c-2d45-d817" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c75a-60c6-78d3-e386" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="2214-f8a3-77ad-aca5" name="Mounted Unit" hidden="false" targetId="mounted unit" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="1f9a-3a50-4587-73b3" name="models" hidden="false" collective="false" defaultSelectionEntryId="7e7e-b509-c357-d130">
+        <selectionEntryGroup id="1f9a-3a50-4587-73b3" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="7e7e-b509-c357-d130">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c543-d2f5-0a2f-4490" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5401-0ec1-79f2-f388" type="min"/>
@@ -400,7 +333,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="86.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d3a2-dbbd-6302-1699" name="Orc Bodyguard in Light Armour" hidden="false" collective="false" type="model">
@@ -413,7 +346,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -421,7 +354,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c7e9-36af-775c-227b" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -438,7 +371,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="96.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="fe68-c865-4d3e-4e86" name="Orc Bodyguard in Medium Armour" hidden="false" collective="false" type="model">
@@ -451,7 +384,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -459,7 +392,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -476,7 +409,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2b16-780a-da64-0220" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -485,7 +418,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -502,7 +435,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9727-7111-4415-a13f" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -511,7 +444,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c87-803d-c81f-2694" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -520,7 +453,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -537,7 +470,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1232-1b53-c2b6-57f2" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -546,7 +479,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a96b-c9db-a090-8c24" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -555,7 +488,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f47-e87f-b915-fd72" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -564,7 +497,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e49d-73c2-890b-e156" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -580,7 +513,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e009-f8df-7e28-108c" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -596,7 +529,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -619,85 +552,18 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="3ebc-1783-b34e-3e6b" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2cf-37e3-e1a3-d14d" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="3250-1051-23c2-1bfe" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="10b9-01e8-fe3b-f737" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8662-f304-1eda-5b73" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c80a-6d2c-07c9-8e18" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="bbc1-3e69-6f77-0f1e" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="6dae-189c-0955-f5a2" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="28f0-2e30-9282-7204" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e5c2-e495-5b90-6ba0" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e6a3-2ce8-277e-83d0" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a67a-29d4-86af-a124" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="59e5-71ec-e493-c9dc" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="3aa2-5f0e-4702-dcd9" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1cc5-9098-5821-51ab" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="af99-9f59-3e86-d483" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4f99-52f5-571f-5d47" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8507-c9fb-4724-e2b5" name="Orc Shaman [57 pts]" hidden="false" collective="false" type="unit">
@@ -711,25 +577,23 @@
         <categoryLink id="7bf6-bb56-e738-5bca" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
         <categoryLink id="0cb4-adc2-ab9d-6c1b" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="245c-81dd-dd4f-2928" name="Orc Shaman with Sword or Axe" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08bc-58a5-4439-1ff7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eded-26fd-098a-e381" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="02cc-4324-9fd9-4ec3" name="Orc Shaman" hidden="false" targetId="7aef-0379-3032-9531" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="57.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f8ac-93fb-323b-916b" name="Shaman" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="7989-7c3c-fd67-f9ec" name="Orc Shaman with Sword or Axe" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce61-bca1-2415-140e" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b07-f3be-ef90-365e" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="cdaf-bd59-cf44-a06e" name="Orc Shaman" hidden="false" targetId="7aef-0379-3032-9531" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="57.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="9bc9-56af-f423-5c86" name="Bodyguard" hidden="false" collective="false">
+        <selectionEntryGroup id="9bc9-56af-f423-5c86" name="Bodyguards" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="0134-3b3c-4edd-6ac1" name="Orc Bodyguard" hidden="false" collective="false" type="model">
               <constraints>
@@ -740,7 +604,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -757,7 +621,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a6b8-4549-e050-eac3" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -766,7 +630,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3e13-a469-4ff8-c0ef" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -775,7 +639,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -792,7 +656,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5e0a-b73d-5608-1121" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -801,7 +665,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="871f-7b0a-926b-2a3a" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -810,7 +674,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ebe-7e78-78f8-64f1" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -819,7 +683,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -836,7 +700,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3714-2a9e-7cfe-9237" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -845,7 +709,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -854,7 +718,7 @@
           <selectionEntries>
             <selectionEntry id="efe5-93d4-a099-4e17" name="Ferocious Charge" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="8507-c9fb-4724-e2b5" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -864,11 +728,11 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6675-ac90-d377-438a" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="5633-f3ba-cea2-8875" name="Ferocious Charge" hidden="false" targetId="7ef8-77c6-28f8-c3e3" type="rule"/>
+                <infoLink id="1468-9e01-67c8-75c8" name="Ferocious Charge" hidden="false" targetId="c2ce-a18c-2d45-d817" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -884,7 +748,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bb1b-60aa-77af-6ba8" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -896,7 +760,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="35de-ccec-aa7c-571e" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -908,7 +772,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f4e-9379-01b9-8012" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -920,7 +784,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="25fc-5262-b57b-504c" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -932,7 +796,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd22-fb0d-2f2b-d47d" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -944,7 +808,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a719-0c26-eb2a-a1a8" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -956,7 +820,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b2b-1791-fff2-2a7f" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -968,7 +832,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="558c-aa93-02d5-71cd" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -980,7 +844,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="86e1-f96b-ac75-0901" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -992,7 +856,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d80-f96f-3e3a-37e8" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1004,7 +868,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f3fe-4da9-f6c8-f78b" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1016,7 +880,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="38de-402c-219a-a530" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1028,7 +892,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="185a-1e6e-8e33-6727" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1040,7 +904,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1057,7 +921,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4cb0-76d8-380f-d4a3" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1066,7 +930,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffae-f734-831b-bdfd" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1075,7 +939,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36ba-0094-fd70-ac0e" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1084,7 +948,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="234b-af38-71cc-6ec4" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1093,7 +957,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6b9b-0ed1-1097-f045" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1102,7 +966,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="763a-5285-de0a-8c9e" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1111,7 +975,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f842-2cac-9fc1-2772" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1120,7 +984,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="95d7-a0fd-6dc3-2084" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1129,7 +993,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e8e6-7b3a-c94e-c93f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1138,7 +1002,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e64-0bb0-61cf-6681" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1147,7 +1011,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee66-ea01-7ede-1b58" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1156,7 +1020,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cfd7-4611-5c3b-527d" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1165,7 +1029,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6cba-be22-a307-5db2" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1174,93 +1038,30 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="1189-100c-07fb-3127" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd11-ea7f-f7d7-ee9d" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="2e15-4aa8-9c86-3f6f" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e052-4a75-28f0-9acd" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a019-fe19-0cda-8997" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a20f-ccab-a1c8-eb74" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3a7c-c0d6-079d-8817" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4b36-0a80-010d-ed6f" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="eebc-69f8-0ab0-fc6e" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="adde-3d01-055b-ea3f" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="db73-f0d4-671f-801b" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bbbb-b182-2ca8-3a10" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5b05-0230-8877-91bb" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="258b-219c-4563-5efe" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b132-9671-d791-32e5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bd83-46a8-6973-e9cb" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="0e69-cb58-023c-2f77" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8c52-ad3f-0992-e671" name="Orc Champion [75 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3fb-c4e5-a221-b5ec" type="max"/>
+      </constraints>
       <infoLinks>
         <infoLink id="fef6-9812-1714-e337" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ed22-b3c4-617d-735c" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
+        <categoryLink id="7620-5438-c2b4-44a3" name="Hero Unit" hidden="false" targetId="hero unit" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="8179-c1e5-49ca-a49a" name="Champion" hidden="false" collective="false" defaultSelectionEntryId="597a-fd32-ce9c-623f">
@@ -1275,7 +1076,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="75.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="68b3-5fa5-8c3d-b213" name="Orc Champion in Medium Armour" hidden="false" collective="false" type="model">
@@ -1284,7 +1085,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="85.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1301,7 +1102,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f1fa-5d20-cc10-8388" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1310,7 +1111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f32-937c-9a36-1b66" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1319,7 +1120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96bf-e41f-1571-3914" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1328,7 +1129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c74-d39f-d468-79a2" name="Improbably Vast Sword" hidden="false" collective="false" type="upgrade">
@@ -1337,7 +1138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eeb3-30f3-1118-a4cd" name="Bloomin&apos;Big Axe" hidden="false" collective="false" type="upgrade">
@@ -1346,7 +1147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1362,7 +1163,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1379,7 +1180,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f35-73d6-7425-97cf" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1388,7 +1189,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1405,7 +1206,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c4cc-b00f-db38-a08b" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1414,7 +1215,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="71ac-bc83-2f82-7242" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1423,7 +1224,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1439,7 +1240,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1456,91 +1257,24 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b105-3767-8397-70af" name="Ferocious Charge" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="22f9-fed1-30b3-be86" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="296f-4eda-55c2-45a1" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="aee7-6c5e-7c5e-cbc8" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="03ec-7e99-bf73-488e" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b9a7-5334-e57f-fb70" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="1e78-bb43-169b-9518" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c06d-b05d-4c19-4d80" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="6ac8-5b65-e1c7-6cc1" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ba2e-6620-1079-e32b" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4c5c-0c2a-b80d-42fc" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2d80-7247-4690-206a" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="a9d9-a460-a946-7c44" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4f3e-acf8-9ceb-302b" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="2b13-ecd8-db19-31ef" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2ed7-c97a-254a-1bae" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e3c2-041f-0925-78d9" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a3bd-4acf-b531-58f4" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ce3-888a-1952-2f6d" name="Orc Warriors [70 pts]" hidden="false" collective="false" type="unit">
@@ -1552,7 +1286,7 @@
           <selectionEntries>
             <selectionEntry id="abc7-3015-91a8-0d45" name="Ferocious Charge" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="3ce3-888a-1952-2f6d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -1562,11 +1296,11 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bef-afd9-0ef6-a8ab" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="d68e-08de-2eae-5f76" name="Ferocious Charge" hidden="false" targetId="7ef8-77c6-28f8-c3e3" type="rule"/>
+                <infoLink id="255a-85e9-bb99-80f9" name="Ferocious Charge" hidden="false" targetId="c2ce-a18c-2d45-d817" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1583,7 +1317,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8aa4-c2ce-3652-ed25" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1592,7 +1326,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="46ae-166e-ee54-0523" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1608,12 +1342,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="2a69-e6d8-1714-f8fe" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="2a69-e6d8-1714-f8fe" name="Orc Warriors" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="03f3-5502-93f2-1f33" name="Orc Warrior Leader" hidden="false" collective="false" type="model">
               <constraints>
@@ -1626,7 +1360,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="22.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f093-e625-e8c5-88e7" name="Orc Warrior" hidden="false" collective="false" type="model">
@@ -1639,7 +1373,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1647,12 +1381,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="776f-bb6e-cb3e-3f0d" name="Orc Archers [70 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="6bee-e46f-7111-ba2c" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+        <infoLink id="34e7-e2a1-7020-4a7f" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="814e-0d9b-2b23-9439" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -1670,7 +1405,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="300a-d660-da96-fa35" name="Crossbows" hidden="false" collective="false" type="upgrade">
@@ -1683,15 +1418,16 @@
               </modifiers>
               <infoLinks>
                 <infoLink id="b919-3093-530d-a048" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
+                <infoLink id="6fcf-f40b-8d5f-d5ac" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="2ff5-47bb-d988-17e1" name="Models" hidden="false" collective="false" defaultSelectionEntryId="205b-42e8-7b43-27eb">
+        <selectionEntryGroup id="2ff5-47bb-d988-17e1" name="Armour" publicationId="cffa-cd51-pubN65537" hidden="false" collective="false" defaultSelectionEntryId="205b-42e8-7b43-27eb">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c60b-cde6-7ff9-51fc" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df4f-0342-a5ee-11be" type="max"/>
@@ -1707,12 +1443,11 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec5d-a85f-a480-96f8" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="eb27-4803-99ad-5d0a" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                         <infoLink id="fbe5-68ad-8c89-a8ce" name="Orc Archer Leader" hidden="false" targetId="e829-077d-ae5f-312e" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="e079-23a6-3b93-5149" name="Orc Archers" hidden="false" collective="false" type="model">
@@ -1725,7 +1460,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1733,7 +1468,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="688f-00f4-af7f-64f4" name="Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1747,11 +1482,10 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="75f5-e26d-3ee3-124a" name="Orc Archer Leader in Light Armour" hidden="false" targetId="5e96-b683-f1e3-6f81" type="profile"/>
-                        <infoLink id="0582-fa15-467a-034c" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1574-9d4a-84bc-576a" name="Orc Archers in Light Armour" hidden="false" collective="false" type="model">
@@ -1764,7 +1498,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1772,7 +1506,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1781,7 +1515,7 @@
           <selectionEntries>
             <selectionEntry id="95cf-cb10-5613-acb0" name="Ferocious Charge" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="776f-bb6e-cb3e-3f0d" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -1791,11 +1525,11 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f22-62d6-a3ea-867d" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="3b16-8b13-2f1b-8c4d" name="Ferocious Charge" hidden="false" targetId="7ef8-77c6-28f8-c3e3" type="rule"/>
+                <infoLink id="22b7-339e-9213-98cc" name="Ferocious Charge" hidden="false" targetId="c2ce-a18c-2d45-d817" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1803,7 +1537,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="617f-5069-cbec-cae2" name="Trolls [105 pts]" hidden="false" collective="false" type="unit">
@@ -1828,7 +1562,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="35.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1836,10 +1570,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cecf-a6e9-be27-a87a" name="Orc Guard [70 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ade0-d958-13ff-ee98" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="3b6a-cb8e-2401-f837" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1848,7 +1585,7 @@
           <selectionEntries>
             <selectionEntry id="b543-2c9d-ae24-e0cc" name="Ferocious Charge" hidden="false" collective="false" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="points" value="1">
+                <modifier type="increment" field="points" value="1.0">
                   <repeats>
                     <repeat field="selections" scope="cecf-a6e9-be27-a87a" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
@@ -1858,11 +1595,11 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e214-2755-8aaf-daec" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="4620-81a2-bd21-d733" name="Ferocious Charge" hidden="false" targetId="7ef8-77c6-28f8-c3e3" type="rule"/>
+                <infoLink id="00a9-b024-f319-8283" name="Ferocious Charge" hidden="false" targetId="c2ce-a18c-2d45-d817" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1879,7 +1616,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8fd3-5df9-dc6c-5595" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1895,7 +1632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1509-0615-1264-194b" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1904,7 +1641,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a2b4-9aad-7d80-33b6" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -1913,7 +1650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b67d-f6c9-ad8d-c689" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1922,12 +1659,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c6aa-6f6f-bf0e-91ec" name="Models" hidden="false" collective="false" defaultSelectionEntryId="b93f-a586-815c-dc11">
+        <selectionEntryGroup id="c6aa-6f6f-bf0e-91ec" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="b93f-a586-815c-dc11">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac88-6393-c4be-c7c9" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b929-d446-2b19-de56" type="min"/>
@@ -1948,7 +1685,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5ce9-04d5-4601-b1d8" name="Orc Guard in Light Armour" hidden="false" collective="false" type="model">
@@ -1961,7 +1698,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1969,7 +1706,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4973-5f15-bbfd-cff6" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1987,7 +1724,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2f50-2e85-7c16-62ca" name="Orc Guard in Medium Armour" hidden="false" collective="false" type="model">
@@ -2000,7 +1737,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2008,7 +1745,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2016,14 +1753,14 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9e88-a067-9011-aaec" name="Orc Boar Riders [85 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="9da8-ecfe-e655-c06b" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-        <infoLink id="d7d4-c5d7-31a6-9b80" name="Ferocious Charge" hidden="false" targetId="7ef8-77c6-28f8-c3e3" type="rule"/>
+        <infoLink id="9da8-ecfe-e655-c06b" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
         <infoLink id="9318-dfbc-1d83-3cf0" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="60c5-aa8c-eee1-ed32" name="Ferocious Charge" hidden="false" targetId="c2ce-a18c-2d45-d817" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="2841-fec9-1940-7589" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
@@ -2041,7 +1778,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eca3-44f9-40d3-8f7c" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2050,7 +1787,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c7d6-9071-bac5-02a6" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2059,12 +1796,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="2712-a517-a1ee-031d" name="Models" hidden="false" collective="false" defaultSelectionEntryId="e3ed-db9d-d9ff-2a0a">
+        <selectionEntryGroup id="2712-a517-a1ee-031d" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="e3ed-db9d-d9ff-2a0a">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ed8-29e2-aeb1-4684" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c897-94e2-e98d-1d0d" type="min"/>
@@ -2084,7 +1821,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="35.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="359d-8fb4-9855-0812" name="Orc Boar Rider in Light Armour" hidden="false" collective="false" type="model">
@@ -2097,7 +1834,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2105,7 +1842,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36e1-1c18-bf8b-8422" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2122,7 +1859,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="37.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8590-8aea-5f04-8508" name="Orc Boar Rider in Medium Armour" hidden="false" collective="false" type="model">
@@ -2135,7 +1872,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2143,7 +1880,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2151,18 +1888,44 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8409-5df8-64c6-07ee" name="Orc Boar Chariot [101 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="00e1-5920-a31f-3350" name="Boars" hidden="false" targetId="20f8-c95a-aeb0-4345" type="profile"/>
+        <infoLink id="9d89-76a1-ab8b-6ebd" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
+        <infoLink id="e069-fcb8-43c9-4068" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+        <infoLink id="4a45-092d-6b2f-776c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5333-9ea2-ef53-0883" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="85db-f20e-dd67-c50a" name="Chariot" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd59-8a29-6550-5051" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74d2-bc7c-5b6e-23cf" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="92e2-88ae-54b1-0900" name="Orc Chariot, With Crew, pulled by 2 boars" hidden="false" targetId="e7bb-7aef-6a15-c98a" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="91.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6b49-7ee7-fafa-7510" name="Boars" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cc7-689b-f165-39c4" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e768-2bf8-7eea-0df5" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="142d-0fad-40b7-bb5b" name="Boars" hidden="false" targetId="20f8-c95a-aeb0-4345" type="profile"/>
+          </infoLinks>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b53a-337a-e24a-1c8b" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="122a-8a4e-f9e5-28a4">
+        <selectionEntryGroup id="b53a-337a-e24a-1c8b" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="122a-8a4e-f9e5-28a4">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15a3-377c-af25-fa87" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e7c-7d73-18f0-12a1" type="min"/>
@@ -2174,7 +1937,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="399b-ce13-7300-0217" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2183,7 +1946,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="122a-8a4e-f9e5-28a4" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2192,7 +1955,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2215,7 +1978,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2231,12 +1994,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="3a3c-94bd-a0a2-7c50" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="3a3c-94bd-a0a2-7c50" name="Crew" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="ee25-07ce-0d5d-4b84" name="Orc Crew" hidden="false" collective="false" type="model">
               <constraints>
@@ -2248,27 +2011,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="00ff-1a79-10c4-9c4c" name="Chariot" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="73ec-2649-3961-802a" name="Chariot" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4f5-5d24-bb10-230e" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="376e-c495-d9da-afba" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="c9cd-6099-b720-5cdd" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
-                <infoLink id="4ea9-7ac2-d6d5-ba03" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-                <infoLink id="85f1-5382-0699-c05f" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="f0a9-36d3-cacf-e721" name="Orc Chariot, With Crew, pulled by 2 boars" hidden="false" targetId="e7bb-7aef-6a15-c98a" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="91.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2276,21 +2019,27 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3e4b-e953-ca97-44e9" name="Orc Stone Thrower [84 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="4783-fd36-614a-0917" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="9286-a953-47b6-bde3" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="6eff-0ec0-2940-632c" name="Overhead" hidden="false" targetId="7751-622a-b896-4874" type="rule"/>
+        <infoLink id="3b95-e677-3dbc-d789" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="5516-869c-892b-9c00" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ad11-d6e9-b28e-ff1c" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="9ea9-5966-31a4-3960">
+        <selectionEntryGroup id="ad11-d6e9-b28e-ff1c" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="9ea9-5966-31a4-3960">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1edf-812f-70e9-000e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd14-980a-0f17-ab89" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="9ea9-5966-31a4-3960" name="Crew" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="9ea9-5966-31a4-3960" name="Crew with No Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
                 <selectionEntryGroup id="7cff-2933-f1f5-d401" name="Crew" hidden="false" collective="false">
                   <selectionEntries>
@@ -2306,7 +2055,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2314,7 +2063,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="695b-6764-9cc9-7f88" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2333,7 +2082,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2341,7 +2090,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2358,7 +2107,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53f6-0980-fa25-499e" name="Large Stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -2367,12 +2116,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1527-e280-295f-d961" name="Crew HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="4ede-54a6-021e-8a4d">
+        <selectionEntryGroup id="1527-e280-295f-d961" name="Crew HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="4ede-54a6-021e-8a4d">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec1c-5f66-4993-ac0b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7248-30e2-0a04-189b" type="min"/>
@@ -2384,7 +2133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ede-54a6-021e-8a4d" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2393,7 +2142,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2401,21 +2150,26 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f424-904a-5733-500a" name="Orc Bolt Thrower [60 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="abe6-fa27-3422-ca7a" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="9eb0-c5ae-d592-5082" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="8014-a7fd-ffe7-24f8" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="9e53-2bf0-052e-5430" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="c6df-b2d4-50e1-8c37" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="6ba1-3d4d-39c8-a013">
+        <selectionEntryGroup id="c6df-b2d4-50e1-8c37" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="6ba1-3d4d-39c8-a013">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="356b-dbc0-9d58-339c" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fea2-8320-18ac-42a0" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6ba1-3d4d-39c8-a013" name="Crew" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6ba1-3d4d-39c8-a013" name="Crew with No Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
                 <selectionEntryGroup id="a9fc-c734-b9c7-faab" name="Crew" hidden="false" collective="false">
                   <selectionEntries>
@@ -2425,13 +2179,11 @@
                         <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36ff-dc92-a875-3aba" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="53a2-c30d-6115-6042" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                        <infoLink id="7cf0-6d74-8f49-fac4" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
                         <infoLink id="776e-fdd7-ae74-e279" name="Orc Bolt Thrower Crew" hidden="false" targetId="2fd0-d277-128e-f6db" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2439,7 +2191,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d8e-cd2c-cb87-c973" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2452,13 +2204,11 @@
                         <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff11-8a66-4756-5dfc" type="max"/>
                       </constraints>
                       <infoLinks>
-                        <infoLink id="e7ac-4dcf-daeb-39e7" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                        <infoLink id="8f76-8f04-dec9-3e5e" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
                         <infoLink id="f3b8-ec2a-60b8-b2b6" name="Orc Bolt Thrower Crew in Light Armour" hidden="false" targetId="8e9f-316a-695b-7cad" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2466,7 +2216,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2483,21 +2233,22 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e204-5103-00e0-299e" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="57f7-22fb-f149-75e4" name="Large Bolt Thrower" hidden="false" targetId="fbdf-a3cf-f1d1-8d05" type="profile"/>
+                <infoLink id="4ed1-25fb-6534-d9e4" name="Unstoppable" hidden="false" targetId="a8bf-f48c-1b08-58e6" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="51.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="b1ed-b6a8-780a-37dd" name="Crew HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="52a4-d766-b9d5-86ee">
+        <selectionEntryGroup id="b1ed-b6a8-780a-37dd" name="Crew HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="52a4-d766-b9d5-86ee">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cc1-f2d7-11f4-ef7f" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af20-8955-3647-156b" type="min"/>
@@ -2509,7 +2260,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="52a4-d766-b9d5-86ee" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -2518,7 +2269,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2526,16 +2277,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
-  <sharedRules>
-    <rule id="7ef8-77c6-28f8-c3e3" name="Ferocious Charge" hidden="false">
-      <description>
-+1SV bonus when charging.</description>
-    </rule>
-  </sharedRules>
   <sharedProfiles>
     <profile id="2955-7b20-8674-d200" name="Orc Chieftain in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
@@ -2545,7 +2290,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, 3xHTH Attacks, Wound X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, 3xHtH Attacks, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="fc45-d5f1-1394-05de" name="Orc Chieftain in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2556,7 +2301,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, 3xHTH Attacks, Wound X</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, 3xHtH Attacks, Wound X</characteristic>
       </characteristics>
     </profile>
     <profile id="ec95-af7c-7c4a-6a31" name="Orc Bodyguard in light armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2589,7 +2334,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, Fast 6, Ferocious Charge, 3xHTH, Wound, Boar 1xHTH SV3 attack</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, Fast 6, Ferocious Charge, 3xHtH, Wound, Boar 1xHtH SV3 attack</characteristic>
       </characteristics>
     </profile>
     <profile id="9fb0-ed58-57af-c85f" name="Orc Chieftain in Medium Armour, Riding Wild Boar" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2600,7 +2345,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, Fast 6, Ferocious Charge, 3xHTH, Wound, Boar 1xHTH SV3 attack</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Follow, Fast 6, Ferocious Charge, 3xHtH, Wound, Boar 1xHtH SV3 attack</characteristic>
       </characteristics>
     </profile>
     <profile id="dd15-b3f0-ff0b-808d" name="Orc bodyguard in light armour riding wild boar" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2611,7 +2356,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Ferocious charge, Boar 1xHTH SV3 attack.</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Ferocious charge, Boar 1xHtH SV3 attack.</characteristic>
       </characteristics>
     </profile>
     <profile id="963c-2afd-a90e-5b82" name="Orc bodyguard in Medium armour riding wild boar" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2622,7 +2367,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Ferocious charge, Boar 1xHTH SV3 attack.</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Ferocious charge, Boar 1xHtH SV3 attack.</characteristic>
       </characteristics>
     </profile>
     <profile id="7aef-0379-3032-9531" name="Orc Shaman" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2633,7 +2378,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Magic Level X, Wound</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Magic Level X, Wound</characteristic>
       </characteristics>
     </profile>
     <profile id="7a3f-4fd9-f4f9-0500" name="Orc Bodyguard (Shaman)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2655,7 +2400,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHTH, Wound X, Ferocious Charge</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHtH, Wound X, Ferocious Charge</characteristic>
       </characteristics>
     </profile>
     <profile id="e466-d671-5a9b-4156" name="Orc Champion in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2666,7 +2411,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHTH, Wound X, Ferocious Charge</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, 3xHtH, Wound X, Ferocious Charge</characteristic>
       </characteristics>
     </profile>
     <profile id="da42-4375-ccd0-6b09" name="Orc Warrior Leader in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2743,7 +2488,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">4</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 3xHTH SV2, Chunder, Regenerate</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, 3xHtH SV2, Chunder, Regenerate</characteristic>
       </characteristics>
     </profile>
     <profile id="1d67-aefa-9dee-2ec5" name="Orc Guard Leader in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2798,7 +2543,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 6, Ferocious Charge, Boar:1xHTH SV3</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 6, Ferocious Charge, Boar:1xHtH SV3</characteristic>
       </characteristics>
     </profile>
     <profile id="0c0f-0e64-5b22-ad96" name="Orc Boar Rider Leader in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2809,7 +2554,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 6, Ferocious Charge, Boar:1xHTH SV3</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Fast 6, Ferocious Charge, Boar:1xHtH SV3</characteristic>
       </characteristics>
     </profile>
     <profile id="40aa-1505-81ca-a670" name="Orc Boar Rider in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2820,7 +2565,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Ferocious Charge, Boar:1xHTH SV3</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Ferocious Charge, Boar:1xHtH SV3</characteristic>
       </characteristics>
     </profile>
     <profile id="663e-e52a-2e7a-6594" name="Orc Boar Rider in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -2831,10 +2576,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">6</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Ferocious Charge, Boar:1xHTH SV3</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Fast 6, Ferocious Charge, Boar:1xHtH SV3</characteristic>
       </characteristics>
     </profile>
-    <profile id="e7bb-7aef-6a15-c98a" name="Orc Chariot, With Crew, pulled by 2 boars" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="e7bb-7aef-6a15-c98a" name="Orc Chariot: Orc crew, pulled by two boars" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">3</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
@@ -2864,7 +2609,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHTH SV3</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">1xHtH SV3</characteristic>
       </characteristics>
     </profile>
     <profile id="5300-02c1-4598-7c30" name="Orc Stone Thrower Crew with Swords or Axes" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 Warlords of Erehwon
 ===================
-Files created by the3dwargamer@outlook.com  Contact for any issues or bugs you may find. 
+Files originally created by the3dwargamer@outlook.com  Contact for any issues or bugs you may find. 
 
+8/19/19 - Order dice have been added.
+8/15/19 - Skill descriptions updated to be complete.
+8/14/19 - Reviewed Undead.
 2/19/19 - Beta version is complete, all army lists are now available.  For the next few weeks I will be working on bug fixes and format fixes to make the selections better and to add spell selections.  Right now there is just a placeholder for spells to account for the points you spend, but it doesn't actually let you pick the specific spell.
 
 Will upgrade the choice selection and armour selection process for knights/beastmen/olympian.  Those were the first lists I created and I didn't use different profiles for armour selection.
+
 #### Contents ####
 
 * [Overview][]

--- a/Samurai.cat
+++ b/Samurai.cat
@@ -23,29 +23,33 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="7fb8-4fba-65cf-e467" name="Daimyo [122 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="4c57-afdd-fbc4-c8b5" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
+        <infoLink id="dac8-d9d7-903b-be79" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
+        <infoLink id="451f-376d-1bcb-efc2" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="81f7-207f-45d2-8f06" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="5543-f077-9866-f35e" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="cffa-9984-4dd6-995d" name="Daimyo" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86a5-f6b5-5252-a3bf" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d89a-708c-44cb-fe8e" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="e17b-62b9-0df4-2378" name="Daimyo in Medium Armour" hidden="false" targetId="213f-f97c-9f16-f8a5" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="82.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="385c-00c2-77bc-25f9" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="385c-00c2-77bc-25f9" name="Bodyguards" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="bc15-ad5d-74e3-0068" name="Daimyo" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b53-477f-72c3-e149" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f373-642d-e58a-3803" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="a4f9-5e2a-af31-763c" name="Daimyo in Medium Armour" hidden="false" targetId="213f-f97c-9f16-f8a5" type="profile"/>
-                <infoLink id="bd6b-8de6-5c78-865f" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
-                <infoLink id="f63b-2452-9714-5eb3" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
-                <infoLink id="574b-7bff-78f8-5662" name="Follow" hidden="false" targetId="83d2-f89c-33a4-258d" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="82.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="2ffa-dd56-9dbb-9292" name="Hatamoto in Medium Armour" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46c6-cad9-5abb-81eb" type="min"/>
@@ -53,11 +57,10 @@
               </constraints>
               <infoLinks>
                 <infoLink id="b7aa-deea-95c5-3d78" name="Hatamoto in Medium Armour" hidden="false" targetId="d533-75c5-abc2-7613" type="profile"/>
-                <infoLink id="a78c-e097-8007-0c9f" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -74,7 +77,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="64e5-82ab-15c9-27ca" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -83,7 +86,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -106,7 +109,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -117,13 +120,13 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fa7-e94c-4513-fb32" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8649-42c1-e534-d928" name="Tough" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8649-42c1-e534-d928" name="Tough 1" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="2a6d-f290-7a18-bb86" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+                <infoLink id="2a6d-f290-7a18-bb86" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a68a-d549-1683-96ad" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -132,7 +135,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -149,7 +152,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ed5-24ab-e29a-63d5" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -158,94 +161,27 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="e0ee-6a7e-9b8c-d4a9" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e6b-fff1-9c5a-93e5" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="eb49-6904-5e8f-5699" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="013b-866b-3cee-3e42" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b130-152b-8d88-540d" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e0b5-11ab-a9db-364c" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ca34-f5ca-7900-41ea" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="2153-5807-693a-6631" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2bd8-54ae-2611-ea75" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="29d7-0c28-194f-3b0e" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a24a-a202-55ae-c619" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5b79-7aa7-fc32-4ec0" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ed19-e0da-7718-3fc9" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7517-db7c-218b-19bf" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4bfb-5f0f-9fd0-5f1a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ea6f-6fe9-6abc-6ea7" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="fc90-a9db-6bef-20b4" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0548-5344-d38b-832f" name="Mounted Daimyo [148 pts]" hidden="false" collective="false" type="unit">
       <categoryLinks>
         <categoryLink id="ce0b-f83a-5bf8-64ed" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
-        <categoryLink id="924a-1841-50b3-a873" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
+        <categoryLink id="64c3-f2ac-0bf9-b7cb" name="Mounted Unit" hidden="false" targetId="mounted unit" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="bdc6-8391-3e8c-a0e4" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="bdc6-8391-3e8c-a0e4" name="Bodyguards" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="8141-a3fc-88f7-79e5" name="Daimyo" hidden="false" collective="false" type="model">
               <constraints>
@@ -261,7 +197,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="92.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e961-aed5-86ff-36f5" name="Hatamoto in Medium Armour" hidden="false" collective="false" type="model">
@@ -275,7 +211,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -292,7 +228,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6def-f70c-a5b5-ee79" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -308,7 +244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -331,7 +267,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -348,7 +284,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7569-fd57-75ec-1057" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -357,7 +293,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -374,7 +310,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3e19-a6dd-d4d1-d33b" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -383,7 +319,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -406,113 +342,45 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="e8a5-1711-3f94-43ee" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fe6-93b3-cfc8-ddab" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="0b75-beab-cd44-08d6" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b5c4-1e03-0caf-7eb7" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="36eb-5f78-dd0a-3d38" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8e54-bf3d-b96c-3358" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c3f3-62cb-01c4-9da2" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="64d0-46dc-e7af-4bef" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a742-298f-dc07-47f5" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="338c-4e6a-86c4-d278" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="899a-194d-daf5-9cf6" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4c9b-fa66-fe86-8c8d" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1d75-a72c-373c-49b0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5df6-feaa-b657-d489" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3c35-88d0-3079-48b5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c816-4508-9277-c1a3" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a85d-21a8-0030-fc9f" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="546c-46ef-b4dc-cd2b" name="Onmyoji Diviner [55 pts]" hidden="false" collective="false" type="unit">
       <categoryLinks>
         <categoryLink id="c09c-2897-57eb-57ee" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
+        <categoryLink id="02c0-d5d6-2a4c-7c36" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="7fe8-df20-8e8f-f460" name="Onmyoji" hidden="false" collective="false" defaultSelectionEntryId="f989-8a97-2ce4-78bd">
+      <selectionEntries>
+        <selectionEntry id="1ac5-9506-4b75-a118" name="Onmyoji" hidden="false" collective="false" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7de8-eeb3-a060-b37b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1de-6d9d-7821-ba51" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1c9-b4bc-f05b-c037" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d74-539b-ab6c-2b89" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="f989-8a97-2ce4-78bd" name="Onmyoji" hidden="false" collective="false" type="model">
-              <infoLinks>
-                <infoLink id="c206-3cea-ffea-3fc3" name="Onmyoji" hidden="false" targetId="dedf-2494-cb70-cdec" type="profile"/>
-                <infoLink id="64c5-973d-5914-dd60" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="55.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+          <infoLinks>
+            <infoLink id="41e5-0528-b13b-9a4d" name="Onmyoji" hidden="false" targetId="dedf-2494-cb70-cdec" type="profile"/>
+            <infoLink id="73a1-d7c2-a7ef-db47" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="55.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="828e-312c-b4fa-6679" name="Spirits or Servants" hidden="false" collective="false">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3529-b3e3-6726-95d2" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3529-b3e3-6726-95d2" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77e5-5bbc-b30e-b4f4" type="max"/>
           </constraints>
           <selectionEntries>
@@ -529,7 +397,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -537,7 +405,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="485c-3d06-ba24-6414" name="Shikigami Spirits" hidden="false" collective="false" type="upgrade">
@@ -554,7 +422,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -562,7 +430,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -579,7 +447,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbc9-109a-63b1-8805" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -588,7 +456,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c53-f753-4142-a72d" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -597,7 +465,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -614,7 +482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f36e-0a3f-20b4-5adf" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -623,7 +491,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dbda-bc2e-bb8f-948e" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -632,7 +500,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ed0-9666-8d85-e1a7" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -641,7 +509,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0fb-4705-18a8-5d02" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -650,7 +518,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4bae-cc91-9e78-524e" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -659,7 +527,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3cbf-796e-d8b6-6b92" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -668,7 +536,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3991-b7a1-3bf5-60a3" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -677,7 +545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e466-c37a-c655-3836" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -686,7 +554,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0340-ff1a-86f4-a7aa" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -695,7 +563,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffec-13fb-3d10-039f" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -704,7 +572,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7904-d2de-a7ed-80ee" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -713,7 +581,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0404-a5d8-62e0-3ab3" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -722,7 +590,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="70ad-7356-732b-8f5f" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -731,7 +599,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -747,7 +615,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f566-eb33-32e3-fcd7" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -759,7 +627,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="726f-992e-1660-87c6" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -771,7 +639,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="961c-d934-e42b-c125" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -783,7 +651,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7678-30bd-736b-fcf6" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -795,7 +663,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db5c-e878-75cb-b8ee" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -807,7 +675,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6d9a-53e9-7e75-6284" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -819,7 +687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cb1a-d65c-e142-ce14" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -831,7 +699,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f91-ea51-050c-1dda" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -843,7 +711,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dae4-658a-9bf1-706d" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -855,7 +723,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53f1-4225-e57a-ab5a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -867,7 +735,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a33-d1c7-14d1-af87" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -879,7 +747,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f931-dbf8-e8af-2cd9" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -891,7 +759,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="97d6-71f6-b81f-b0af" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -903,7 +771,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -920,120 +788,53 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7eb0-c108-3e57-1ec2" name="Tough" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7eb0-c108-3e57-1ec2" name="Tough 1" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="70da-cd4b-1843-adde" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+                <infoLink id="70da-cd4b-1843-adde" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="07fb-102d-950f-c909" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e3d-d1bb-f83b-f75b" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="65f7-48d3-0cd8-0bff" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4964-b42e-a105-de8a" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e60f-38e7-8369-36f1" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="cfd8-e913-d40d-a67f" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5b58-9cd4-b8ba-2c2f" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="725f-40a9-b8f3-7706" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8b5a-399d-e4c2-c522" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="3ddb-2d27-1999-6f17" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="afdc-15fd-a801-954d" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4075-0c81-5dfe-6640" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6283-6f87-8311-69a0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0b89-44bd-bde6-d2d0" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b631-45bc-a75d-564e" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0366-6383-1caf-6e81" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a428-e1e2-b431-f1c2" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1070-fe2d-2e93-c2c1" name="Shugyosha Samurai Hero [86 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="72be-144d-2dc5-c20e" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="cf0a-92c4-c92a-a65b" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="8297-f0f5-d62d-f2d4" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="47dd-3651-5b2e-798f" name="Shugyosha Samurai Hero" hidden="false" collective="false" defaultSelectionEntryId="5fb6-56e9-99d6-1df6">
+      <selectionEntries>
+        <selectionEntry id="ecf8-b089-ca8b-fc26" name="Shugyosha Samurai Hero" hidden="false" collective="false" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d304-2b76-a64c-497d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fae2-191d-c085-d2e1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4050-9fa6-2dc6-57c2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4888-a971-2e2c-54cb" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="5fb6-56e9-99d6-1df6" name="Shugyosha Samurai Hero" hidden="false" collective="false" type="model">
-              <infoLinks>
-                <infoLink id="cd9c-3597-e025-4e04" name="Shugyosha Samurai in Medium Armour" hidden="false" targetId="b417-c06a-ed07-646a" type="profile"/>
-                <infoLink id="d057-8a85-434c-122b" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="86.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+          <infoLinks>
+            <infoLink id="bf74-899d-3d7a-a152" name="Shugyosha Samurai in Medium Armour" hidden="false" targetId="b417-c06a-ed07-646a" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="86.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="926a-24f3-ebff-ecda" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="2956-9bc2-f4ba-7a8e">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20b2-f45a-e7a4-b159" type="max"/>
@@ -1046,7 +847,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1794-c6f7-8d3b-5b85" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -1055,7 +856,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1071,23 +872,23 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f6a3-f69a-59e3-f5ec" name="Challenge Rule" hidden="false" collective="false">
+        <selectionEntryGroup id="f6a3-f69a-59e3-f5ec" name="Challenge Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ca8-ddcb-f2b2-299a" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="124a-9360-be12-5dac" name="Give Shugyosha Challenge Rule" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="124a-9360-be12-5dac" name="Challenge" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="b3c2-bf15-13d1-8d2f" name="Challenge" hidden="false" targetId="bb63-e7db-89cf-19e6" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1097,13 +898,13 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49af-a0b5-02e6-2d80" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="8f87-9feb-0db0-f2e7" name="Zealous Upgrade" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="8f87-9feb-0db0-f2e7" name="Zealous" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="affc-eba7-dedc-0fda" name="Zealous" hidden="false" targetId="45bb-28cf-94fd-f899" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1120,7 +921,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f748-b2f3-0192-a5f4" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1129,7 +930,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1146,7 +947,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8730-23f3-0948-d35a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1155,7 +956,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3571-e988-f78c-7071" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1164,111 +965,44 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="f6fe-faeb-5cc5-9239" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c2e-9fab-4ffb-ff7a" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="5407-e5b7-5f26-3f44" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ba41-bdff-2273-c6e3" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="890d-e762-9ecd-296d" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e376-6ecc-49e5-61ff" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ccd2-a7d0-ffaf-f26f" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9272-2998-fd37-03f1" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="cc74-40e7-9373-085c" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="21d0-876e-7094-1c0a" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7ec3-eb61-4594-cb71" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="b3d4-19ea-0290-e957" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3ad5-9c4a-9d70-ec63" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="6742-e487-2d09-4225" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="93ca-5329-5677-2b61" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="f87e-eedf-7c2b-df2c" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1f45-f4c6-70ab-eac4" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e68b-8444-a4ef-bf6b" name="Mounted Shugyosha Samurai Hero [102 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="9098-0d4f-890b-efb0" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="8086-28f6-7842-77f2" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
-        <categoryLink id="1a9b-1ba3-f600-58cd" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
+        <categoryLink id="e646-9e69-789c-35a9" name="Mounted Unit" hidden="false" targetId="mounted unit" primary="false"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="1ae1-1dcd-4219-dbed" name="Shugyosha Samurai Hero" hidden="false" collective="false" defaultSelectionEntryId="22d4-c10f-a28f-1313">
+      <selectionEntries>
+        <selectionEntry id="4456-4e2c-e629-d519" name="Shugyosha Samurai Hero" hidden="false" collective="false" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdb1-2058-eaaa-5bd6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dbd-bf48-1438-93dc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a463-0b71-c23a-073b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2b8-fd33-8242-10ae" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="22d4-c10f-a28f-1313" name="Shugyosha Samurai Hero" hidden="false" collective="false" type="model">
-              <infoLinks>
-                <infoLink id="c8e7-2ec9-890f-f7f8" name="Shugyosha Samurai riding Warhorse" hidden="false" targetId="2e18-17d8-b6b3-325a" type="profile"/>
-                <infoLink id="8dee-3b8e-fe0e-5a4f" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="102.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+          <infoLinks>
+            <infoLink id="a5f8-f371-38a1-a30b" name="Shugyosha Samurai riding Warhorse" hidden="false" targetId="2e18-17d8-b6b3-325a" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="102.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="6e43-9517-82b7-7e4d" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="9193-93e4-feab-28d5">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72e2-f647-8497-e862" type="max"/>
@@ -1281,7 +1015,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="351a-6a60-7bc6-ffbe" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -1290,7 +1024,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1306,23 +1040,23 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6dac-ceab-79a7-1894" name="Challenge Rule" hidden="false" collective="false">
+        <selectionEntryGroup id="6dac-ceab-79a7-1894" name="Challenge Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31df-371c-8582-cf35" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="89c6-2738-f302-c626" name="Give Shugyosha Challenge Rule" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="89c6-2738-f302-c626" name="Challenge" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="802d-e207-28ba-9849" name="Challenge" hidden="false" targetId="bb63-e7db-89cf-19e6" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1332,13 +1066,13 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="577c-bbfa-85a8-cdcb" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ca24-fc5e-d5e8-ce0a" name="Zealous Upgrade" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ca24-fc5e-d5e8-ce0a" name="Zealous" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="2d94-dcf8-3172-8a7c" name="Zealous" hidden="false" targetId="45bb-28cf-94fd-f899" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1355,7 +1089,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="056d-0c5f-5cf7-a315" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1364,7 +1098,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1381,7 +1115,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7997-bc4e-2b6b-3b98" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1390,7 +1124,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b6c2-7b72-5ec5-9a1b" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1399,7 +1133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1415,112 +1149,46 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="23e7-bb44-0ca7-3be5" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf03-ccbe-dcf9-4a63" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="b355-5801-986a-bbbf" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="fb96-0f40-1fd2-0a56" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="731c-dab1-a71e-7516" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="4c94-be78-d906-d584" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="fd43-90d6-290d-ef03" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="36f1-2cfe-a47a-8fb6" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="cd00-bf56-b285-7e37" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e747-0faa-2c7f-9e9b" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e2f1-0bb4-f6ba-e5d9" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ef89-bc41-5c9b-6267" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="504f-a7ef-5bce-ac65" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="308d-0b59-5e31-a4d0" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f0fb-4ef8-9e23-4a9e" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="848b-8215-378b-2c2f" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="c5ed-aeeb-ff67-6dfd" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7f2c-f65b-b0b8-36b8" name="Ninja Master" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="a618-6952-247c-f4fe" name="Shuriken" hidden="false" targetId="bdba-151e-81e7-3b45" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="f7b7-b384-2f4a-c0ba" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="bc02-dba8-0fd3-6e7c" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="0ea0-30e8-a0b3-9450" name="Ninja Hero" hidden="false" collective="false" defaultSelectionEntryId="98ba-a779-7153-9f68">
+      <selectionEntries>
+        <selectionEntry id="f252-c63f-432b-6409" name="Ninja Hero" hidden="false" collective="false" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89fd-3d1f-f8a2-afb0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ae7-62bb-9214-5e11" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1642-2a9a-4057-36a5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27f3-5fd2-d9f3-3919" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="98ba-a779-7153-9f68" name="Ninja Hero" hidden="false" collective="false" type="model">
-              <infoLinks>
-                <infoLink id="c5ef-b5e4-0977-e45c" name="Ninja Hero" hidden="false" targetId="5190-ed6c-4a96-2f57" type="profile"/>
-                <infoLink id="6d31-ef32-62d0-6e1c" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
-                <infoLink id="dd59-bd00-8a08-5fae" name="Stealthy" hidden="false" targetId="dcb2-de55-1fca-e0a8" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="90.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+          <infoLinks>
+            <infoLink id="2870-ba44-24ed-9008" name="Ninja Hero" hidden="false" targetId="5190-ed6c-4a96-2f57" type="profile"/>
+            <infoLink id="ae3f-e688-849f-8c77" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
+            <infoLink id="8d00-2a6b-0489-c2c5" name="Stealthy" hidden="false" targetId="dcb2-de55-1fca-e0a8" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="90.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="388a-a326-2409-7912" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="d444-a2b1-e8b6-bf12">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dee-d88a-6d8a-de3d" type="max"/>
@@ -1533,7 +1201,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9a30-5c5e-53b0-9668" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -1542,7 +1210,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d94-af99-2da8-28da" name="Nunchaku" hidden="false" collective="false" type="upgrade">
@@ -1551,66 +1219,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="5c87-3a68-06ef-0945" name="Shuriken" hidden="false" collective="false" defaultSelectionEntryId="d77e-62a2-ac86-35de">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94e7-6557-a554-039c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f6e-5edb-c930-97a7" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="d77e-62a2-ac86-35de" name="Shuriken" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="f681-5a48-47e8-f428" name="Shuriken" hidden="false" targetId="bdba-151e-81e7-3b45" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4f49-8739-03a2-b998" name="Ranged Magic Weapons" hidden="false" collective="false" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="9ff2-53a3-8aee-80a9" name="Ranged Magic Weapons" hidden="false" collective="false">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bd5-d8e5-f06c-857b" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="55f7-0281-2beb-d672" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="e37c-1213-98c3-1a3e" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="1174-8132-ab16-30dd" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="1ea0-e725-4539-0b17" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="62bc-c789-1b37-44f1" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-                      <infoLinks>
-                        <infoLink id="d0f9-d1c9-7ce7-54c5" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1626,7 +1235,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1643,7 +1252,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e533-f642-dc71-3c81" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1652,7 +1261,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1669,7 +1278,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a24a-d39a-3f20-6f2e" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1678,7 +1287,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c4b6-84b4-918e-7492" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1687,121 +1296,55 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="0e57-cc74-39a5-8e5e" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e2e-1cdd-6e03-f08c" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="58b0-3616-eceb-91bc" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="cb78-d840-f436-5976" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="aa11-0d76-32f3-777c" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9e70-7659-2383-d9ff" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e346-c654-1d70-3b83" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="fc95-1d36-777c-53f5" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ef29-42d1-7185-ffe4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="8369-23c8-125d-d0e5" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5f66-cb62-5d3c-238f" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="0f9a-a8dc-9014-0fde" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a9a3-5e0b-b50f-e92e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="507f-fcf4-1133-78c9" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0af7-48e5-9db1-2a42" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="9af8-c9b3-2415-590b" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8041-878a-6dea-04a8" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="31fd-5e25-2ed4-b763" name="Mounted Samurai [84 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="b4fc-9df3-673c-e900" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+        <infoLink id="f7f1-b940-4c73-9f55" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="8f03-5707-d029-6d91" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e1f4-2f0e-e9ba-2a89" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="e1f4-2f0e-e9ba-2a89" name="Mounted Samurai" hidden="false" collective="false">
           <selectionEntries>
-            <selectionEntry id="edec-145d-b408-0cdc" name="Samurai Leader" hidden="false" collective="false" type="model">
+            <selectionEntry id="edec-145d-b408-0cdc" name="Mounted Samurai Leader" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="169b-4949-b260-0169" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="056b-affa-cc94-9830" type="min"/>
               </constraints>
               <infoLinks>
-                <infoLink id="63b4-f33a-631a-48dc" name="Sumarai Leader in Medium Armour riding Horse" hidden="false" targetId="5e79-caf2-c029-f9f9" type="profile"/>
-                <infoLink id="488a-6f10-8ffc-adc1" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-                <infoLink id="9302-0406-f258-694b" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+                <infoLink id="63b4-f33a-631a-48dc" name="Mounted Samurai Leader in Medium Armour" hidden="false" targetId="5e79-caf2-c029-f9f9" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="901b-c09b-61cc-63ae" name="Samurai in Medium Armour, Riding Horse" hidden="false" collective="false" type="model">
+            <selectionEntry id="901b-c09b-61cc-63ae" name="Mounted Samurai in Medium Armour" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1e3-b639-ccf4-dd47" type="min"/>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5f0-6e20-42e2-904f" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="2dbb-fb9d-3dff-ed9e" name="Samurai in Medium Armour, riding Horse" hidden="false" targetId="c6f1-5207-c7fa-314f" type="profile"/>
-                <infoLink id="ea23-e290-f5d9-ca0f" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+                <infoLink id="2dbb-fb9d-3dff-ed9e" name="Mounted Samurai in Medium Armour" hidden="false" targetId="c6f1-5207-c7fa-314f" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1818,7 +1361,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b70d-c310-b4d5-5e49" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -1834,7 +1377,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ba89-49b3-040f-f5a3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1843,7 +1386,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1866,7 +1409,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1883,7 +1426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18d2-3baf-34d4-a45a" name="Warhorses" hidden="false" collective="false" type="upgrade">
@@ -1899,7 +1442,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9c4b-c038-8f20-9791" name="Komainu Lion Dog" hidden="false" collective="false" type="upgrade">
@@ -1915,7 +1458,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1923,7 +1466,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bb3d-9040-9441-5630" name="Samurai [92 pts]" hidden="false" collective="false" type="unit">
@@ -1931,7 +1474,7 @@
         <categoryLink id="575f-53f8-d296-0f2e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f0bf-f761-a080-915c" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="f0bf-f761-a080-915c" name="Samurai" publicationId="cffa-cd51-pubN65537" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="932f-73ae-3c60-e8c4" name="Samurai Leader" hidden="false" collective="false" type="model">
               <constraints>
@@ -1944,7 +1487,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8292-905e-eacf-3f11" name="Samurai" hidden="false" collective="false" type="model">
@@ -1957,7 +1500,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1974,7 +1517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98ca-9f39-fa47-b428" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -1983,7 +1526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="16ce-6494-6d8a-d749" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1992,7 +1535,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2015,7 +1558,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2023,7 +1566,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="22be-f604-b5ad-9a31" name="Ashigaru [72 pts]" hidden="false" collective="false" type="unit">
@@ -2031,7 +1574,7 @@
         <categoryLink id="c360-b3f6-4678-78c3" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="4282-f0da-4e26-a322" name="Models" hidden="false" collective="false" defaultSelectionEntryId="b4c1-7cfd-2434-c172">
+        <selectionEntryGroup id="4282-f0da-4e26-a322" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="b4c1-7cfd-2434-c172">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50ad-c331-2bab-e174" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f77b-a360-c8ae-0b81" type="min"/>
@@ -2051,7 +1594,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4b63-9ddb-aa8d-d54f" name="Ashigaru leader in Light Armour" hidden="false" collective="false" type="model">
@@ -2065,7 +1608,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2073,7 +1616,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15ce-09d4-fe6e-5e5f" name="Ashigaru in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2091,7 +1634,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="aded-c528-a496-f3ee" name="Ashigaru in Medium Armour" hidden="false" collective="false" type="model">
@@ -2104,7 +1647,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2112,7 +1655,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2129,7 +1672,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd4b-f302-ca7e-afd5" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -2138,7 +1681,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10a5-df23-edf6-f695" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -2147,7 +1690,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3cc-ece7-a0af-5d25" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2156,7 +1699,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="baba-94bb-27e3-7cf4" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -2172,7 +1715,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2180,7 +1723,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="089f-9e45-d225-bd30" name="Archers [72 pts]" hidden="false" collective="false" type="unit">
@@ -2191,7 +1734,7 @@
         <categoryLink id="92d8-b950-a376-de73" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="75fb-a60a-6535-d1d6" name="Models" hidden="false" collective="false" defaultSelectionEntryId="3254-d6c1-1efc-0bf7">
+        <selectionEntryGroup id="75fb-a60a-6535-d1d6" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="3254-d6c1-1efc-0bf7">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc9e-dd74-d0d5-ebad" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c1a-b562-0dbe-a3b1" type="min"/>
@@ -2211,7 +1754,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5e06-6932-d177-a733" name="Archer Leader" hidden="false" collective="false" type="model">
@@ -2225,7 +1768,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2233,7 +1776,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0d80-a67d-5432-4ae2" name="Archers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2251,7 +1794,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ab2d-cc42-d12c-26ca" name="Archers in Light Armour" hidden="false" collective="false" type="model">
@@ -2264,7 +1807,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2272,7 +1815,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2026-4800-3eda-e2bc" name="Archers in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2290,7 +1833,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f180-a9c8-efd8-7cb0" name="Archers in Medium Armour" hidden="false" collective="false" type="model">
@@ -2303,7 +1846,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2311,7 +1854,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2328,7 +1871,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f22b-285a-e598-51cb" name="Long Bows" hidden="false" collective="false" type="upgrade">
@@ -2344,7 +1887,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2352,7 +1895,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e5d4-364a-44f3-cf24" name="Bandits and Brigands [57 pts]" hidden="false" collective="false" type="unit">
@@ -2360,7 +1903,7 @@
         <categoryLink id="169b-796b-2654-f929" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b054-2efd-bb6e-b3e0" name="Models" hidden="false" collective="false">
+        <selectionEntryGroup id="b054-2efd-bb6e-b3e0" name="Bandits" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="1457-eaf9-c6f4-670e" name="Bandit Leader" hidden="false" collective="false" type="model">
               <constraints>
@@ -2373,7 +1916,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b4c-b0c8-dada-e057" name="Bandits" hidden="false" collective="false" type="model">
@@ -2386,7 +1929,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2403,7 +1946,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="905b-f9d4-3c69-ba64" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -2414,9 +1957,12 @@
                   </repeats>
                 </modifier>
               </modifiers>
+              <infoLinks>
+                <infoLink id="d871-cc70-7d8e-4234" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2424,19 +1970,20 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b6af-603d-a7c3-a000" name="Tanigashima Men [82 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="4471-f073-f2b8-3b50" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="65c2-1d0c-f1f2-4588" name="Hand Gun" hidden="false" targetId="4d4a-8ee3-260b-037b" type="profile"/>
+        <infoLink id="ae9d-4166-c941-55c9" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0c5d-6dcf-edea-d87b" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="cd39-4eca-a1e2-54d8" name="Models" hidden="false" collective="false" defaultSelectionEntryId="582a-7ed3-57e9-ee2b">
+        <selectionEntryGroup id="cd39-4eca-a1e2-54d8" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="582a-7ed3-57e9-ee2b">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd41-0735-db0d-1bb6" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fe1-113f-f033-39a2" type="min"/>
@@ -2457,7 +2004,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="45de-4e3a-f176-f907" name="Tanigashima Men" hidden="false" collective="false" type="model">
@@ -2470,7 +2017,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2478,7 +2025,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6851-781e-698a-2c66" name="Tanigashima Men in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2496,7 +2043,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3782-3b8f-fac6-8ad3" name="Tanigashima Men in Light Armour" hidden="false" collective="false" type="model">
@@ -2509,7 +2056,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2517,7 +2064,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d09e-f0ab-d4ea-f144" name="Tanigashima Men in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2535,7 +2082,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9ccb-08b0-1c51-6d9a" name="Tanigashima Men in Medium Armour" hidden="false" collective="false" type="model">
@@ -2548,7 +2095,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2556,17 +2103,17 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1f52-0f8b-7236-6372" name="Pavisse Upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="1f52-0f8b-7236-6372" name="Pavise Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5a2-d6ef-e4db-8586" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="39b1-6e32-80bd-1621" name="Give Unit Pavisse Rule" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="39b1-6e32-80bd-1621" name="Pavise" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
@@ -2579,7 +2126,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2587,7 +2134,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6e1d-4700-e35d-cfd5" name="Onna Bugeisha [62 pts]" hidden="false" collective="false" type="unit">
@@ -2595,7 +2142,7 @@
         <categoryLink id="6d9a-27a2-cefa-294e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6b95-328c-8de8-47cc" name="Models" hidden="false" collective="false" defaultSelectionEntryId="afae-9649-8860-f72f">
+        <selectionEntryGroup id="6b95-328c-8de8-47cc" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="afae-9649-8860-f72f">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c82d-3f4a-ab47-389c" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5b4-bc3d-055b-fb92" type="min"/>
@@ -2616,7 +2163,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1c66-5212-72da-61ad" name="Onna Bugeisha" hidden="false" collective="false" type="model">
@@ -2629,7 +2176,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2637,7 +2184,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="65a9-2013-ba5b-0544" name="Onna Bugeisha in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2655,7 +2202,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a14f-9a1a-0d0f-0c48" name="Onna Bugeisha" hidden="false" collective="false" type="model">
@@ -2668,7 +2215,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2676,7 +2223,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ceb0-5d4c-cf72-146f" name="Onna Bugeisha in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2694,7 +2241,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b4a3-dd78-e08d-71e0" name="Onna Bugeisha" hidden="false" collective="false" type="model">
@@ -2707,7 +2254,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2715,7 +2262,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2738,7 +2285,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2755,7 +2302,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2dfe-9d67-dc0c-700c" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -2764,7 +2311,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a65-1140-9a0e-3211" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -2773,7 +2320,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2781,7 +2328,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1f70-b03f-149b-186e" name="Sohei Warrior Monks [132 pts]" hidden="false" collective="false" type="unit">
@@ -2792,7 +2339,7 @@
         <categoryLink id="d8ed-e745-c173-8535" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f69d-7466-0528-1aad" name="Models" hidden="false" collective="false" defaultSelectionEntryId="b3d7-1b7d-50ee-0764">
+        <selectionEntryGroup id="f69d-7466-0528-1aad" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="b3d7-1b7d-50ee-0764">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6d4-9857-4935-d6d8" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2057-24c8-6b8f-8cec" type="max"/>
@@ -2814,7 +2361,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6242-6196-3635-234a" name="Monk" hidden="false" collective="false" type="model">
@@ -2827,7 +2374,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2835,7 +2382,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5182-3b4d-5c05-d639" name="Sohei Warrior Monks in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2854,7 +2401,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a395-4204-301a-e701" name="Monk in Light Armour" hidden="false" collective="false" type="model">
@@ -2867,7 +2414,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2875,7 +2422,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2898,7 +2445,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2915,7 +2462,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aecf-1199-89fa-8e81" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -2931,7 +2478,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2947,7 +2494,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2955,10 +2502,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e1ed-3a13-14a6-97e1" name="Ninja [205 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="234d-267f-92d8-a9a5" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="9380-11e5-3228-2fe8" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -2977,7 +2527,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="41.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2994,7 +2544,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b61d-53a5-92f9-e423" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -3003,7 +2553,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99ae-9cdf-f1d4-5c86" name="Nunchaku" hidden="false" collective="false" type="upgrade">
@@ -3012,7 +2562,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3025,7 +2575,7 @@
             <selectionEntry id="0256-06e0-6d14-9543" name="Dead Eye Shot" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3033,7 +2583,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7909-8c75-a592-8775" name="Oni Ogres [26 pts]" hidden="false" collective="false" type="unit">
@@ -3055,7 +2605,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="26.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3063,13 +2613,17 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1d8c-7e0b-a8ed-d1f8" name="Tengu Birdmen [144 pts]" hidden="false" collective="false" type="unit">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cd5-05ab-10ff-2d4d" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="20cd-9bb3-2007-3226" name="Fast 10" hidden="false" targetId="0034-82ae-f695-d446" type="rule"/>
+        <infoLink id="e9ab-9ab7-df33-b7cc" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="cd61-7c10-ea88-179a" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
       </categoryLinks>
@@ -3083,12 +2637,10 @@
               </constraints>
               <infoLinks>
                 <infoLink id="1e89-0779-b497-4853" name="Tengu Birdmen" hidden="false" targetId="399f-09b5-deab-9753" type="profile"/>
-                <infoLink id="28e3-1962-7e06-79a8" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-                <infoLink id="e28a-538d-a64e-5778" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="48.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3096,25 +2648,27 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e383-a41b-2f88-a302" name="Cannon [77 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="c2c5-5480-a49b-b56c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="c8e6-56fc-bd9c-e4a6" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+        <infoLink id="c8e6-56fc-bd9c-e4a6" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="8141-003c-a3c6-c20f" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+        <infoLink id="77ff-2aec-bb7d-d559" name="Unstoppable" hidden="false" targetId="a8bf-f48c-1b08-58e6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="b1f4-8682-da7d-3e64" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="059c-d402-accf-cdfa" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="6256-5eab-2688-7b4d">
+        <selectionEntryGroup id="059c-d402-accf-cdfa" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="6256-5eab-2688-7b4d">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de54-c09c-2b7c-c5f6" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="254e-7814-231f-350b" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6256-5eab-2688-7b4d" name="Cannon Crew" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6256-5eab-2688-7b4d" name="Cannon Crew (no armour)" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
                 <selectionEntryGroup id="e9d6-d819-74b9-60e5" name="Cannon Crew" hidden="false" collective="false" defaultSelectionEntryId="2822-aef7-23bd-a504">
                   <selectionEntries>
@@ -3128,7 +2682,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3136,7 +2690,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b739-d5bd-1fee-5dfe" name="Cannon Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -3153,7 +2707,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3161,7 +2715,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3178,7 +2732,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b326-65e6-9101-d76a" name="Large Cannon" hidden="false" collective="false" type="upgrade">
@@ -3187,7 +2741,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="100.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3204,7 +2758,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="64d7-3af3-84c4-f050" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -3220,7 +2774,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3228,25 +2782,26 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1be0-ddf4-8aab-f6fb" name="Bolt Thrower [69 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="7f5c-a1d5-0ec7-97d8" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-        <infoLink id="010a-8f61-8e05-8247" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+        <infoLink id="010a-8f61-8e05-8247" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+        <infoLink id="763e-c3ce-4c48-bbc4" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5e95-289a-ed59-5283" name="New CategoryLink" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="99cd-f1cf-9d54-b3c2" name="Crew" hidden="false" collective="false" defaultSelectionEntryId="d7d6-6eab-30eb-6155">
+        <selectionEntryGroup id="99cd-f1cf-9d54-b3c2" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="d7d6-6eab-30eb-6155">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0180-f804-5946-9a5d" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2582-0591-573a-2f06" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="d7d6-6eab-30eb-6155" name="Bolt Thrower Crew" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d7d6-6eab-30eb-6155" name="Crew (no armour)" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
                 <selectionEntryGroup id="0d23-57f2-5622-3b32" name="Bolt Thrower Crew" hidden="false" collective="false" defaultSelectionEntryId="a9e3-4cea-40a1-f4ef">
                   <selectionEntries>
@@ -3260,7 +2815,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3268,10 +2823,10 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d6ee-ab3a-fc3b-61bb" name="Bolt Thrower Crew in Light Armour" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d6ee-ab3a-fc3b-61bb" name="Crew in Light Armour" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
                 <selectionEntryGroup id="c38c-ef79-dc95-b8e2" name="Bolt Thrower Crew in Light Armour" hidden="false" collective="false" defaultSelectionEntryId="5ce2-e93a-6c6a-bec2">
                   <selectionEntries>
@@ -3285,7 +2840,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3293,7 +2848,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3310,16 +2865,17 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="376f-b959-1f8b-048c" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="9889-8df6-c664-92cf" name="Large Bolt Thrower" hidden="false" targetId="fbdf-a3cf-f1d1-8d05" type="profile"/>
+                <infoLink id="21c5-ed40-c88f-d81e" name="Unstoppable" hidden="false" targetId="a8bf-f48c-1b08-58e6" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3336,7 +2892,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bfb3-da1d-bfeb-29f8" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -3352,7 +2908,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3360,7 +2916,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -3387,7 +2943,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Stubborn</characteristic>
       </characteristics>
     </profile>
-    <profile id="0855-8b9c-bf29-ae09" name="Daimyo in Medium Armour Riding Horse" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="0855-8b9c-bf29-ae09" name="Mounted Daimyo in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3398,7 +2954,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Stubborn, Command, Follow, Fast 8, 3xHtH, Wound X</characteristic>
       </characteristics>
     </profile>
-    <profile id="a14e-c2d6-913c-3043" name="Hatamoto in Medium Armour riding Horses" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="a14e-c2d6-913c-3043" name="Mounted Hatamoto in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3464,7 +3020,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, Wound X, 3xHtH</characteristic>
       </characteristics>
     </profile>
-    <profile id="2e18-17d8-b6b3-325a" name="Shugyosha Samurai riding Warhorse" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="2e18-17d8-b6b3-325a" name="Mounted Shugyosha Samurai" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">6</characteristic>
@@ -3497,7 +3053,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Hero, Stealthy, 3xHtH, 3xRanged, Wound X</characteristic>
       </characteristics>
     </profile>
-    <profile id="5e79-caf2-c029-f9f9" name="Sumarai Leader in Medium Armour riding Horse" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="5e79-caf2-c029-f9f9" name="Mounted Samurai Leader in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -3508,7 +3064,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Fast 8</characteristic>
       </characteristics>
     </profile>
-    <profile id="c6f1-5207-c7fa-314f" name="Samurai in Medium Armour, riding Horse" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="c6f1-5207-c7fa-314f" name="Mounted Samurai in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>

--- a/Samurai.cat
+++ b/Samurai.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cd5c-e29b-080c-a69e" name="Samurai" revision="1" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cd5c-e29b-080c-a69e" name="Samurai" revision="2" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="c5fa-527f-fedb-136a" name="Daimyo [122 pts]" hidden="false" collective="false" targetId="7fb8-4fba-65cf-e467" type="selectionEntry"/>
     <entryLink id="b6d4-f3c3-3e38-5d65" name="Mounted Daimyo [148 pts]" hidden="false" collective="false" targetId="0548-5344-d38b-832f" type="selectionEntry"/>
@@ -23,6 +23,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="7fb8-4fba-65cf-e467" name="Daimyo [122 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="81f7-207f-45d2-8f06" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="5543-f077-9866-f35e" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -43,6 +46,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="82.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2ffa-dd56-9dbb-9292" name="Hatamoto in Medium Armour" hidden="false" collective="false" type="model">
@@ -56,6 +60,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -72,6 +77,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="64e5-82ab-15c9-27ca" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -80,6 +86,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -102,6 +109,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -118,6 +126,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a68a-d549-1683-96ad" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -126,6 +135,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -142,6 +152,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ed5-24ab-e29a-63d5" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -150,6 +161,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -165,6 +177,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b130-152b-8d88-540d" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -173,6 +186,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ca34-f5ca-7900-41ea" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -181,6 +195,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2bd8-54ae-2611-ea75" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -189,6 +204,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a24a-a202-55ae-c619" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -197,6 +213,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed19-e0da-7718-3fc9" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -205,6 +222,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4bfb-5f0f-9fd0-5f1a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -213,6 +231,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -220,9 +239,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0548-5344-d38b-832f" name="Mounted Daimyo [148 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="ce0b-f83a-5bf8-64ed" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="924a-1841-50b3-a873" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -244,6 +267,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="92.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e961-aed5-86ff-36f5" name="Hatamoto in Medium Armour" hidden="false" collective="false" type="model">
@@ -257,6 +281,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -273,6 +298,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6def-f70c-a5b5-ee79" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -288,6 +314,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -310,6 +337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -326,6 +354,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7569-fd57-75ec-1057" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -334,6 +363,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -350,6 +380,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3e19-a6dd-d4d1-d33b" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -358,6 +389,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -380,6 +412,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -395,6 +428,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36eb-5f78-dd0a-3d38" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -403,6 +437,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3f3-62cb-01c4-9da2" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -411,6 +446,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a742-298f-dc07-47f5" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -419,6 +455,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="899a-194d-daf5-9cf6" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -427,6 +464,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1d75-a72c-373c-49b0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -435,6 +473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c35-88d0-3079-48b5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -443,6 +482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -450,9 +490,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="546c-46ef-b4dc-cd2b" name="Onmyoji Diviner [55 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="c09c-2897-57eb-57ee" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
       </categoryLinks>
@@ -470,6 +514,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="55.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -493,6 +538,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -500,6 +546,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="485c-3d06-ba24-6414" name="Shikigami Spirits" hidden="false" collective="false" type="upgrade">
@@ -516,6 +563,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -523,6 +571,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -539,6 +588,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbc9-109a-63b1-8805" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -547,6 +597,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c53-f753-4142-a72d" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -555,6 +606,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -571,6 +623,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f36e-0a3f-20b4-5adf" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -579,6 +632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dbda-bc2e-bb8f-948e" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -587,6 +641,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ed0-9666-8d85-e1a7" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -595,6 +650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0fb-4705-18a8-5d02" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -603,6 +659,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4bae-cc91-9e78-524e" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -611,6 +668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3cbf-796e-d8b6-6b92" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -619,6 +677,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3991-b7a1-3bf5-60a3" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -627,6 +686,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e466-c37a-c655-3836" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -635,6 +695,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0340-ff1a-86f4-a7aa" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -643,6 +704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffec-13fb-3d10-039f" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -651,6 +713,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7904-d2de-a7ed-80ee" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -659,6 +722,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0404-a5d8-62e0-3ab3" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -667,6 +731,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="70ad-7356-732b-8f5f" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -675,6 +740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -690,6 +756,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f566-eb33-32e3-fcd7" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -701,6 +768,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="726f-992e-1660-87c6" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -712,6 +780,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="961c-d934-e42b-c125" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -723,6 +792,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7678-30bd-736b-fcf6" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -734,6 +804,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db5c-e878-75cb-b8ee" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -745,6 +816,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6d9a-53e9-7e75-6284" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -756,6 +828,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cb1a-d65c-e142-ce14" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -767,6 +840,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f91-ea51-050c-1dda" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -778,6 +852,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dae4-658a-9bf1-706d" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -789,6 +864,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53f1-4225-e57a-ab5a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -800,6 +876,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a33-d1c7-14d1-af87" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -811,6 +888,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f931-dbf8-e8af-2cd9" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -822,6 +900,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="97d6-71f6-b81f-b0af" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -833,6 +912,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -849,6 +929,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7eb0-c108-3e57-1ec2" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -857,6 +938,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -872,6 +954,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e60f-38e7-8369-36f1" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -880,6 +963,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5b58-9cd4-b8ba-2c2f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -888,6 +972,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b5a-399d-e4c2-c522" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -896,6 +981,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="afdc-15fd-a801-954d" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -904,6 +990,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6283-6f87-8311-69a0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -912,6 +999,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b631-45bc-a75d-564e" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -920,6 +1008,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -927,9 +1016,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1070-fe2d-2e93-c2c1" name="Shugyosha Samurai Hero [86 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="cf0a-92c4-c92a-a65b" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="8297-f0f5-d62d-f2d4" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -948,6 +1041,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -964,6 +1058,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1794-c6f7-8d3b-5b85" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -972,6 +1067,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -987,6 +1083,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1002,6 +1099,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1017,6 +1115,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1033,6 +1132,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f748-b2f3-0192-a5f4" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1041,6 +1141,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1057,6 +1158,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8730-23f3-0948-d35a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1065,6 +1167,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3571-e988-f78c-7071" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1073,6 +1176,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1088,6 +1192,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="890d-e762-9ecd-296d" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1096,6 +1201,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ccd2-a7d0-ffaf-f26f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1104,6 +1210,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cc74-40e7-9373-085c" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1112,6 +1219,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7ec3-eb61-4594-cb71" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1120,6 +1228,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3ad5-9c4a-9d70-ec63" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1128,6 +1237,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="93ca-5329-5677-2b61" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1136,6 +1246,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1143,9 +1254,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e68b-8444-a4ef-bf6b" name="Mounted Shugyosha Samurai Hero [102 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="8086-28f6-7842-77f2" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="1a9b-1ba3-f600-58cd" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1164,6 +1279,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="102.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1180,6 +1296,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="351a-6a60-7bc6-ffbe" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -1188,6 +1305,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1203,6 +1321,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1218,6 +1337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1233,6 +1353,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1249,6 +1370,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="056d-0c5f-5cf7-a315" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1257,6 +1379,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1273,6 +1396,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7997-bc4e-2b6b-3b98" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1281,6 +1405,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b6c2-7b72-5ec5-9a1b" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1289,6 +1414,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1304,6 +1430,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1319,6 +1446,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="731c-dab1-a71e-7516" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1327,6 +1455,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fd43-90d6-290d-ef03" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1335,6 +1464,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd00-bf56-b285-7e37" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1343,6 +1473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e2f1-0bb4-f6ba-e5d9" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1351,6 +1482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="504f-a7ef-5bce-ac65" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1359,6 +1491,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f0fb-4ef8-9e23-4a9e" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1367,6 +1500,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1374,9 +1508,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7f2c-f65b-b0b8-36b8" name="Ninja Master" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="f7b7-b384-2f4a-c0ba" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="bc02-dba8-0fd3-6e7c" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1396,6 +1534,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="90.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1412,6 +1551,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9a30-5c5e-53b0-9668" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -1420,6 +1560,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d94-af99-2da8-28da" name="Nunchaku" hidden="false" collective="false" type="upgrade">
@@ -1428,6 +1569,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1444,6 +1586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4f49-8739-03a2-b998" name="Ranged Magic Weapons" hidden="false" collective="false" type="upgrade">
@@ -1459,6 +1602,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1174-8132-ab16-30dd" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1467,6 +1611,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="62bc-c789-1b37-44f1" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1475,6 +1620,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1482,6 +1628,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1497,6 +1644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1513,6 +1661,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e533-f642-dc71-3c81" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1521,6 +1670,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1537,6 +1687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a24a-d39a-3f20-6f2e" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1545,6 +1696,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c4b6-84b4-918e-7492" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1553,6 +1705,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1568,6 +1721,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa11-0d76-32f3-777c" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1576,6 +1730,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e346-c654-1d70-3b83" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1584,6 +1739,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ef29-42d1-7185-ffe4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1592,6 +1748,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5f66-cb62-5d3c-238f" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1600,6 +1757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9a3-5e0b-b50f-e92e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1608,6 +1766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0af7-48e5-9db1-2a42" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1616,6 +1775,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1623,9 +1783,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="31fd-5e25-2ed4-b763" name="Mounted Samurai [84 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="8f03-5707-d029-6d91" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
@@ -1644,6 +1808,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="901b-c09b-61cc-63ae" name="Samurai in Medium Armour, Riding Horse" hidden="false" collective="false" type="model">
@@ -1657,6 +1822,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1673,6 +1839,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b70d-c310-b4d5-5e49" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -1688,6 +1855,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ba89-49b3-040f-f5a3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1696,6 +1864,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1718,6 +1887,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1734,6 +1904,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18d2-3baf-34d4-a45a" name="Warhorses" hidden="false" collective="false" type="upgrade">
@@ -1749,6 +1920,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9c4b-c038-8f20-9791" name="Komainu Lion Dog" hidden="false" collective="false" type="upgrade">
@@ -1764,6 +1936,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1771,9 +1944,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bb3d-9040-9441-5630" name="Samurai [92 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="575f-53f8-d296-0f2e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1791,6 +1968,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8292-905e-eacf-3f11" name="Samurai" hidden="false" collective="false" type="model">
@@ -1803,6 +1981,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1819,6 +1998,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98ca-9f39-fa47-b428" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -1827,6 +2007,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="16ce-6494-6d8a-d749" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1835,6 +2016,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1857,6 +2039,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1864,9 +2047,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="22be-f604-b5ad-9a31" name="Ashigaru [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="c360-b3f6-4678-78c3" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1891,6 +2078,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4b63-9ddb-aa8d-d54f" name="Ashigaru leader in Light Armour" hidden="false" collective="false" type="model">
@@ -1904,6 +2092,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1911,6 +2100,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15ce-09d4-fe6e-5e5f" name="Ashigaru in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -1928,6 +2118,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="aded-c528-a496-f3ee" name="Ashigaru in Medium Armour" hidden="false" collective="false" type="model">
@@ -1940,6 +2131,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1947,6 +2139,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1963,6 +2156,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd4b-f302-ca7e-afd5" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -1971,6 +2165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10a5-df23-edf6-f695" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1979,6 +2174,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3cc-ece7-a0af-5d25" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -1987,6 +2183,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="baba-94bb-27e3-7cf4" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -2002,6 +2199,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2009,9 +2207,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="089f-9e45-d225-bd30" name="Archers [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="613e-0dc7-1357-e520" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
@@ -2039,6 +2241,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5e06-6932-d177-a733" name="Archer Leader" hidden="false" collective="false" type="model">
@@ -2052,6 +2255,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2059,6 +2263,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0d80-a67d-5432-4ae2" name="Archers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2076,6 +2281,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ab2d-cc42-d12c-26ca" name="Archers in Light Armour" hidden="false" collective="false" type="model">
@@ -2088,6 +2294,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2095,6 +2302,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2026-4800-3eda-e2bc" name="Archers in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2112,6 +2320,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f180-a9c8-efd8-7cb0" name="Archers in Medium Armour" hidden="false" collective="false" type="model">
@@ -2124,6 +2333,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2131,6 +2341,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2147,6 +2358,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f22b-285a-e598-51cb" name="Long Bows" hidden="false" collective="false" type="upgrade">
@@ -2162,6 +2374,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2169,9 +2382,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e5d4-364a-44f3-cf24" name="Bandits and Brigands [57 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="169b-796b-2654-f929" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -2189,6 +2406,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b4c-b0c8-dada-e057" name="Bandits" hidden="false" collective="false" type="model">
@@ -2201,6 +2419,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2217,6 +2436,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="905b-f9d4-3c69-ba64" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -2229,6 +2449,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2236,9 +2457,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b6af-603d-a7c3-a000" name="Tanigashima Men [82 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="4471-f073-f2b8-3b50" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="65c2-1d0c-f1f2-4588" name="Hand Gun" hidden="false" targetId="4d4a-8ee3-260b-037b" type="profile"/>
@@ -2268,6 +2493,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="45de-4e3a-f176-f907" name="Tanigashima Men" hidden="false" collective="false" type="model">
@@ -2280,6 +2506,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2287,6 +2514,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6851-781e-698a-2c66" name="Tanigashima Men in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2304,6 +2532,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3782-3b8f-fac6-8ad3" name="Tanigashima Men in Light Armour" hidden="false" collective="false" type="model">
@@ -2316,6 +2545,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2323,6 +2553,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d09e-f0ab-d4ea-f144" name="Tanigashima Men in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2340,6 +2571,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9ccb-08b0-1c51-6d9a" name="Tanigashima Men in Medium Armour" hidden="false" collective="false" type="model">
@@ -2352,6 +2584,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2359,6 +2592,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2381,6 +2615,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2388,9 +2623,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6e1d-4700-e35d-cfd5" name="Onna Bugeisha [62 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="6d9a-27a2-cefa-294e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -2416,6 +2655,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1c66-5212-72da-61ad" name="Onna Bugeisha" hidden="false" collective="false" type="model">
@@ -2428,6 +2668,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2435,6 +2676,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="65a9-2013-ba5b-0544" name="Onna Bugeisha in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2452,6 +2694,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a14f-9a1a-0d0f-0c48" name="Onna Bugeisha" hidden="false" collective="false" type="model">
@@ -2464,6 +2707,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2471,6 +2715,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ceb0-5d4c-cf72-146f" name="Onna Bugeisha in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2488,6 +2733,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b4a3-dd78-e08d-71e0" name="Onna Bugeisha" hidden="false" collective="false" type="model">
@@ -2500,6 +2746,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2507,6 +2754,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2529,6 +2777,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2545,6 +2794,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2dfe-9d67-dc0c-700c" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -2553,6 +2803,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a65-1140-9a0e-3211" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -2561,6 +2812,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2568,9 +2820,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1f70-b03f-149b-186e" name="Sohei Warrior Monks [132 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3836-3c5c-250b-1f2a" type="max"/>
       </constraints>
@@ -2600,6 +2856,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6242-6196-3635-234a" name="Monk" hidden="false" collective="false" type="model">
@@ -2612,6 +2869,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2619,6 +2877,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5182-3b4d-5c05-d639" name="Sohei Warrior Monks in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2637,6 +2896,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a395-4204-301a-e701" name="Monk in Light Armour" hidden="false" collective="false" type="model">
@@ -2649,6 +2909,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2656,6 +2917,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2678,6 +2940,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2694,6 +2957,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aecf-1199-89fa-8e81" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -2709,6 +2973,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2724,6 +2989,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2731,9 +2997,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e1ed-3a13-14a6-97e1" name="Ninja [205 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9380-11e5-3228-2fe8" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -2752,6 +3022,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="41.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2768,6 +3039,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b61d-53a5-92f9-e423" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -2776,6 +3048,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99ae-9cdf-f1d4-5c86" name="Nunchaku" hidden="false" collective="false" type="upgrade">
@@ -2784,6 +3057,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2796,6 +3070,7 @@
             <selectionEntry id="0256-06e0-6d14-9543" name="Dead Eye Shot" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2803,9 +3078,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7909-8c75-a592-8775" name="Oni Ogres [26 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="be43-3d07-54a4-cf38" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -2824,6 +3103,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="26.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2831,9 +3111,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1d8c-7e0b-a8ed-d1f8" name="Tengu Birdmen [144 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cd5-05ab-10ff-2d4d" type="max"/>
       </constraints>
@@ -2855,6 +3139,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="48.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2862,9 +3147,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e383-a41b-2f88-a302" name="Cannon [77 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="c2c5-5480-a49b-b56c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="c8e6-56fc-bd9c-e4a6" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -2893,6 +3182,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2900,6 +3190,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b739-d5bd-1fee-5dfe" name="Cannon Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2916,6 +3207,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2923,6 +3215,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2939,6 +3232,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b326-65e6-9101-d76a" name="Large Cannon" hidden="false" collective="false" type="upgrade">
@@ -2947,6 +3241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="100.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2963,6 +3258,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="64d7-3af3-84c4-f050" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -2978,6 +3274,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2985,9 +3282,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1be0-ddf4-8aab-f6fb" name="Bolt Thrower [69 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="7f5c-a1d5-0ec7-97d8" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="010a-8f61-8e05-8247" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -3016,6 +3317,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3023,6 +3325,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d6ee-ab3a-fc3b-61bb" name="Bolt Thrower Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -3039,6 +3342,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3046,6 +3350,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3062,6 +3367,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="376f-b959-1f8b-048c" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -3070,6 +3376,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3086,6 +3393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bfb3-da1d-bfeb-29f8" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -3101,6 +3409,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3108,6 +3417,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -3420,7 +3730,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="6dcf-b813-589c-27e8" name="Mixed Arms" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="6dcf-b813-589c-27e8" name="Mixed Arms" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR</characteristic>

--- a/Samurai.cat
+++ b/Samurai.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="cd5c-e29b-080c-a69e" name="Samurai" revision="2" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="cd5c-e29b-080c-a69e" name="Samurai" revision="3" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="c5fa-527f-fedb-136a" name="Daimyo [122 pts]" hidden="false" collective="false" targetId="7fb8-4fba-65cf-e467" type="selectionEntry"/>
     <entryLink id="b6d4-f3c3-3e38-5d65" name="Mounted Daimyo [148 pts]" hidden="false" collective="false" targetId="0548-5344-d38b-832f" type="selectionEntry"/>
@@ -23,9 +23,6 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="7fb8-4fba-65cf-e467" name="Daimyo [122 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="81f7-207f-45d2-8f06" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="5543-f077-9866-f35e" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -46,7 +43,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="82.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2ffa-dd56-9dbb-9292" name="Hatamoto in Medium Armour" hidden="false" collective="false" type="model">
@@ -60,7 +57,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -77,7 +74,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="64e5-82ab-15c9-27ca" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -86,7 +83,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -109,7 +106,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -126,7 +123,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a68a-d549-1683-96ad" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -135,7 +132,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -152,7 +149,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9ed5-24ab-e29a-63d5" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -161,7 +158,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -177,7 +174,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b130-152b-8d88-540d" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -186,7 +183,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ca34-f5ca-7900-41ea" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -195,7 +192,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2bd8-54ae-2611-ea75" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -204,7 +201,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a24a-a202-55ae-c619" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -213,7 +210,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed19-e0da-7718-3fc9" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -222,7 +219,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4bfb-5f0f-9fd0-5f1a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -231,7 +228,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -239,13 +236,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0548-5344-d38b-832f" name="Mounted Daimyo [148 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="ce0b-f83a-5bf8-64ed" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="924a-1841-50b3-a873" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -267,7 +261,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="92.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e961-aed5-86ff-36f5" name="Hatamoto in Medium Armour" hidden="false" collective="false" type="model">
@@ -281,7 +275,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -298,7 +292,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6def-f70c-a5b5-ee79" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -314,7 +308,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -337,7 +331,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -354,7 +348,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7569-fd57-75ec-1057" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -363,7 +357,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -380,7 +374,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3e19-a6dd-d4d1-d33b" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -389,7 +383,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -412,7 +406,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -428,7 +422,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="36eb-5f78-dd0a-3d38" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -437,7 +431,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3f3-62cb-01c4-9da2" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -446,7 +440,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a742-298f-dc07-47f5" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -455,7 +449,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="899a-194d-daf5-9cf6" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -464,7 +458,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1d75-a72c-373c-49b0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -473,7 +467,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3c35-88d0-3079-48b5" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -482,7 +476,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -490,13 +484,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="546c-46ef-b4dc-cd2b" name="Onmyoji Diviner [55 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="c09c-2897-57eb-57ee" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
       </categoryLinks>
@@ -514,7 +505,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="55.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -538,7 +529,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -546,7 +537,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="485c-3d06-ba24-6414" name="Shikigami Spirits" hidden="false" collective="false" type="upgrade">
@@ -563,7 +554,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -571,7 +562,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -588,7 +579,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbc9-109a-63b1-8805" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -597,7 +588,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c53-f753-4142-a72d" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -606,7 +597,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -623,7 +614,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f36e-0a3f-20b4-5adf" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -632,7 +623,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dbda-bc2e-bb8f-948e" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -641,7 +632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0ed0-9666-8d85-e1a7" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -650,7 +641,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0fb-4705-18a8-5d02" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -659,7 +650,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4bae-cc91-9e78-524e" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -668,7 +659,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3cbf-796e-d8b6-6b92" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -677,7 +668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3991-b7a1-3bf5-60a3" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -686,7 +677,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e466-c37a-c655-3836" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -695,7 +686,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0340-ff1a-86f4-a7aa" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -704,7 +695,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ffec-13fb-3d10-039f" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -713,7 +704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7904-d2de-a7ed-80ee" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -722,7 +713,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0404-a5d8-62e0-3ab3" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -731,7 +722,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="70ad-7356-732b-8f5f" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -740,7 +731,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -756,7 +747,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f566-eb33-32e3-fcd7" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -768,7 +759,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="726f-992e-1660-87c6" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -780,7 +771,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="961c-d934-e42b-c125" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -792,7 +783,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7678-30bd-736b-fcf6" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -804,7 +795,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="db5c-e878-75cb-b8ee" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -816,7 +807,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6d9a-53e9-7e75-6284" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -828,7 +819,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cb1a-d65c-e142-ce14" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -840,7 +831,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f91-ea51-050c-1dda" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -852,7 +843,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dae4-658a-9bf1-706d" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -864,7 +855,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="53f1-4225-e57a-ab5a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -876,7 +867,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a33-d1c7-14d1-af87" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -888,7 +879,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f931-dbf8-e8af-2cd9" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -900,7 +891,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="97d6-71f6-b81f-b0af" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -912,7 +903,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -929,7 +920,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7eb0-c108-3e57-1ec2" name="Tough" hidden="false" collective="false" type="upgrade">
@@ -938,7 +929,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -954,7 +945,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e60f-38e7-8369-36f1" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -963,7 +954,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5b58-9cd4-b8ba-2c2f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -972,7 +963,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b5a-399d-e4c2-c522" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -981,7 +972,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="afdc-15fd-a801-954d" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -990,7 +981,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6283-6f87-8311-69a0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -999,7 +990,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b631-45bc-a75d-564e" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1008,7 +999,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1016,13 +1007,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1070-fe2d-2e93-c2c1" name="Shugyosha Samurai Hero [86 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="cf0a-92c4-c92a-a65b" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="8297-f0f5-d62d-f2d4" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1041,7 +1029,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1058,7 +1046,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1794-c6f7-8d3b-5b85" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -1067,7 +1055,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1083,7 +1071,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1099,7 +1087,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1115,7 +1103,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1132,7 +1120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f748-b2f3-0192-a5f4" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1141,7 +1129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1158,7 +1146,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8730-23f3-0948-d35a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1167,7 +1155,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3571-e988-f78c-7071" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1176,7 +1164,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1192,7 +1180,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="890d-e762-9ecd-296d" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1201,7 +1189,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ccd2-a7d0-ffaf-f26f" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1210,7 +1198,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cc74-40e7-9373-085c" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1219,7 +1207,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7ec3-eb61-4594-cb71" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1228,7 +1216,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3ad5-9c4a-9d70-ec63" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1237,7 +1225,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="93ca-5329-5677-2b61" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1246,7 +1234,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1254,13 +1242,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e68b-8444-a4ef-bf6b" name="Mounted Shugyosha Samurai Hero [102 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="8086-28f6-7842-77f2" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="1a9b-1ba3-f600-58cd" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1279,7 +1264,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="102.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1296,7 +1281,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="351a-6a60-7bc6-ffbe" name="Lance" hidden="false" collective="false" type="upgrade">
@@ -1305,7 +1290,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1321,7 +1306,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="4.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1337,7 +1322,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1353,7 +1338,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1370,7 +1355,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="056d-0c5f-5cf7-a315" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1379,7 +1364,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1396,7 +1381,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7997-bc4e-2b6b-3b98" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1405,7 +1390,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="18.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b6c2-7b72-5ec5-9a1b" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1414,7 +1399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1430,7 +1415,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="1.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1446,7 +1431,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="731c-dab1-a71e-7516" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1455,7 +1440,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fd43-90d6-290d-ef03" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1464,7 +1449,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd00-bf56-b285-7e37" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1473,7 +1458,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e2f1-0bb4-f6ba-e5d9" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1482,7 +1467,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="504f-a7ef-5bce-ac65" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1491,7 +1476,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f0fb-4ef8-9e23-4a9e" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1500,7 +1485,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1508,13 +1493,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7f2c-f65b-b0b8-36b8" name="Ninja Master" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="f7b7-b384-2f4a-c0ba" name="New CategoryLink" hidden="false" targetId="hero unit" primary="true"/>
         <categoryLink id="bc02-dba8-0fd3-6e7c" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1534,7 +1516,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="90.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1551,7 +1533,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9a30-5c5e-53b0-9668" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -1560,7 +1542,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4d94-af99-2da8-28da" name="Nunchaku" hidden="false" collective="false" type="upgrade">
@@ -1569,7 +1551,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1586,7 +1568,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4f49-8739-03a2-b998" name="Ranged Magic Weapons" hidden="false" collective="false" type="upgrade">
@@ -1602,7 +1584,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="15.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1174-8132-ab16-30dd" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1611,7 +1593,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="62bc-c789-1b37-44f1" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1620,7 +1602,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="20.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1628,7 +1610,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1644,7 +1626,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1661,7 +1643,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e533-f642-dc71-3c81" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1670,7 +1652,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1687,7 +1669,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a24a-d39a-3f20-6f2e" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1696,7 +1678,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c4b6-84b4-918e-7492" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1705,7 +1687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1721,7 +1703,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa11-0d76-32f3-777c" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1730,7 +1712,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e346-c654-1d70-3b83" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1739,7 +1721,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ef29-42d1-7185-ffe4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1748,7 +1730,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5f66-cb62-5d3c-238f" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1757,7 +1739,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a9a3-5e0b-b50f-e92e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1766,7 +1748,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0af7-48e5-9db1-2a42" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1775,7 +1757,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1783,13 +1765,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="31fd-5e25-2ed4-b763" name="Mounted Samurai [84 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="8f03-5707-d029-6d91" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
       </categoryLinks>
@@ -1808,7 +1787,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="901b-c09b-61cc-63ae" name="Samurai in Medium Armour, Riding Horse" hidden="false" collective="false" type="model">
@@ -1822,7 +1801,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1839,7 +1818,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b70d-c310-b4d5-5e49" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -1855,7 +1834,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ba89-49b3-040f-f5a3" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1864,7 +1843,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1887,7 +1866,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1904,7 +1883,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="18d2-3baf-34d4-a45a" name="Warhorses" hidden="false" collective="false" type="upgrade">
@@ -1920,7 +1899,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9c4b-c038-8f20-9791" name="Komainu Lion Dog" hidden="false" collective="false" type="upgrade">
@@ -1936,7 +1915,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1944,13 +1923,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bb3d-9040-9441-5630" name="Samurai [92 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="575f-53f8-d296-0f2e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1968,7 +1944,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="28.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8292-905e-eacf-3f11" name="Samurai" hidden="false" collective="false" type="model">
@@ -1981,7 +1957,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1998,7 +1974,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98ca-9f39-fa47-b428" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -2007,7 +1983,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="16ce-6494-6d8a-d749" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -2016,7 +1992,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2039,7 +2015,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2047,13 +2023,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="22be-f604-b5ad-9a31" name="Ashigaru [72 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="c360-b3f6-4678-78c3" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -2078,7 +2051,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="4b63-9ddb-aa8d-d54f" name="Ashigaru leader in Light Armour" hidden="false" collective="false" type="model">
@@ -2092,7 +2065,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2100,7 +2073,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15ce-09d4-fe6e-5e5f" name="Ashigaru in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2118,7 +2091,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="aded-c528-a496-f3ee" name="Ashigaru in Medium Armour" hidden="false" collective="false" type="model">
@@ -2131,7 +2104,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2139,7 +2112,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2156,7 +2129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd4b-f302-ca7e-afd5" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -2165,7 +2138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="10a5-df23-edf6-f695" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -2174,7 +2147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c3cc-ece7-a0af-5d25" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -2183,7 +2156,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="baba-94bb-27e3-7cf4" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -2199,7 +2172,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2207,13 +2180,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="089f-9e45-d225-bd30" name="Archers [72 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="613e-0dc7-1357-e520" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
       </infoLinks>
@@ -2241,7 +2211,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="5e06-6932-d177-a733" name="Archer Leader" hidden="false" collective="false" type="model">
@@ -2255,7 +2225,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2263,7 +2233,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0d80-a67d-5432-4ae2" name="Archers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2281,7 +2251,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ab2d-cc42-d12c-26ca" name="Archers in Light Armour" hidden="false" collective="false" type="model">
@@ -2294,7 +2264,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2302,7 +2272,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2026-4800-3eda-e2bc" name="Archers in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2320,7 +2290,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="f180-a9c8-efd8-7cb0" name="Archers in Medium Armour" hidden="false" collective="false" type="model">
@@ -2333,7 +2303,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2341,7 +2311,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2358,7 +2328,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f22b-285a-e598-51cb" name="Long Bows" hidden="false" collective="false" type="upgrade">
@@ -2374,7 +2344,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2382,13 +2352,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e5d4-364a-44f3-cf24" name="Bandits and Brigands [57 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="169b-796b-2654-f929" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -2406,7 +2373,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0b4c-b0c8-dada-e057" name="Bandits" hidden="false" collective="false" type="model">
@@ -2419,7 +2386,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2436,7 +2403,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="905b-f9d4-3c69-ba64" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -2449,7 +2416,7 @@
               </modifiers>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2457,13 +2424,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b6af-603d-a7c3-a000" name="Tanigashima Men [82 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="4471-f073-f2b8-3b50" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="65c2-1d0c-f1f2-4588" name="Hand Gun" hidden="false" targetId="4d4a-8ee3-260b-037b" type="profile"/>
@@ -2493,7 +2457,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="45de-4e3a-f176-f907" name="Tanigashima Men" hidden="false" collective="false" type="model">
@@ -2506,7 +2470,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2514,7 +2478,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6851-781e-698a-2c66" name="Tanigashima Men in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2532,7 +2496,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="3782-3b8f-fac6-8ad3" name="Tanigashima Men in Light Armour" hidden="false" collective="false" type="model">
@@ -2545,7 +2509,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2553,7 +2517,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d09e-f0ab-d4ea-f144" name="Tanigashima Men in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2571,7 +2535,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="30.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9ccb-08b0-1c51-6d9a" name="Tanigashima Men in Medium Armour" hidden="false" collective="false" type="model">
@@ -2584,7 +2548,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="18.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2592,7 +2556,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2615,7 +2579,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2623,13 +2587,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6e1d-4700-e35d-cfd5" name="Onna Bugeisha [62 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="6d9a-27a2-cefa-294e" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -2655,7 +2616,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="22.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="1c66-5212-72da-61ad" name="Onna Bugeisha" hidden="false" collective="false" type="model">
@@ -2668,7 +2629,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2676,7 +2637,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="65a9-2013-ba5b-0544" name="Onna Bugeisha in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2694,7 +2655,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a14f-9a1a-0d0f-0c48" name="Onna Bugeisha" hidden="false" collective="false" type="model">
@@ -2707,7 +2668,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2715,7 +2676,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ceb0-5d4c-cf72-146f" name="Onna Bugeisha in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2733,7 +2694,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="b4a3-dd78-e08d-71e0" name="Onna Bugeisha" hidden="false" collective="false" type="model">
@@ -2746,7 +2707,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2754,7 +2715,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2777,7 +2738,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2794,7 +2755,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2dfe-9d67-dc0c-700c" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -2803,7 +2764,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a65-1140-9a0e-3211" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -2812,7 +2773,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2820,13 +2781,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1f70-b03f-149b-186e" name="Sohei Warrior Monks [132 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3836-3c5c-250b-1f2a" type="max"/>
       </constraints>
@@ -2856,7 +2814,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="32.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6242-6196-3635-234a" name="Monk" hidden="false" collective="false" type="model">
@@ -2869,7 +2827,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2877,7 +2835,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5182-3b4d-5c05-d639" name="Sohei Warrior Monks in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -2896,7 +2854,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="34.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="a395-4204-301a-e701" name="Monk in Light Armour" hidden="false" collective="false" type="model">
@@ -2909,7 +2867,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="27.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2917,7 +2875,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2940,7 +2898,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2957,7 +2915,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aecf-1199-89fa-8e81" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -2973,7 +2931,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2989,7 +2947,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2997,13 +2955,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e1ed-3a13-14a6-97e1" name="Ninja [205 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="9380-11e5-3228-2fe8" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -3022,7 +2977,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="41.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3039,7 +2994,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b61d-53a5-92f9-e423" name="Naginata" hidden="false" collective="false" type="upgrade">
@@ -3048,7 +3003,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="99ae-9cdf-f1d4-5c86" name="Nunchaku" hidden="false" collective="false" type="upgrade">
@@ -3057,7 +3012,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3070,7 +3025,7 @@
             <selectionEntry id="0256-06e0-6d14-9543" name="Dead Eye Shot" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3078,13 +3033,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7909-8c75-a592-8775" name="Oni Ogres [26 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="be43-3d07-54a4-cf38" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -3103,7 +3055,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="26.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3111,13 +3063,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1d8c-7e0b-a8ed-d1f8" name="Tengu Birdmen [144 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cd5-05ab-10ff-2d4d" type="max"/>
       </constraints>
@@ -3139,7 +3088,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="48.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3147,13 +3096,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e383-a41b-2f88-a302" name="Cannon [77 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="c2c5-5480-a49b-b56c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="c8e6-56fc-bd9c-e4a6" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -3182,7 +3128,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3190,7 +3136,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b739-d5bd-1fee-5dfe" name="Cannon Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -3207,7 +3153,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3215,7 +3161,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3232,7 +3178,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b326-65e6-9101-d76a" name="Large Cannon" hidden="false" collective="false" type="upgrade">
@@ -3241,7 +3187,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="100.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3258,7 +3204,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="64d7-3af3-84c4-f050" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -3274,7 +3220,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3282,13 +3228,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1be0-ddf4-8aab-f6fb" name="Bolt Thrower [69 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="7f5c-a1d5-0ec7-97d8" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="010a-8f61-8e05-8247" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
@@ -3317,7 +3260,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3325,7 +3268,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d6ee-ab3a-fc3b-61bb" name="Bolt Thrower Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -3342,7 +3285,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3350,7 +3293,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3367,7 +3310,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="376f-b959-1f8b-048c" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -3376,7 +3319,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="63.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3393,7 +3336,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bfb3-da1d-bfeb-29f8" name="Swords" hidden="false" collective="false" type="upgrade">
@@ -3409,7 +3352,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3417,7 +3360,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Snakemen.cat
+++ b/Snakemen.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="152d-3173-80b2-a764" name="Snakemen" revision="2" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="152d-3173-80b2-a764" name="Snakemen" revision="3" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="1a78-4648-bf1b-ebd0" name="Snakeman Serpent Lord [103 pts]" hidden="false" collective="false" targetId="4f93-772c-1a68-d127" type="selectionEntry"/>
     <entryLink id="8258-9325-b4ad-7d2d" name="Snakeman High-Priest of Hissta [60 pts]" hidden="false" collective="false" targetId="2019-dbf1-8aa9-364d" type="selectionEntry"/>
@@ -17,9 +17,6 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4f93-772c-1a68-d127" name="Snakeman Serpent Lord [103 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="a580-b659-c3f5-2efc" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="1fb4-7485-73d9-6a93" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -47,7 +44,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="75.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="178d-8fdc-c4ff-d7e8" name="Snakeman Bodyguard" hidden="false" collective="false" type="model">
@@ -60,7 +57,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -68,7 +65,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="276b-b7ff-6475-baf0" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -87,7 +84,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="85.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ff3f-f029-c46b-44b3" name="Snakeman Bodyguard" hidden="false" collective="false" type="model">
@@ -100,7 +97,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -108,7 +105,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -125,7 +122,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3440-1ece-770f-f46a" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -134,7 +131,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -150,7 +147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -167,7 +164,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3f9e-4ed1-6030-198a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -176,7 +173,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -193,7 +190,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e720-6c1c-cb62-0a35" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -202,7 +199,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4493-4cfc-3e9d-e069" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -211,7 +208,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="92fc-720f-6f36-8b09" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -220,7 +217,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -236,7 +233,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dbf8-6f35-ec0a-f0f2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -245,7 +242,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b997-514e-55d0-473d" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -254,7 +251,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e58f-98c6-81e7-f284" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -263,7 +260,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="835c-7550-3ba8-1a6e" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -272,7 +269,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ea1-4172-fa68-e1a0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -281,7 +278,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="678c-924d-94f7-734a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -290,7 +287,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -298,13 +295,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2019-dbf1-8aa9-364d" name="Snakeman High-Priest of Hissta [60 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="5a11-bfe5-42f8-4422" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
         <categoryLink id="198e-9bd8-a312-1917" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -323,7 +317,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -340,7 +334,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff02-d2fd-50db-de94" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -349,7 +343,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f732-8518-f069-ef11" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -358,7 +352,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -375,7 +369,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c80a-2120-1dc3-2955" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -384,7 +378,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2e8d-b3c7-f838-1292" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -393,7 +387,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da07-4691-43f4-2f15" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -402,7 +396,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a42e-c7b9-18db-3418" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -411,7 +405,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c78-7df7-e7d6-7d77" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -420,7 +414,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6102-3ce3-1747-d9aa" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -429,7 +423,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9394-e443-a958-921f" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -438,7 +432,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2a14-cfa0-fc14-b278" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -447,7 +441,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4b00-73b0-0672-83aa" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -456,7 +450,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9fcd-c770-f0b8-2a13" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -465,7 +459,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e842-3ef1-89e9-57de" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -474,7 +468,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a32c-0e35-e71f-0f74" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -483,7 +477,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4201-22ae-6d01-83bc" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -492,7 +486,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -508,7 +502,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d557-7b9a-4c07-ac2b" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -520,7 +514,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de1d-ea81-2ccf-8f80" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -532,7 +526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0107-16ec-14c4-a655" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -544,7 +538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e9e1-4630-3953-2e34" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -556,7 +550,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4041-8992-74f2-534b" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -568,7 +562,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c06-bcda-2b07-05b5" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -580,7 +574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c72d-5f19-dc88-9797" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -592,7 +586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8be2-8b0a-bbe7-5721" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -604,7 +598,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d5c6-dc8f-e3e2-7567" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -616,7 +610,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="999c-ce3f-be75-176a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -628,7 +622,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1243-d77e-44a0-dd7a" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -640,7 +634,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7458-06ea-264b-bf2c" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -652,7 +646,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c657-e0b2-708f-1b10" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -664,7 +658,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -681,7 +675,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6eb-82fb-174a-6419" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -690,7 +684,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -714,7 +708,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="209a-458e-040d-659d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -730,7 +724,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed10-d05c-b2c3-e68c" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -739,7 +733,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -762,7 +756,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -770,7 +764,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de00-ff55-111a-81a3" name="Spirits" hidden="false" collective="false" type="upgrade">
@@ -787,7 +781,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -795,7 +789,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -811,7 +805,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -827,7 +821,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5d4-7702-9a86-ace7" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -836,7 +830,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c6fb-545f-a304-f241" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -845,7 +839,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e25-fd2b-1036-15d9" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -854,7 +848,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="084c-40d5-56d9-7141" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -863,7 +857,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51e1-d088-8a78-fc02" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -872,7 +866,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6cc6-3b48-68bf-a9a8" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -881,7 +875,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -889,13 +883,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1a5e-d33f-9652-297f" name="Snakeman Cosmic Star Serpent Hero [86 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="e42f-dd29-ed29-5c70" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
         <infoLink id="653a-3490-5b89-dbc4" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
@@ -918,7 +909,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="20f3-a7f9-64ff-ac91" name="Snakeman Hero in Light Armour" hidden="false" collective="false" type="model">
@@ -927,7 +918,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="96.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04d1-ac6a-4342-2533" name="Snakeman Hero in Medium Armour" hidden="false" collective="false" type="model">
@@ -936,7 +927,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="106.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -953,7 +944,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2067-0ddd-d02b-658d" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -962,7 +953,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="41fe-c8d8-c4b9-5d04" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -971,7 +962,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b640-2656-7500-f5ef" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -980,7 +971,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -997,7 +988,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="752c-04a9-3365-da57" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1006,7 +997,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d36b-a862-349e-1bc7" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1015,7 +1006,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1032,7 +1023,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de95-7a8b-59e1-0927" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1041,7 +1032,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1057,7 +1048,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1073,7 +1064,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1089,7 +1080,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="63b8-b32d-64ea-9207" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1098,7 +1089,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="095e-2101-1382-5415" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1107,7 +1098,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e94e-d081-1208-bc1f" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1116,7 +1107,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f564-8f16-2fe3-8460" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1125,7 +1116,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="26fa-ce47-e67b-e29e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1134,7 +1125,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d312-06a5-e4e3-7529" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1143,7 +1134,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1151,13 +1142,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7cba-b245-d058-46af" name="Snakeman Python Guard [82 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="a254-b10e-25ef-b72f" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1183,7 +1171,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9e27-bffa-e77b-4cf9" name="Snakeman Python Guard" hidden="false" collective="false" type="model">
@@ -1196,7 +1184,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1204,7 +1192,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a112-5b56-ed27-fb46" name="Python Guard in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1222,7 +1210,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="19de-dc65-2f75-3205" name="Snakeman Python Guard" hidden="false" collective="false" type="model">
@@ -1235,7 +1223,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1243,7 +1231,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1260,7 +1248,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c34b-5aaf-e17f-daab" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1269,7 +1257,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cecd-dacc-06fa-d32e" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1278,7 +1266,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6756-bc6d-c1b8-3435" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1287,7 +1275,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1310,7 +1298,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1318,13 +1306,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="37b6-f4e6-0e5d-6d14" name="Snakeman Warriors [72 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="e4d3-1c86-8538-a954" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1350,7 +1335,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d673-810d-9059-6534" name="Snakeman Warriors" hidden="false" collective="false" type="model">
@@ -1363,7 +1348,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1371,7 +1356,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3b7a-02b0-e81c-58ba" name="Snakeman Warriors in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1389,7 +1374,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="510f-aef8-abdb-3249" name="Snakeman Warriors in Light Armour" hidden="false" collective="false" type="model">
@@ -1402,7 +1387,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1410,7 +1395,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1427,7 +1412,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f120-e673-346b-6ff2" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1436,7 +1421,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da2d-0b45-d842-a71a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1445,7 +1430,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="16e9-94a4-fd6b-dcda" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1454,7 +1439,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1462,13 +1447,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9033-ab9b-3a31-06fd" name="Snakeman Viper Warriors [77 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="1d47-a883-db09-12dd" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1494,7 +1476,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2028-5d67-0165-2478" name="Snakeman Warriors" hidden="false" collective="false" type="model">
@@ -1507,7 +1489,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1515,7 +1497,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1539,7 +1521,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="369d-0781-3f1e-ba04" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1555,7 +1537,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a40e-4e95-5e63-f805" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -1564,7 +1546,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1580,7 +1562,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1597,7 +1579,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1605,13 +1587,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="995b-88e6-92aa-8220" name="Snakeman Cobra Guard [87 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbc2-6757-f7bf-22f1" type="max"/>
       </constraints>
@@ -1640,7 +1619,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ba64-6d55-8979-525d" name="Snakemen Cobra Guard" hidden="false" collective="false" type="model">
@@ -1653,7 +1632,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1661,7 +1640,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1685,7 +1664,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a002-9b39-159f-50f5" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1701,7 +1680,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9692-2f72-d29c-cf6e" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -1710,7 +1689,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1726,7 +1705,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1743,7 +1722,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1766,7 +1745,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1774,13 +1753,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="00aa-31c0-56fc-f219" name="Hemata Elder Guardian [41 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="9973-af89-79b8-5c63" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -1800,7 +1776,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="41.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1816,7 +1792,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1832,7 +1808,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1840,13 +1816,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="73c2-ab60-7aef-87f4" name="Gorgon Elder Serpent [62 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b28-0983-05bd-82b7" type="max"/>
       </constraints>
@@ -1868,7 +1841,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1881,7 +1854,7 @@
             <selectionEntry id="8ba4-8e74-e61f-b0bd" name="Baleful Glare (can shoot bow or use glare, but not both at same time)" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1897,7 +1870,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1914,7 +1887,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4103-e8fc-92b3-f39a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1923,7 +1896,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1931,13 +1904,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c1d8-f242-88b4-7ce4" name="Saurian Slithering Beast Pack [94 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="50fc-7522-b9fa-d20a" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
         <categoryLink id="8c69-aab2-d0b2-cd51" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1968,7 +1938,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6deb-a7da-9c79-f955" name="Snakeman Pack Master in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1982,7 +1952,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1990,7 +1960,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e6df-3af4-1018-bcfa" name="Saurian Beasts" hidden="false" collective="false" type="upgrade">
@@ -2013,7 +1983,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2021,7 +1991,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2038,7 +2008,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="161c-4036-7a6c-ee2b" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2047,7 +2017,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="159c-eb2e-7496-a9e3" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -2056,7 +2026,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2069,7 +2039,7 @@
             <selectionEntry id="8e27-5d6a-b89d-d9a2" name="Packmaster Bow Upgrade" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2092,7 +2062,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df82-c8e4-244f-8bde" name="Give Saurian Beasts Venomous Attacks" hidden="false" collective="false" type="upgrade">
@@ -2101,7 +2071,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2109,13 +2079,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="19f9-b7db-3799-e42a" name="Pterosaurs [129 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8756-422d-cf47-3a13" type="max"/>
       </constraints>
@@ -2138,7 +2105,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="43.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2146,13 +2113,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3cb6-522d-f175-f84e" name="Tyrannosaur/Sail Back Saurian/Giant Horned Saurian" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0100-f7ee-ab55-4691" type="max"/>
       </constraints>
@@ -2179,7 +2143,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="188.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6b28-7ddf-fb35-978d" name="Sail Back Saurian" hidden="false" collective="false" type="model">
@@ -2189,7 +2153,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="126.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="913b-a478-a055-62f0" name="Giant Horned Saurian" hidden="false" collective="false" type="model">
@@ -2199,7 +2163,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="122.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2207,13 +2171,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c917-12a1-c769-10e1" name="Raptors [93 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="a1e8-455d-2f92-b62f" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -2233,7 +2194,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="31.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2241,7 +2202,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Snakemen.cat
+++ b/Snakemen.cat
@@ -213,7 +213,7 @@
             </selectionEntry>
             <selectionEntry id="4493-4cfc-3e9d-e069" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="7fc4-debf-8033-29df" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="7fc4-debf-8033-29df" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -660,7 +660,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="c88d-3340-cf36-2604" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="c88d-3340-cf36-2604" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -831,7 +831,7 @@
             </selectionEntry>
             <selectionEntry id="41fe-c8d8-c4b9-5d04" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="4bc0-1ecc-1fce-9a96" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="4bc0-1ecc-1fce-9a96" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1071,7 +1071,7 @@
             </selectionEntry>
             <selectionEntry id="cecd-dacc-06fa-d32e" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="2a2f-e359-9433-92a6" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="2a2f-e359-9433-92a6" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1235,7 +1235,7 @@
             </selectionEntry>
             <selectionEntry id="da2d-0b45-d842-a71a" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="db49-8991-d973-2309" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="db49-8991-d973-2309" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1343,7 +1343,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="48c3-388d-b0b3-d7ef" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="48c3-388d-b0b3-d7ef" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1470,7 +1470,7 @@
                 </modifier>
               </modifiers>
               <infoLinks>
-                <infoLink id="c886-57ee-8277-5d5a" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="c886-57ee-8277-5d5a" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -1778,7 +1778,7 @@
             </selectionEntry>
             <selectionEntry id="161c-4036-7a6c-ee2b" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="f26b-3f08-68f9-9633" name="Axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="f26b-3f08-68f9-9633" name="Axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>

--- a/Snakemen.cat
+++ b/Snakemen.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="152d-3173-80b2-a764" name="Snakemen" revision="3" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="152d-3173-80b2-a764" name="Snakemen" revision="4" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <categoryEntries>
     <categoryEntry id="9fb1-47aa-24d5-0f85" name="Snakeman Monstrosity" hidden="false">
       <constraints>
@@ -1412,6 +1412,9 @@
                   <infoLinks>
                     <infoLink id="2e76-a1a6-9460-ea11" name="Snakemen Cobra Guard" hidden="false" targetId="e2cd-774e-9678-6a11" type="profile"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="14.0"/>
+                  </costs>
                 </selectionEntry>
                 <selectionEntry id="a7d6-16d0-c41d-8576" name="Snakeman Cobra Guard Leader" hidden="false" collective="false" type="upgrade">
                   <constraints>
@@ -1421,10 +1424,18 @@
                   <infoLinks>
                     <infoLink id="b819-f7e4-8da8-dcf8" name="Snakemen Cobra Guard Leader" hidden="false" targetId="0de9-1e2e-92bb-de08" type="profile"/>
                   </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="31.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                  </costs>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
           </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>

--- a/Snakemen.cat
+++ b/Snakemen.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="152d-3173-80b2-a764" name="Snakemen" revision="1" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="152d-3173-80b2-a764" name="Snakemen" revision="2" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="1a78-4648-bf1b-ebd0" name="Snakeman Serpent Lord [103 pts]" hidden="false" collective="false" targetId="4f93-772c-1a68-d127" type="selectionEntry"/>
     <entryLink id="8258-9325-b4ad-7d2d" name="Snakeman High-Priest of Hissta [60 pts]" hidden="false" collective="false" targetId="2019-dbf1-8aa9-364d" type="selectionEntry"/>
@@ -17,6 +17,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4f93-772c-1a68-d127" name="Snakeman Serpent Lord [103 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="a580-b659-c3f5-2efc" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="1fb4-7485-73d9-6a93" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -44,6 +47,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="75.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="178d-8fdc-c4ff-d7e8" name="Snakeman Bodyguard" hidden="false" collective="false" type="model">
@@ -56,6 +60,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -63,6 +68,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="276b-b7ff-6475-baf0" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -81,6 +87,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="85.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ff3f-f029-c46b-44b3" name="Snakeman Bodyguard" hidden="false" collective="false" type="model">
@@ -93,6 +100,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -100,6 +108,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -116,6 +125,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3440-1ece-770f-f46a" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -124,6 +134,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -139,6 +150,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -155,6 +167,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3f9e-4ed1-6030-198a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -163,6 +176,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -179,6 +193,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e720-6c1c-cb62-0a35" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -187,6 +202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4493-4cfc-3e9d-e069" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -195,6 +211,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="92fc-720f-6f36-8b09" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -203,6 +220,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -218,6 +236,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dbf8-6f35-ec0a-f0f2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -226,6 +245,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b997-514e-55d0-473d" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -234,6 +254,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e58f-98c6-81e7-f284" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -242,6 +263,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="835c-7550-3ba8-1a6e" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -250,6 +272,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6ea1-4172-fa68-e1a0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -258,6 +281,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="678c-924d-94f7-734a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -266,6 +290,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -273,9 +298,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2019-dbf1-8aa9-364d" name="Snakeman High-Priest of Hissta [60 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="5a11-bfe5-42f8-4422" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
         <categoryLink id="198e-9bd8-a312-1917" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -294,6 +323,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="60.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -310,6 +340,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff02-d2fd-50db-de94" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -318,6 +349,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f732-8518-f069-ef11" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -326,6 +358,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -342,6 +375,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c80a-2120-1dc3-2955" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -350,6 +384,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2e8d-b3c7-f838-1292" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -358,6 +393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da07-4691-43f4-2f15" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -366,6 +402,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a42e-c7b9-18db-3418" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -374,6 +411,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c78-7df7-e7d6-7d77" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -382,6 +420,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6102-3ce3-1747-d9aa" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -390,6 +429,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9394-e443-a958-921f" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -398,6 +438,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2a14-cfa0-fc14-b278" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -406,6 +447,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4b00-73b0-0672-83aa" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -414,6 +456,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9fcd-c770-f0b8-2a13" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -422,6 +465,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e842-3ef1-89e9-57de" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -430,6 +474,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a32c-0e35-e71f-0f74" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -438,6 +483,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4201-22ae-6d01-83bc" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -446,6 +492,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -461,6 +508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d557-7b9a-4c07-ac2b" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -472,6 +520,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de1d-ea81-2ccf-8f80" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -483,6 +532,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0107-16ec-14c4-a655" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -494,6 +544,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e9e1-4630-3953-2e34" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -505,6 +556,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4041-8992-74f2-534b" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -516,6 +568,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c06-bcda-2b07-05b5" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -527,6 +580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c72d-5f19-dc88-9797" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -538,6 +592,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8be2-8b0a-bbe7-5721" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -549,6 +604,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d5c6-dc8f-e3e2-7567" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -560,6 +616,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="999c-ce3f-be75-176a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -571,6 +628,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1243-d77e-44a0-dd7a" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -582,6 +640,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7458-06ea-264b-bf2c" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -593,6 +652,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c657-e0b2-708f-1b10" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -604,6 +664,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -620,6 +681,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6eb-82fb-174a-6419" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -628,6 +690,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -651,6 +714,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="209a-458e-040d-659d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -666,6 +730,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed10-d05c-b2c3-e68c" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -674,6 +739,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -696,6 +762,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -703,6 +770,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de00-ff55-111a-81a3" name="Spirits" hidden="false" collective="false" type="upgrade">
@@ -719,6 +787,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -726,6 +795,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -741,6 +811,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -756,6 +827,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5d4-7702-9a86-ace7" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -764,6 +836,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c6fb-545f-a304-f241" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -772,6 +845,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e25-fd2b-1036-15d9" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -780,6 +854,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="084c-40d5-56d9-7141" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -788,6 +863,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51e1-d088-8a78-fc02" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -796,6 +872,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6cc6-3b48-68bf-a9a8" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -804,6 +881,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -811,9 +889,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1a5e-d33f-9652-297f" name="Snakeman Cosmic Star Serpent Hero [86 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="e42f-dd29-ed29-5c70" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
         <infoLink id="653a-3490-5b89-dbc4" name="Stubborn" hidden="false" targetId="4440-376a-8093-35b8" type="rule"/>
@@ -836,6 +918,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="20f3-a7f9-64ff-ac91" name="Snakeman Hero in Light Armour" hidden="false" collective="false" type="model">
@@ -844,6 +927,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="96.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04d1-ac6a-4342-2533" name="Snakeman Hero in Medium Armour" hidden="false" collective="false" type="model">
@@ -852,6 +936,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="106.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -868,6 +953,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2067-0ddd-d02b-658d" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -876,6 +962,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="41fe-c8d8-c4b9-5d04" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -884,6 +971,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b640-2656-7500-f5ef" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -892,6 +980,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -908,6 +997,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="752c-04a9-3365-da57" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -916,6 +1006,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d36b-a862-349e-1bc7" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -924,6 +1015,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -940,6 +1032,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de95-7a8b-59e1-0927" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -948,6 +1041,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -963,6 +1057,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -978,6 +1073,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -993,6 +1089,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="63b8-b32d-64ea-9207" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1001,6 +1098,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="095e-2101-1382-5415" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1009,6 +1107,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e94e-d081-1208-bc1f" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1017,6 +1116,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f564-8f16-2fe3-8460" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1025,6 +1125,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="26fa-ce47-e67b-e29e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1033,6 +1134,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d312-06a5-e4e3-7529" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1041,6 +1143,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1048,9 +1151,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7cba-b245-d058-46af" name="Snakeman Python Guard [82 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="a254-b10e-25ef-b72f" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1076,6 +1183,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9e27-bffa-e77b-4cf9" name="Snakeman Python Guard" hidden="false" collective="false" type="model">
@@ -1088,6 +1196,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1095,6 +1204,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a112-5b56-ed27-fb46" name="Python Guard in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1112,6 +1222,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="19de-dc65-2f75-3205" name="Snakeman Python Guard" hidden="false" collective="false" type="model">
@@ -1124,6 +1235,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1131,6 +1243,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1147,6 +1260,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c34b-5aaf-e17f-daab" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1155,6 +1269,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cecd-dacc-06fa-d32e" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1163,6 +1278,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6756-bc6d-c1b8-3435" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1171,6 +1287,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1193,6 +1310,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1200,9 +1318,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="37b6-f4e6-0e5d-6d14" name="Snakeman Warriors [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="e4d3-1c86-8538-a954" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1228,6 +1350,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d673-810d-9059-6534" name="Snakeman Warriors" hidden="false" collective="false" type="model">
@@ -1240,6 +1363,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1247,6 +1371,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3b7a-02b0-e81c-58ba" name="Snakeman Warriors in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1264,6 +1389,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="510f-aef8-abdb-3249" name="Snakeman Warriors in Light Armour" hidden="false" collective="false" type="model">
@@ -1276,6 +1402,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1283,6 +1410,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1299,6 +1427,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f120-e673-346b-6ff2" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1307,6 +1436,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da2d-0b45-d842-a71a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1315,6 +1445,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="16e9-94a4-fd6b-dcda" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1323,6 +1454,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1330,9 +1462,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9033-ab9b-3a31-06fd" name="Snakeman Viper Warriors [77 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="1d47-a883-db09-12dd" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -1358,6 +1494,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="2028-5d67-0165-2478" name="Snakeman Warriors" hidden="false" collective="false" type="model">
@@ -1370,6 +1507,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="13.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1377,6 +1515,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1400,6 +1539,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="369d-0781-3f1e-ba04" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1415,6 +1555,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a40e-4e95-5e63-f805" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -1423,6 +1564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1438,6 +1580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1454,6 +1597,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1461,9 +1605,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="995b-88e6-92aa-8220" name="Snakeman Cobra Guard [87 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbc2-6757-f7bf-22f1" type="max"/>
       </constraints>
@@ -1492,6 +1640,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="31.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ba64-6d55-8979-525d" name="Snakemen Cobra Guard" hidden="false" collective="false" type="model">
@@ -1504,6 +1653,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1511,6 +1661,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1534,6 +1685,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a002-9b39-159f-50f5" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1549,6 +1701,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9692-2f72-d29c-cf6e" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -1557,6 +1710,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1572,6 +1726,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1588,6 +1743,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1610,6 +1766,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1617,9 +1774,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="00aa-31c0-56fc-f219" name="Hemata Elder Guardian [41 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="9973-af89-79b8-5c63" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -1639,6 +1800,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="41.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1654,6 +1816,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1669,6 +1832,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1676,9 +1840,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="73c2-ab60-7aef-87f4" name="Gorgon Elder Serpent [62 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b28-0983-05bd-82b7" type="max"/>
       </constraints>
@@ -1700,6 +1868,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="62.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1712,6 +1881,7 @@
             <selectionEntry id="8ba4-8e74-e61f-b0bd" name="Baleful Glare (can shoot bow or use glare, but not both at same time)" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1727,6 +1897,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1743,6 +1914,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4103-e8fc-92b3-f39a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1751,6 +1923,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1758,9 +1931,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c1d8-f242-88b4-7ce4" name="Saurian Slithering Beast Pack [94 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="50fc-7522-b9fa-d20a" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
         <categoryLink id="8c69-aab2-d0b2-cd51" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1786,11 +1963,12 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="02b2-6eea-ff2c-760e" name="Snakeman Pack Master" hidden="false" targetId="ae15-5d71-d1f1-6cd9" type="profile"/>
-                        <infoLink id="1fcc-44a6-6d4d-f84e" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                        <infoLink id="1fcc-44a6-6d4d-f84e" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
                         <infoLink id="5f7f-c1a9-7945-0d45" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="6deb-a7da-9c79-f955" name="Snakeman Pack Master in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1799,11 +1977,12 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="efb0-69c7-e77b-4c89" name="Snakeman Pack Master in Light Armour" hidden="false" targetId="5cbe-12a3-d570-ea10" type="profile"/>
-                        <infoLink id="df04-7bc7-9a43-7eb5" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                        <infoLink id="df04-7bc7-9a43-7eb5" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
                         <infoLink id="69b6-c1f9-b1af-7f78" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1811,6 +1990,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e6df-3af4-1018-bcfa" name="Saurian Beasts" hidden="false" collective="false" type="upgrade">
@@ -1828,11 +2008,12 @@
                       </constraints>
                       <infoLinks>
                         <infoLink id="e116-10ff-1a56-7c80" name="Saurian Beast" hidden="false" targetId="0ee0-9140-215b-34fb" type="profile"/>
-                        <infoLink id="ed34-a10e-73d9-89fa" name="Rapid Sprint" hidden="false" targetId="e291-560d-f0fb-5572" type="rule"/>
+                        <infoLink id="ed34-a10e-73d9-89fa" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
                         <infoLink id="764e-94dd-955a-4598" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1840,6 +2021,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1856,6 +2038,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="161c-4036-7a6c-ee2b" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1864,6 +2047,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="159c-eb2e-7496-a9e3" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -1872,6 +2056,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1884,6 +2069,7 @@
             <selectionEntry id="8e27-5d6a-b89d-d9a2" name="Packmaster Bow Upgrade" hidden="false" collective="false" type="upgrade">
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1906,6 +2092,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df82-c8e4-244f-8bde" name="Give Saurian Beasts Venomous Attacks" hidden="false" collective="false" type="upgrade">
@@ -1914,6 +2101,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1921,9 +2109,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="19f9-b7db-3799-e42a" name="Pterosaurs [129 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8756-422d-cf47-3a13" type="max"/>
       </constraints>
@@ -1946,6 +2138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="43.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1953,9 +2146,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3cb6-522d-f175-f84e" name="Tyrannosaur/Sail Back Saurian/Giant Horned Saurian" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="2.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0100-f7ee-ab55-4691" type="max"/>
       </constraints>
@@ -1982,6 +2179,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="188.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6b28-7ddf-fb35-978d" name="Sail Back Saurian" hidden="false" collective="false" type="model">
@@ -1991,6 +2189,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="126.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="913b-a478-a055-62f0" name="Giant Horned Saurian" hidden="false" collective="false" type="model">
@@ -2000,6 +2199,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="122.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2007,9 +2207,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c917-12a1-c769-10e1" name="Raptors [93 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="a1e8-455d-2f92-b62f" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -2029,6 +2233,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="31.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2036,6 +2241,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Snakemen.cat
+++ b/Snakemen.cat
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue id="152d-3173-80b2-a764" name="Snakemen" revision="3" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <categoryEntries>
+    <categoryEntry id="9fb1-47aa-24d5-0f85" name="Snakeman Monstrosity" hidden="false">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c676-7611-d641-59a1" type="max"/>
+      </constraints>
+    </categoryEntry>
+  </categoryEntries>
   <entryLinks>
     <entryLink id="1a78-4648-bf1b-ebd0" name="Snakeman Serpent Lord [103 pts]" hidden="false" collective="false" targetId="4f93-772c-1a68-d127" type="selectionEntry"/>
     <entryLink id="8258-9325-b4ad-7d2d" name="Snakeman High-Priest of Hissta [60 pts]" hidden="false" collective="false" targetId="2019-dbf1-8aa9-364d" type="selectionEntry"/>
@@ -12,8 +19,10 @@
     <entryLink id="ed17-3eb3-507e-df72" name="Gorgon Elder Serpent [62 pts]" hidden="false" collective="false" targetId="73c2-ab60-7aef-87f4" type="selectionEntry"/>
     <entryLink id="6c99-a90f-8442-60e7" name="Saurian Slithering Beast Pack [94 pts]" hidden="false" collective="false" targetId="c1d8-f242-88b4-7ce4" type="selectionEntry"/>
     <entryLink id="8bba-0f32-f8d4-c5b1" name="Pterosaurs [129 pts]" hidden="false" collective="false" targetId="19f9-b7db-3799-e42a" type="selectionEntry"/>
-    <entryLink id="e504-4186-4519-2694" name="Tyrannosaur [188 pts]" hidden="false" collective="false" targetId="3cb6-522d-f175-f84e" type="selectionEntry"/>
     <entryLink id="caea-7e4f-3e28-8ef1" name="Raptors [93 pts]" hidden="false" collective="false" targetId="c917-12a1-c769-10e1" type="selectionEntry"/>
+    <entryLink id="467a-3815-5064-242a" name="Tyrannosaur" hidden="false" collective="false" targetId="18a2-7a44-1f56-0b9b" type="selectionEntry"/>
+    <entryLink id="2031-099c-197e-d00c" name="Sail Back Saurian" hidden="false" collective="false" targetId="5ce8-543c-1a85-1343" type="selectionEntry"/>
+    <entryLink id="0d26-f8dc-dc7b-6f1f" name="Giant Horned Saurian" hidden="false" collective="false" targetId="242e-666d-78d7-0b00" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="4f93-772c-1a68-d127" name="Snakeman Serpent Lord [103 pts]" hidden="false" collective="false" type="unit">
@@ -22,7 +31,7 @@
         <categoryLink id="1fb4-7485-73d9-6a93" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="09bd-6931-dd0a-017c" name="Models" hidden="false" collective="false" defaultSelectionEntryId="d7e9-6c59-4a8d-ffba">
+        <selectionEntryGroup id="09bd-6931-dd0a-017c" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="d7e9-6c59-4a8d-ffba">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b7f-7577-ffe0-c205" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff81-5077-6d4e-141b" type="min"/>
@@ -44,7 +53,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="75.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="178d-8fdc-c4ff-d7e8" name="Snakeman Bodyguard" hidden="false" collective="false" type="model">
@@ -57,7 +66,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -65,7 +74,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="276b-b7ff-6475-baf0" name="Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -84,7 +93,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="85.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="ff3f-f029-c46b-44b3" name="Snakeman Bodyguard" hidden="false" collective="false" type="model">
@@ -97,7 +106,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -105,12 +114,12 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="0d6f-5960-5713-d119" name="Serpent Lord Tough upgrade" hidden="false" collective="false" defaultSelectionEntryId="dff9-4948-babb-2691">
+        <selectionEntryGroup id="0d6f-5960-5713-d119" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="dff9-4948-babb-2691">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4064-4030-d200-f5d6" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcc9-8726-ec5a-e7bc" type="min"/>
@@ -122,7 +131,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3440-1ece-770f-f46a" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -131,28 +140,28 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="6cf7-9b31-6c65-44ce" name="Poisonous Fangs (makes all attacks Venomous)" hidden="false" collective="false">
+        <selectionEntryGroup id="6cf7-9b31-6c65-44ce" name="Venomous Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dc5-549a-7531-db5c" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="a4ed-bede-61d5-c0f8" name="Poisonous Fangs" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="a4ed-bede-61d5-c0f8" name="Venomous" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="747a-88c7-141d-06be" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8b66-14e1-bf38-1bd8" name="Serpent Lord Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="839c-650f-9452-91a9">
+        <selectionEntryGroup id="8b66-14e1-bf38-1bd8" name="Wound Upgrade" hidden="false" collective="false" defaultSelectionEntryId="839c-650f-9452-91a9">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebca-0ba8-5c13-a83c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a6f-6b50-46f6-0733" type="max"/>
@@ -164,7 +173,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3f9e-4ed1-6030-198a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -173,7 +182,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -190,7 +199,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e720-6c1c-cb62-0a35" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -199,7 +208,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4493-4cfc-3e9d-e069" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -208,7 +217,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="92fc-720f-6f36-8b09" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -217,85 +226,18 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="d8cd-30d2-101f-3e84" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7f8-0e11-64c7-eca6" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="5aa5-a4a4-c039-49fc" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="11cf-e0ec-2554-e7b1" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="dbf8-6f35-ec0a-f0f2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="5162-efcf-cb9e-d541" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b997-514e-55d0-473d" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="f26d-edf5-54a5-fbd3" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e58f-98c6-81e7-f284" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="c1f5-285a-e82d-461f" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="835c-7550-3ba8-1a6e" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7e90-566f-d32e-c8fe" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6ea1-4172-fa68-e1a0" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="613f-ab5f-dadb-6cd6" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="678c-924d-94f7-734a" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="e90a-3b2b-9aa4-87de" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="33c2-8eb8-3217-0bcb" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2019-dbf1-8aa9-364d" name="Snakeman High-Priest of Hissta [60 pts]" hidden="false" collective="false" type="unit">
@@ -303,25 +245,23 @@
         <categoryLink id="5a11-bfe5-42f8-4422" name="New CategoryLink" hidden="false" targetId="wizard unit" primary="true"/>
         <categoryLink id="198e-9bd8-a312-1917" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="5d77-6524-ec27-dcd3" name="High Priest" hidden="false" collective="false" defaultSelectionEntryId="17f0-65d6-ad91-c94d">
+      <selectionEntries>
+        <selectionEntry id="f5a3-559b-b85f-5c1f" name="Snakeman High-Priest" hidden="false" collective="false" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1192-dcf9-1bb7-3144" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c725-d12d-1dcf-76ab" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b42-2b0d-f9b9-22a5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7077-cb0d-7a3b-dd6e" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="17f0-65d6-ad91-c94d" name="Snakeman High-Priest" hidden="false" collective="false" type="model">
-              <infoLinks>
-                <infoLink id="8aff-9f56-b056-ae88" name="Snakeman High-Priest" hidden="false" targetId="18d2-7397-779b-f993" type="profile"/>
-                <infoLink id="bbdc-6f0c-905a-8849" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="60.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+          <infoLinks>
+            <infoLink id="d4d2-d974-5130-306e" name="Snakeman High-Priest" hidden="false" targetId="18d2-7397-779b-f993" type="profile"/>
+            <infoLink id="cbcc-7065-e02b-cafd" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="60.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="b49d-3c0b-d9b6-cf9f" name="Magic Level" hidden="false" collective="false" defaultSelectionEntryId="0737-6c8e-4d7a-89c9">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5590-2eae-7702-d37e" type="max"/>
@@ -334,7 +274,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ff02-d2fd-50db-de94" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -343,7 +283,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f732-8518-f069-ef11" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -352,7 +292,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -369,7 +309,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c80a-2120-1dc3-2955" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -378,7 +318,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2e8d-b3c7-f838-1292" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -387,7 +327,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da07-4691-43f4-2f15" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -396,7 +336,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a42e-c7b9-18db-3418" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -405,7 +345,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c78-7df7-e7d6-7d77" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -414,7 +354,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6102-3ce3-1747-d9aa" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -423,7 +363,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9394-e443-a958-921f" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -432,7 +372,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2a14-cfa0-fc14-b278" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -441,7 +381,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4b00-73b0-0672-83aa" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -450,7 +390,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9fcd-c770-f0b8-2a13" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -459,7 +399,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e842-3ef1-89e9-57de" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -468,7 +408,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a32c-0e35-e71f-0f74" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -477,7 +417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4201-22ae-6d01-83bc" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -486,7 +426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -502,7 +442,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d557-7b9a-4c07-ac2b" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -514,7 +454,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de1d-ea81-2ccf-8f80" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -526,7 +466,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0107-16ec-14c4-a655" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -538,7 +478,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e9e1-4630-3953-2e34" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -550,7 +490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4041-8992-74f2-534b" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -562,7 +502,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6c06-bcda-2b07-05b5" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -574,7 +514,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c72d-5f19-dc88-9797" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -586,7 +526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8be2-8b0a-bbe7-5721" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -598,7 +538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d5c6-dc8f-e3e2-7567" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -610,7 +550,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="999c-ce3f-be75-176a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -622,7 +562,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1243-d77e-44a0-dd7a" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -634,7 +574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7458-06ea-264b-bf2c" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -646,7 +586,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c657-e0b2-708f-1b10" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -658,12 +598,12 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="20b3-3aa5-c11e-e1ed" name="High-Priest Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="eda7-7a13-ddba-14be">
+        <selectionEntryGroup id="20b3-3aa5-c11e-e1ed" name="Tough Upgrade" hidden="false" collective="false" defaultSelectionEntryId="eda7-7a13-ddba-14be">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d388-a2d9-8d26-f94c" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5681-cf08-d4d8-7bcb" type="min"/>
@@ -675,7 +615,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f6eb-82fb-174a-6419" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -684,7 +624,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -708,7 +648,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="209a-458e-040d-659d" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -724,7 +664,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ed10-d05c-b2c3-e68c" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -733,7 +673,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -756,7 +696,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -764,7 +704,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de00-ff55-111a-81a3" name="Spirits" hidden="false" collective="false" type="upgrade">
@@ -781,7 +721,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -789,7 +729,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -799,91 +739,24 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ad1-6143-4ec3-ab47" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="acc3-df98-5dba-4370" name="Servants of the Cosmic Sky (Disciplined rule)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="acc3-df98-5dba-4370" name="Disciplined" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="7b87-b6e0-dc19-5192" name="Disciplined" hidden="false" targetId="0056-a41e-408e-1673" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="302f-cc12-5c45-ae34" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57d7-2630-ae0f-c7e9" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="3e5a-0c65-6805-db8b" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="eb22-04d7-fd5b-4371" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c5d4-7702-9a86-ace7" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="bf96-bc81-a237-eb24" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c6fb-545f-a304-f241" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7ab1-3df5-8006-de29" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7e25-fd2b-1036-15d9" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="49dd-acd8-d97e-54ce" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="084c-40d5-56d9-7141" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="82c7-1703-e39a-ee6c" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="51e1-d088-8a78-fc02" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="34cf-31b1-9423-30a9" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6cc6-3b48-68bf-a9a8" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="47ce-89dd-b058-ef5f" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1242-adba-3c8a-a88e" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1a5e-d33f-9652-297f" name="Snakeman Cosmic Star Serpent Hero [86 pts]" hidden="false" collective="false" type="unit">
@@ -897,7 +770,7 @@
         <categoryLink id="30aa-ed61-0239-45dd" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="7911-b6f6-1941-7eb5" name="Hero Model" hidden="false" collective="false" defaultSelectionEntryId="bc38-d313-c6a6-e646">
+        <selectionEntryGroup id="7911-b6f6-1941-7eb5" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="bc38-d313-c6a6-e646">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f626-19cc-7878-e879" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f48c-e347-554f-79c3" type="min"/>
@@ -909,7 +782,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="86.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="20f3-a7f9-64ff-ac91" name="Snakeman Hero in Light Armour" hidden="false" collective="false" type="model">
@@ -918,7 +791,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="96.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="04d1-ac6a-4342-2533" name="Snakeman Hero in Medium Armour" hidden="false" collective="false" type="model">
@@ -927,7 +800,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="106.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -944,7 +817,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2067-0ddd-d02b-658d" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -953,7 +826,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="41fe-c8d8-c4b9-5d04" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -962,7 +835,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b640-2656-7500-f5ef" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -971,7 +844,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -988,7 +861,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="752c-04a9-3365-da57" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -997,7 +870,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d36b-a862-349e-1bc7" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1006,7 +879,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1023,7 +896,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="de95-7a8b-59e1-0927" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1032,23 +905,23 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="49d5-ae4c-05a5-b2c2" name="Poisonous Fangs (makes all attacks Venomous)" hidden="false" collective="false">
+        <selectionEntryGroup id="49d5-ae4c-05a5-b2c2" name="Poisonous Fangs Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b1b-aa96-f173-1d23" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="716f-e0a2-a5dc-9912" name="Poisonous Fangs" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="716f-e0a2-a5dc-9912" name="Venomous" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="4048-94c9-1aee-cef1" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1058,99 +931,35 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d45-a75d-6d2b-692c" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="d7d0-8e05-79f2-0430" name="Cosmic Destiny (Gives Divine Intervention)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="d7d0-8e05-79f2-0430" name="Divine Intervention" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="7fee-e95d-265e-0f0e" name="Divine Intervention" hidden="false" targetId="a447-d495-b7ab-1477" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="3add-3312-41ff-0a15" name="Magic Weapon " hidden="false" collective="false">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58a2-3456-6e6e-25d3" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="f2a3-2631-3bd2-646f" name="Foe Striker" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="6034-514c-d2f5-830c" name="(Magic Weapon) Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="63b8-b32d-64ea-9207" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="55e5-a66c-5155-8c6b" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="095e-2101-1382-5415" name="War Bringer" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="6a98-29cd-1cf1-c2d5" name="(Magic Weapon) War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e94e-d081-1208-bc1f" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="2dcf-9734-06b7-a815" name="(Magic Weapon) Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f564-8f16-2fe3-8460" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="ea7d-108c-b904-db43" name="(Magic Weapon) Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="26fa-ce47-e67b-e29e" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="cd97-597d-a247-c452" name="(Magic Weapon) Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d312-06a5-e4e3-7529" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="f47e-7592-e4ba-7021" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="671b-eb1b-7bed-f25b" name="Magic Weapons" hidden="false" collective="false" targetId="04c0-42c1-8864-cf22" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7cba-b245-d058-46af" name="Snakeman Python Guard [82 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4884-24ee-0c18-e5b1" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="a254-b10e-25ef-b72f" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="c999-922b-9ffd-2bc7" name="Models" hidden="false" collective="false" defaultSelectionEntryId="c08c-990d-c37c-7e8e">
+        <selectionEntryGroup id="c999-922b-9ffd-2bc7" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="c08c-990d-c37c-7e8e">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd7e-3d88-ee48-da71" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac29-23e6-1496-8795" type="min"/>
@@ -1171,7 +980,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9e27-bffa-e77b-4cf9" name="Snakeman Python Guard" hidden="false" collective="false" type="model">
@@ -1184,7 +993,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1192,7 +1001,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a112-5b56-ed27-fb46" name="Python Guard in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1210,7 +1019,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="19de-dc65-2f75-3205" name="Snakeman Python Guard" hidden="false" collective="false" type="model">
@@ -1223,7 +1032,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="16.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1231,7 +1040,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1248,7 +1057,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c34b-5aaf-e17f-daab" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1257,7 +1066,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cecd-dacc-06fa-d32e" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1266,7 +1075,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6756-bc6d-c1b8-3435" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1275,7 +1084,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1285,7 +1094,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3863-44ab-4386-f1de" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6cd5-f6eb-1c54-455d" name="Cold-Eyed (Adding Stubborn Rule)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6cd5-f6eb-1c54-455d" name="Stubborn" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
@@ -1298,7 +1107,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1306,7 +1115,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="37b6-f4e6-0e5d-6d14" name="Snakeman Warriors [72 pts]" hidden="false" collective="false" type="unit">
@@ -1314,13 +1123,13 @@
         <categoryLink id="e4d3-1c86-8538-a954" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="26f6-4acf-126c-e1cc" name="Models" hidden="false" collective="false" defaultSelectionEntryId="21f7-31f2-43af-6537">
+        <selectionEntryGroup id="26f6-4acf-126c-e1cc" name="Armour" hidden="false" collective="false" defaultSelectionEntryId="21f7-31f2-43af-6537">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24c5-f2c5-53ee-1776" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1990-0814-4e64-7317" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="21f7-31f2-43af-6537" name="Snakeman Warriors" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="21f7-31f2-43af-6537" name="Snakeman Warriors (no armour)" hidden="false" collective="false" type="upgrade">
               <selectionEntryGroups>
                 <selectionEntryGroup id="2dad-6043-7f1f-ebac" name="Snakeman Warriors" hidden="false" collective="false">
                   <selectionEntries>
@@ -1335,7 +1144,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="24.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="d673-810d-9059-6534" name="Snakeman Warriors" hidden="false" collective="false" type="model">
@@ -1348,7 +1157,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1356,7 +1165,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3b7a-02b0-e81c-58ba" name="Snakeman Warriors in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -1374,7 +1183,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="510f-aef8-abdb-3249" name="Snakeman Warriors in Light Armour" hidden="false" collective="false" type="model">
@@ -1387,7 +1196,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                        <cost name=" order dice" typeId="orderDice" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -1395,7 +1204,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1412,7 +1221,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f120-e673-346b-6ff2" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -1421,7 +1230,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da2d-0b45-d842-a71a" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1430,7 +1239,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="16e9-94a4-fd6b-dcda" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -1439,7 +1248,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1447,61 +1256,62 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9033-ab9b-3a31-06fd" name="Snakeman Viper Warriors [77 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="5a4f-9f38-577e-4fe5" name="Bow" hidden="false" targetId="95e1-d9f2-8182-5835" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="1d47-a883-db09-12dd" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="5735-df59-dacb-115d" name="Models" hidden="false" collective="false" defaultSelectionEntryId="d6fe-aed6-8437-4b7b">
+      <selectionEntries>
+        <selectionEntry id="a1cd-d781-c26d-c7e3" name="Snakeman Viper Warriors" hidden="false" collective="false" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80ba-6ba5-623e-3307" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2815-5c99-eb93-4ea9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01ba-2bcb-6900-f7f6" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c94-76a1-c948-1b07" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="d6fe-aed6-8437-4b7b" name="Snakeman Viper Warriors" hidden="false" collective="false" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="c98c-a061-d912-3bf5" name="Snakeman Viper Warriors" hidden="false" collective="false">
-                  <selectionEntries>
-                    <selectionEntry id="4f30-8714-cf81-15b8" name="Snakeman Viper Warrior Leader" hidden="false" collective="false" type="model">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a00-4fcd-7fc4-72ba" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77d6-7226-9782-1835" type="min"/>
-                      </constraints>
-                      <infoLinks>
-                        <infoLink id="4a06-b937-5305-da70" name="Snakeman Viper Warrior Leader" hidden="false" targetId="67c4-4e5d-227d-d26e" type="profile"/>
-                        <infoLink id="6c8e-40a4-53c6-e660" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="2028-5d67-0165-2478" name="Snakeman Warriors" hidden="false" collective="false" type="model">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc8f-7ed6-d921-c068" type="max"/>
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd11-fd37-fdf3-70b0" type="min"/>
-                      </constraints>
-                      <infoLinks>
-                        <infoLink id="723f-1354-8a72-bcdd" name="Snakeman Viper Warrior" hidden="false" targetId="2ff7-a261-cc2f-1192" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="13.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f7bf-6e6a-c029-7222" name="Snakeman Viper Warriors" hidden="false" collective="false">
+              <selectionEntries>
+                <selectionEntry id="48e2-b4cf-1239-d2af" name="Snakeman Viper Warrior Leader" hidden="false" collective="false" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b808-d599-d8d8-2f65" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a013-6014-c838-0d22" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="4924-2ce6-c917-6356" name="Snakeman Viper Warrior Leader" hidden="false" targetId="67c4-4e5d-227d-d26e" type="profile"/>
+                    <infoLink id="5149-d1e3-92df-9d27" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="25.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="12f5-32fe-e84e-7f77" name="Snakeman Warriors" hidden="false" collective="false" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e32-d2ac-bbba-7024" type="max"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3de-e5ad-0cea-9130" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="9143-8de0-9b31-ee7b" name="Snakeman Viper Warrior" hidden="false" targetId="2ff7-a261-cc2f-1192" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="13.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="9166-ebc7-0d18-c9ba" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="a40e-4e95-5e63-f805">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0d9-bf00-f0ef-90ad" type="max"/>
@@ -1521,7 +1331,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="369d-0781-3f1e-ba04" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1537,7 +1347,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a40e-4e95-5e63-f805" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -1546,7 +1356,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1556,30 +1366,13 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff32-cbb6-0c0c-1d6b" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="7955-79d2-4db7-c1d6" name="Poisonous Arrows (Bow hits count as Venomous)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="7955-79d2-4db7-c1d6" name="Venomous" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="7135-1f5d-71a8-c19d" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="6faf-1a21-61e0-71be" name="Bows" hidden="false" collective="false" defaultSelectionEntryId="f1a5-a9bc-7d7c-e88f">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aff9-3e45-24f4-2292" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03d3-26fd-2daa-6ff9" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="f1a5-a9bc-7d7c-e88f" name="Bows" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="98a4-668b-9ec1-f571" name="Bow" hidden="false" targetId="95e1-d9f2-8182-5835" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1587,64 +1380,54 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="995b-88e6-92aa-8220" name="Snakeman Cobra Guard [87 pts]" hidden="false" collective="false" type="unit">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbc2-6757-f7bf-22f1" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbc2-6757-f7bf-22f1" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="2424-9efe-11d5-23ee" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
+        <infoLink id="adb6-70ea-3036-0746" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="b095-20f6-db74-1431" name="Fire Order to Shoot" hidden="false" targetId="d2a3-26b0-f825-e454" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="5d1b-e12a-64b5-678a" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="090b-0b22-37af-2348" name="Models" hidden="false" collective="false" defaultSelectionEntryId="7de8-3270-7cc0-3531">
+      <selectionEntries>
+        <selectionEntry id="a4ef-a072-8ce6-4492" name="Snakeman Cobra Guard" hidden="false" collective="false" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a56-7ea4-5f1f-90ed" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="566f-f71b-4005-2e70" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e226-39c9-fe6b-b6f8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ff9-70c1-5ed4-3526" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="7de8-3270-7cc0-3531" name="Snakeman Cobra Guard" hidden="false" collective="false" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="7198-09c6-50d8-7cef" name="Snakemen Cobra Guard" hidden="false" collective="false">
-                  <selectionEntries>
-                    <selectionEntry id="6a2f-2c43-febf-98f9" name="Snakeman Cobra Guard Leader" hidden="false" collective="false" type="model">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3000-3021-807b-e425" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8915-92f4-184a-fe0c" type="min"/>
-                      </constraints>
-                      <infoLinks>
-                        <infoLink id="836c-f6c2-8ccc-dd31" name="Snakemen Cobra Guard Leader" hidden="false" targetId="0de9-1e2e-92bb-de08" type="profile"/>
-                        <infoLink id="0886-f94b-983d-ab15" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="31.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="ba64-6d55-8979-525d" name="Snakemen Cobra Guard" hidden="false" collective="false" type="model">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="712e-35af-1a65-00d1" type="max"/>
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87e5-2eb1-c829-f917" type="min"/>
-                      </constraints>
-                      <infoLinks>
-                        <infoLink id="be81-5013-6082-5730" name="Snakemen Cobra Guard" hidden="false" targetId="e2cd-774e-9678-6a11" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="14.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e521-620b-7504-56be" name="Snakeman Cobra Guard" hidden="false" collective="false">
+              <selectionEntries>
+                <selectionEntry id="193f-6cd5-7553-f929" name="Snakeman Cobra Guard" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3679-6cb3-3e01-7b50" type="max"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9762-f1de-4e05-6ce1" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="2e76-a1a6-9460-ea11" name="Snakemen Cobra Guard" hidden="false" targetId="e2cd-774e-9678-6a11" type="profile"/>
+                  </infoLinks>
+                </selectionEntry>
+                <selectionEntry id="a7d6-16d0-c41d-8576" name="Snakeman Cobra Guard Leader" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b323-5453-bd32-1b57" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d18-4afb-dfad-bfe8" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="b819-f7e4-8da8-dcf8" name="Snakemen Cobra Guard Leader" hidden="false" targetId="0de9-1e2e-92bb-de08" type="profile"/>
+                  </infoLinks>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="d44a-cdaa-3ad0-e087" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="9692-2f72-d29c-cf6e">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26ef-7cd6-956c-7222" type="max"/>
@@ -1664,7 +1447,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a002-9b39-159f-50f5" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -1680,7 +1463,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9692-2f72-d29c-cf6e" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -1689,40 +1472,23 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4f07-8793-08a1-600a" name="Poisonous quarrels Upgrade" hidden="false" collective="false">
+        <selectionEntryGroup id="4f07-8793-08a1-600a" name="Poisonous Quarrels Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8be4-ad62-d25f-004d" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="fa15-897a-740c-0942" name="Poisonous quarrels (Crossow hits count as Venomous)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="fa15-897a-740c-0942" name="Venomous" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="0d11-caea-50f8-e347" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="e5da-a6ce-42dd-b17b" name="Crossbow" hidden="false" collective="false" defaultSelectionEntryId="dad1-d136-af29-5835">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e54-f275-e87e-3df9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02e7-0df4-ce80-bad1" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="dad1-d136-af29-5835" name="Crossbows" hidden="false" collective="false" type="upgrade">
-              <infoLinks>
-                <infoLink id="7b21-d240-e3ca-715e" name="Crossbow" hidden="false" targetId="d39c-4b92-3b2f-a1dc" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1732,7 +1498,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c658-f96b-9f65-2db2" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6c19-9ed5-1a1a-dc7a" name="Cold-eyed (adds Stubborn rule)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="6c19-9ed5-1a1a-dc7a" name="Stubborn" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
@@ -1745,7 +1511,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1753,46 +1519,36 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="00aa-31c0-56fc-f219" name="Hemata Elder Guardian [41 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6fd-11ea-f0fa-baa4" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="f031-9409-7340-8d28" name="Hemata Guardian" hidden="false" targetId="93b2-0a32-88c5-9011" type="profile"/>
+        <infoLink id="dbd8-db7b-3ba9-bba5" name="Choking" hidden="false" targetId="7ff2-1650-fc0e-5a3a" type="rule"/>
+        <infoLink id="bcb1-cd8c-6597-af53" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="b65d-caf7-512e-622e" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="9973-af89-79b8-5c63" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="e4d3-ad84-8d2f-26d7" name="Hemata Elder Guardian" hidden="false" collective="false" defaultSelectionEntryId="afde-f2c9-4e00-9fbe">
-          <selectionEntries>
-            <selectionEntry id="afde-f2c9-4e00-9fbe" name="Hemata Elder Guardian" hidden="false" collective="false" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="454a-aa45-33dd-1e04" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa63-5217-91d4-bedf" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="4b7f-23e6-7a9d-b5a0" name="Hemata Guardian" hidden="false" targetId="93b2-0a32-88c5-9011" type="profile"/>
-                <infoLink id="0e37-ffe3-ed11-1e66" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="9faf-c3f4-ce61-8af1" name="Choking" hidden="false" targetId="7ff2-1650-fc0e-5a3a" type="rule"/>
-                <infoLink id="eef6-2f52-d918-9ad5" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="41.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="ea09-f83c-6b88-0356" name="Additonal Hemata Guardian" hidden="false" collective="false">
+        <selectionEntryGroup id="ea09-f83c-6b88-0356" name="Hemata Guardians" hidden="false" collective="false">
           <selectionEntries>
             <selectionEntry id="d8d7-de9f-9c0b-0740" name="Hemata Guardian" hidden="false" collective="false" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f064-12a3-82b1-bcee" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f064-12a3-82b1-bcee" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d074-f770-bf6a-0967" type="min"/>
               </constraints>
               <infoLinks>
                 <infoLink id="c1bf-3443-b9a6-2e50" name="Hemata Guardian" hidden="false" targetId="93b2-0a32-88c5-9011" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="36.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1808,7 +1564,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1816,7 +1572,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="73c2-ab60-7aef-87f4" name="Gorgon Elder Serpent [62 pts]" hidden="false" collective="false" type="unit">
@@ -1826,35 +1582,36 @@
       <categoryLinks>
         <categoryLink id="df7b-a7ec-aaf3-9ee3" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="882a-67fc-20d6-d474" name="Gorgon" hidden="false" collective="false" defaultSelectionEntryId="f613-2307-c1c3-3e4b">
+      <selectionEntries>
+        <selectionEntry id="544d-1df9-2748-c04b" name="Gorgon with Bow" hidden="false" collective="false" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1925-4329-7ebc-a8c0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0dd2-abbc-2258-0ba2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78be-6646-9e09-d8c3" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad75-d91e-3fb7-c585" type="min"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="f613-2307-c1c3-3e4b" name="Gorgon with Bow" hidden="false" collective="false" type="model">
-              <infoLinks>
-                <infoLink id="2e3a-e652-963f-d739" name="Gorgon" hidden="false" targetId="c4ef-78fa-e9cf-a2e8" type="profile"/>
-                <infoLink id="bd0e-982e-4289-67ac" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="fc6a-6ac9-7b6d-6e0d" name="Bow" hidden="false" targetId="95e1-d9f2-8182-5835" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="62.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+          <infoLinks>
+            <infoLink id="dbde-0d23-b619-3158" name="Gorgon" hidden="false" targetId="c4ef-78fa-e9cf-a2e8" type="profile"/>
+            <infoLink id="89f5-ba7d-ab24-fc7a" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+            <infoLink id="a890-c685-afd6-b5e7" name="Bow" hidden="false" targetId="95e1-d9f2-8182-5835" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="62.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="196e-1df6-f721-bac4" name="Baleful Glare Upgrade" hidden="false" collective="false">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2da4-11c8-62df-84d6" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="8ba4-8e74-e61f-b0bd" name="Baleful Glare (can shoot bow or use glare, but not both at same time)" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="324a-190d-139f-952d" name="Baleful Glare" hidden="false" targetId="9855-31c9-3745-714d" type="rule"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1864,13 +1621,13 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e4c-458b-b110-614e" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4a5d-3fac-7ff6-0362" name="Poisonous Arrows (Bow hits count as Venomous)" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="4a5d-3fac-7ff6-0362" name="Venomous (bow hits only)" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="2624-5bcd-40f3-9c58" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1887,7 +1644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4103-e8fc-92b3-f39a" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1896,7 +1653,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1904,98 +1661,95 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c1d8-f242-88b4-7ce4" name="Saurian Slithering Beast Pack [94 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="5b01-0241-b541-562a" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
+        <infoLink id="e6f9-b473-75c5-9cf8" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+        <infoLink id="e548-2e9b-db4f-402c" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="50fc-7522-b9fa-d20a" name="New CategoryLink" hidden="false" targetId="c061-a0f2-e7d4-a23b" primary="true"/>
         <categoryLink id="8c69-aab2-d0b2-cd51" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="d08a-3120-b0d7-b92c" name="Models" hidden="false" collective="false">
-          <selectionEntries>
-            <selectionEntry id="992e-e796-c627-7331" name="Pack Master" hidden="false" collective="false" type="upgrade">
+      <selectionEntries>
+        <selectionEntry id="3374-ca12-4ecc-e466" name="Pack Master" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff1d-e93f-e5cf-897d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8eb-f424-0047-928e" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="46be-ca2c-a876-bc92" name="Pack Master" hidden="false" collective="false" defaultSelectionEntryId="dee4-ed99-1c4f-dbd7">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9d1-913d-ef65-b7d7" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55b0-0a60-c77d-491c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4b3-0ec9-2095-e1d9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea22-16c4-e8ea-0746" type="min"/>
               </constraints>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="b4bf-e5a8-f7f3-745f" name="Pack Master" hidden="false" collective="false" defaultSelectionEntryId="294c-b35a-da45-4f44">
+              <selectionEntries>
+                <selectionEntry id="dee4-ed99-1c4f-dbd7" name="Snakeman Pack Master (no armour)" hidden="false" collective="false" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79e6-231a-095c-e776" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d276-6853-e25d-994a" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbbb-433d-f92a-5e10" type="max"/>
                   </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="294c-b35a-da45-4f44" name="Snakeman Pack Master" hidden="false" collective="false" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4654-ff3c-a700-1cd4" type="max"/>
-                      </constraints>
-                      <infoLinks>
-                        <infoLink id="02b2-6eea-ff2c-760e" name="Snakeman Pack Master" hidden="false" targetId="ae15-5d71-d1f1-6cd9" type="profile"/>
-                        <infoLink id="1fcc-44a6-6d4d-f84e" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
-                        <infoLink id="5f7f-c1a9-7945-0d45" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="26.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="6deb-a7da-9c79-f955" name="Snakeman Pack Master in Light Armour" hidden="false" collective="false" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d22-5f58-cd1c-74a2" type="max"/>
-                      </constraints>
-                      <infoLinks>
-                        <infoLink id="efb0-69c7-e77b-4c89" name="Snakeman Pack Master in Light Armour" hidden="false" targetId="5cbe-12a3-d570-ea10" type="profile"/>
-                        <infoLink id="df04-7bc7-9a43-7eb5" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
-                        <infoLink id="69b6-c1f9-b1af-7f78" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="28.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e6df-3af4-1018-bcfa" name="Saurian Beasts" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd55-22dc-2bab-c3f7" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89b1-44e7-79fa-699c" type="max"/>
-              </constraints>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="cd3f-b0d5-f87e-b128" name="Saurian Beasts" hidden="false" collective="false" defaultSelectionEntryId="d355-fdec-ddba-7c5a">
-                  <selectionEntries>
-                    <selectionEntry id="d355-fdec-ddba-7c5a" name="Saurian Beasts" hidden="false" collective="false" type="model">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f57b-ed83-1af4-7e29" type="max"/>
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e32-a1fa-48c0-39df" type="min"/>
-                      </constraints>
-                      <infoLinks>
-                        <infoLink id="e116-10ff-1a56-7c80" name="Saurian Beast" hidden="false" targetId="0ee0-9140-215b-34fb" type="profile"/>
-                        <infoLink id="ed34-a10e-73d9-89fa" name="Rapid Sprint" hidden="false" targetId="1e90-54e2-dd77-c4e3" type="rule"/>
-                        <infoLink id="764e-94dd-955a-4598" name="Savage" hidden="false" targetId="c3b6-8870-61d6-7aaf" type="rule"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
+                  <infoLinks>
+                    <infoLink id="2b1a-c676-7c9c-7c64" name="Snakeman Pack Master" hidden="false" targetId="ae15-5d71-d1f1-6cd9" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="26.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4eea-e30c-bfd4-74a9" name="Snakeman Pack Master in Light Armour" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23f2-5b45-1ce5-0bf9" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="070d-b45c-a71a-4fb0" name="Snakeman Pack Master in Light Armour" hidden="false" targetId="5cbe-12a3-d570-ea10" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="28.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cb1b-c34d-f342-ca3a" name="Saurian Beasts" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="532f-cd8e-9442-1709" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2f7-0591-b0af-b0d2" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b212-b021-2488-2023" name="Saurian Beasts" hidden="false" collective="false">
+              <selectionEntries>
+                <selectionEntry id="de27-db8e-4766-46e5" name="Saurian Beasts" hidden="false" collective="false" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="257b-4ea8-8940-1ba1" type="max"/>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="207f-a23e-1704-75b4" type="min"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="eee6-65a9-e286-8e0f" name="Saurian Beast" hidden="false" targetId="0ee0-9140-215b-34fb" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="points" value="17.0"/>
+                    <cost name=" order dice" typeId="orderDice" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
         <selectionEntryGroup id="d3e8-67f8-8498-d766" name="Packmaster HtH weapon" hidden="false" collective="false" defaultSelectionEntryId="fdb0-f262-3a4b-c9be">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df1f-ec14-a0df-75b3" type="min"/>
@@ -2008,7 +1762,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="161c-4036-7a6c-ee2b" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2017,7 +1771,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="159c-eb2e-7496-a9e3" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -2026,7 +1780,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2037,9 +1791,12 @@
           </constraints>
           <selectionEntries>
             <selectionEntry id="8e27-5d6a-b89d-d9a2" name="Packmaster Bow Upgrade" hidden="false" collective="false" type="upgrade">
+              <infoLinks>
+                <infoLink id="d486-105c-2d06-bc9a" name="Bow" hidden="false" targetId="95e1-d9f2-8182-5835" type="profile"/>
+              </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2049,7 +1806,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a18-4ace-6354-f8f4" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="b3ff-d6bc-92e2-483c" name="Give Saurian Beasts Choking Attacks" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="b3ff-d6bc-92e2-483c" name="Choking" hidden="false" collective="false" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
@@ -2062,16 +1819,16 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="df82-c8e4-244f-8bde" name="Give Saurian Beasts Venomous Attacks" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="df82-c8e4-244f-8bde" name="Venomous" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="29e1-cf36-33e8-005a" name="Venomous" hidden="false" targetId="53b9-a3e9-0e9f-2d77" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2079,7 +1836,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="19f9-b7db-3799-e42a" name="Pterosaurs [129 pts]" hidden="false" collective="false" type="unit">
@@ -2100,12 +1857,12 @@
               <infoLinks>
                 <infoLink id="a95f-046b-2d11-f651" name="Pterosaur" hidden="false" targetId="2b7d-462f-ffbc-2260" type="profile"/>
                 <infoLink id="4118-548e-a1bc-b1b8" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
-                <infoLink id="3173-7582-6cbf-2032" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+                <infoLink id="3173-7582-6cbf-2032" name="Fast 10" hidden="false" targetId="0034-82ae-f695-d446" type="rule"/>
                 <infoLink id="0d4d-92b6-d83f-8d9f" name="Surly" hidden="false" targetId="8a4d-4dea-f005-ddc5" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="43.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+                <cost name=" order dice" typeId="orderDice" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2113,96 +1870,135 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3cb6-522d-f175-f84e" name="Tyrannosaur/Sail Back Saurian/Giant Horned Saurian" hidden="false" collective="false" type="unit">
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0100-f7ee-ab55-4691" type="max"/>
-      </constraints>
+    <selectionEntry id="242e-666d-78d7-0b00" name="Giant Horned Saurian" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="dbda-3c99-5969-0935" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="869e-2989-07e2-957f" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
-        <infoLink id="19b0-0b76-42b4-a343" name="Terror" hidden="false" targetId="583a-fa53-11ff-7b40" type="rule"/>
         <infoLink id="3df5-c7ae-f496-83b9" name="Surly" hidden="false" targetId="8a4d-4dea-f005-ddc5" type="rule"/>
+        <infoLink id="78bb-cffd-100a-a45b" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+        <infoLink id="5518-3d05-d7d4-0513" name="Stampede" hidden="false" targetId="45b3-c028-8c8c-43ae" type="rule"/>
+        <infoLink id="9165-1bb0-e83c-2f18" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0be5-79b6-9460-7c39" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
+        <categoryLink id="35f1-327b-9093-bf8d" name="Snakeman Monstrosity" hidden="false" targetId="9fb1-47aa-24d5-0f85" primary="false"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="0f58-a38b-b02b-dfd3" name="Model" hidden="false" collective="false">
+      <selectionEntries>
+        <selectionEntry id="6ec1-2121-1b3f-48a6" name="Giant Horned Saurian" hidden="false" collective="false" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="264e-0953-2b12-67eb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcb2-e0d6-3713-233d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29c4-1c8b-9e1e-efeb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d3a-c7fc-8d46-f29c" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="65af-6de2-8cc2-e013" name="Tyrannosaur" hidden="false" collective="false" type="model">
-              <infoLinks>
-                <infoLink id="8a6b-990c-9087-46b7" name="Tyrannosaur" hidden="false" targetId="6c2e-9aa4-1b3b-126e" type="profile"/>
-                <infoLink id="753b-3f75-b466-0a71" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="188.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6b28-7ddf-fb35-978d" name="Sail Back Saurian" hidden="false" collective="false" type="model">
-              <infoLinks>
-                <infoLink id="eaa6-c2d5-e041-13da" name="Sail Back Saurian" hidden="false" targetId="6a7b-c37f-621d-3470" type="profile"/>
-                <infoLink id="ba6e-7345-70d5-e307" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="126.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="913b-a478-a055-62f0" name="Giant Horned Saurian" hidden="false" collective="false" type="model">
-              <infoLinks>
-                <infoLink id="0fec-040d-6cba-f98c" name="Giant Horned Saurian" hidden="false" targetId="b74d-5550-565f-8794" type="profile"/>
-                <infoLink id="85d6-9e72-c269-e966" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="122.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+          <infoLinks>
+            <infoLink id="f63e-ccf5-758e-64ad" name="Giant Horned Saurian" hidden="false" targetId="b74d-5550-565f-8794" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="122.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="2.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c917-12a1-c769-10e1" name="Raptors [93 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24e2-6e19-ebdd-1b12" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="a1e8-455d-2f92-b62f" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="2944-aa52-afb9-1b78" name="Raptors" hidden="false" collective="false" defaultSelectionEntryId="d6d6-9722-65ba-ee72">
-          <selectionEntries>
-            <selectionEntry id="d6d6-9722-65ba-ee72" name="Raptors" hidden="false" collective="false" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b33-060b-cb8d-c123" type="max"/>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a011-73bc-f1a7-43be" type="min"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="8a00-5b42-5a0c-aca8" name="Raptors" hidden="false" targetId="f291-ba80-8ec1-53a2" type="profile"/>
-                <infoLink id="8d05-4fa3-efd5-169c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="10c8-8af7-4a82-4437" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-                <infoLink id="ab62-1490-a66d-f024" name="Surly" hidden="false" targetId="8a4d-4dea-f005-ddc5" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="31.0"/>
-                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <selectionEntries>
+        <selectionEntry id="6c81-4b34-b181-7580" name="Raptors" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6418-b5b7-57bf-0850" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7277-835f-7349-5919" type="min"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="4e05-4a0e-3bfd-ab50" name="Raptors" hidden="false" targetId="f291-ba80-8ec1-53a2" type="profile"/>
+            <infoLink id="5a7f-bbe4-d3f7-655c" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+            <infoLink id="6bac-a874-ee73-944d" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+            <infoLink id="3483-d327-1d02-3af9" name="Surly" hidden="false" targetId="8a4d-4dea-f005-ddc5" type="rule"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="31.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
+        <cost name=" order dice" typeId="orderDice" value="1.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5ce8-543c-1a85-1343" name="Sail Back Saurian" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="d72d-8d67-0e57-6cd4" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="0f09-36d0-7d5a-a903" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
+        <infoLink id="6c60-287b-43af-4d7a" name="Surly" hidden="false" targetId="8a4d-4dea-f005-ddc5" type="rule"/>
+        <infoLink id="f646-d117-c2b9-2d15" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
+        <infoLink id="7c51-7491-d876-edcc" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b096-0c8f-a35f-5ccf" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
+        <categoryLink id="a6c5-428c-f1d7-7fa0" name="Snakeman Monstrosity" hidden="false" targetId="9fb1-47aa-24d5-0f85" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="070e-2139-cdcf-e0b9" name="Sail Back Saurian" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b381-6d1a-34ad-a39e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d765-4318-be9f-82bd" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="57de-b75a-3d4e-e663" name="Sail Back Saurian" hidden="false" targetId="6a7b-c37f-621d-3470" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="126.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="18a2-7a44-1f56-0b9b" name="Tyrannosaur" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="5caf-c39f-5f2c-f250" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="8e6b-d572-c23a-ca79" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
+        <infoLink id="f536-e76e-cfbd-e7d0" name="Terror" hidden="false" targetId="583a-fa53-11ff-7b40" type="rule"/>
+        <infoLink id="a87a-a930-b1c5-7b3b" name="Surly" hidden="false" targetId="8a4d-4dea-f005-ddc5" type="rule"/>
+        <infoLink id="0e22-29d3-5f38-0c47" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+        <infoLink id="2c20-1571-4c29-6fb1" name="MoD2" hidden="false" targetId="5da1-1bfa-9b8d-6b82" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8204-0b38-0962-8bc1" name="New CategoryLink" hidden="false" targetId="8efa-298b-b165-ef8b" primary="true"/>
+        <categoryLink id="0ece-6daa-e74a-3499" name="Snakeman Monstrosity" hidden="false" targetId="9fb1-47aa-24d5-0f85" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="341c-6bf1-81aa-d10e" name="Tyrannosaur" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cc9-ef0e-fbfb-a6b5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="311e-68af-df51-7433" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="cfb9-0f5f-3195-c116" name="Tyrannosaur" hidden="false" targetId="6c2e-9aa4-1b3b-126e" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="188.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="2.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Undead.cat
+++ b/Undead.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e5b3-ac3f-4947-9875" name="Undead" revision="2" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e5b3-ac3f-4947-9875" name="Undead" revision="3" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="be7a-2982-bed2-d5b1" name="Necromancer" hidden="false" collective="false" targetId="837f-5310-663b-e80c" type="selectionEntry"/>
     <entryLink id="7019-c706-1279-e7a8" name="Liche" hidden="false" collective="false" targetId="c169-7c00-8d5e-beb4" type="selectionEntry"/>
@@ -21,6 +21,9 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="837f-5310-663b-e80c" name="Necromancer [81 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="810c-be4f-9e3b-7273" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="11b5-c350-01ea-967a" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -41,6 +44,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -57,6 +61,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="21a1-3820-5a30-d96e" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -65,6 +70,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bdf8-377f-9a77-e3ef" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -73,6 +79,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -89,6 +96,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -105,6 +113,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7770-041b-eeaf-b262" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -113,6 +122,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="428d-2d79-ff02-79a7" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -121,6 +131,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -137,6 +148,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f7a-f18c-65dc-3575" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -145,6 +157,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e08-334d-6302-a693" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -153,6 +166,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -169,6 +183,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="23.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -193,6 +208,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -209,6 +225,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="44d9-481c-dd4d-84ad" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -217,6 +234,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="4125-5792-c0d2-d540" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -225,6 +243,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="fd63-4726-ffaa-406a" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -240,6 +259,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -249,6 +269,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="915f-a17d-ea5f-f21c" name="Bodyguards in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -266,6 +287,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -282,6 +304,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="b902-934a-9abf-b4d8" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -290,6 +313,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="6ce5-a5b6-e630-a54e" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -298,6 +322,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="0003-aa2c-a842-4ee6" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -313,6 +338,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -322,6 +348,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -338,6 +365,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2672-6938-6681-fdd9" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -346,6 +374,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1267-e860-d6b3-566d" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -354,6 +383,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ff9-0f62-c458-5e25" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -362,6 +392,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87ef-2150-f4dd-4be0" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -370,6 +401,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f29-518f-7ca5-3bfd" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -378,6 +410,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7380-3ada-e966-d906" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -386,6 +419,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d14-f52c-3401-9d3a" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -394,6 +428,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ca44-49ee-2831-c65a" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -402,6 +437,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="40b8-64e0-7ef6-264f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -410,6 +446,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2a33-e79b-fea5-f483" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -418,6 +455,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d822-74a3-91ec-a505" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -426,6 +464,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d511-9e64-6d4a-93dc" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -434,6 +473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df89-a591-08b8-040e" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -442,6 +482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -457,6 +498,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa2b-8d0c-58ad-8b89" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -468,6 +510,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b8c7-11b0-1b25-4802" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -479,6 +522,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="165e-eb4d-02fd-0599" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -490,6 +534,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="19cf-6597-7124-06bc" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -501,6 +546,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d7a6-d5dc-51a4-b991" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -512,6 +558,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3436-5ef5-f81a-631e" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -523,6 +570,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="473f-e90f-77c4-9ea0" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -534,6 +582,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90df-d6ce-68a6-8bef" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -545,6 +594,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fde8-15e4-7fae-8f20" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -556,6 +606,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58c7-7c78-400f-eb1e" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -567,6 +618,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6a1b-8082-47f5-13ca" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -578,6 +630,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbcf-7ee5-4f1a-3a16" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -589,6 +642,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c822-3fb3-2260-9009" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -600,6 +654,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -615,6 +670,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5c3e-1ece-17fa-e976" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -623,6 +679,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7cee-ce4a-451a-d58d" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -631,6 +688,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="615d-f52b-782d-4986" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -639,6 +697,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="06c0-d7cc-0b6b-d154" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -647,6 +706,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a345-6b9c-2ea4-d077" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -655,6 +715,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2e80-0d7b-9d5f-a171" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -663,6 +724,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -670,9 +732,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c169-7c00-8d5e-beb4" name="Liche [95 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="43d0-ae8a-ca79-df32" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="efe9-7ace-9588-c8c6" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -693,6 +759,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -717,6 +784,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -733,6 +801,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="3bd1-a6f3-486d-a92c" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -741,6 +810,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="ee3e-3174-42dd-b2a4" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -749,6 +819,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="822a-8df4-d037-8dd4" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -764,6 +835,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -773,6 +845,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9056-fc54-a741-306f" name="Bodyguards in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -790,6 +863,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -806,6 +880,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="03b6-423f-4623-97ce" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -814,6 +889,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="c22a-47ad-2735-f312" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -822,6 +898,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="dbd5-2a45-e7c6-e166" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -837,6 +914,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -846,6 +924,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -862,6 +941,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e84-f420-70f9-b752" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -870,6 +950,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d021-e873-06b2-5f28" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -878,6 +959,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -894,6 +976,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5705-70d2-5c2c-8d9e" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -902,6 +985,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d12a-9fd4-b6fc-6cf5" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -910,6 +994,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -926,6 +1011,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="40ce-415d-d751-724c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -934,6 +1020,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62c7-b8e9-f82d-79bc" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -942,6 +1029,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -958,6 +1046,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="23.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -974,6 +1063,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a0cb-910b-8b5f-f70c" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -982,6 +1072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b769-ec2c-3cc6-445f" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -990,6 +1081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51ea-3891-9e4a-a1b7" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -998,6 +1090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e32-007e-a5e4-6164" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1006,6 +1099,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e90-9c34-2343-bb60" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1014,6 +1108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66a4-af77-1228-8748" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1022,6 +1117,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3401-1960-5a55-d7ed" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1030,6 +1126,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="663f-654c-c50c-6d69" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1038,6 +1135,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e6f-1ae8-2e72-f3c1" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1046,6 +1144,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da26-42a5-bf43-ed81" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1054,6 +1153,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f286-1325-49a7-fad4" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1062,6 +1162,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f40a-036a-ba28-e70b" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1070,6 +1171,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="07f3-6cc1-ebff-879c" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1078,6 +1180,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1093,6 +1196,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ec64-758b-ce37-86be" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1104,6 +1208,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5ba-7573-1d2d-c482" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1115,6 +1220,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5826-6978-560d-ab1e" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1126,6 +1232,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a539-af09-2bcf-a17e" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1137,6 +1244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0253-a01c-eafa-2855" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1148,6 +1256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fdb3-9cd6-52ae-1533" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1159,6 +1268,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fcfc-0924-c21a-a3e2" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1170,6 +1280,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e503-70a6-b910-76ed" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1181,6 +1292,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62ef-4e27-ecb7-5b9e" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1192,6 +1304,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c119-b2cb-7016-7dff" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1203,6 +1316,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="245c-b517-cc20-ea7d" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1214,6 +1328,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6315-5e42-87a5-1b47" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1225,6 +1340,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8c43-ee24-062b-9348" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1236,6 +1352,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1251,6 +1368,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="269d-3044-59bb-5285" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1259,6 +1377,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c9b-746c-44e6-edb5" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1267,6 +1386,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fa64-df9e-f330-df4f" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1275,6 +1395,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7485-211d-b4e4-7002" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1283,6 +1404,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96db-2703-a03d-57c4" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1291,6 +1413,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f2b-4c97-12bf-3479" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1299,6 +1422,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1306,9 +1430,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3825-19e7-b8da-c98f" name="Liche Riding Chariot [182 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="59b4-c112-71af-79cc" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="23e0-5b06-a1dc-0624" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
@@ -1329,6 +1457,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="177.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1346,6 +1475,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1361,6 +1491,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1377,6 +1508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b6ec-e914-ea35-b93e" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -1385,6 +1517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ab9c-40b3-5968-30cc" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -1393,6 +1526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1409,6 +1543,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="954f-f156-324e-fb39" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1417,6 +1552,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8abb-6a46-16f1-b26c" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1425,6 +1561,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1441,6 +1578,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73f8-6dbf-634d-4810" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1449,6 +1587,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd24-e36d-5122-cf04" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1457,6 +1596,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1473,6 +1613,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15a8-6253-1e1a-a0ac" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1481,6 +1622,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a092-6880-ccf9-ad5d" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1489,6 +1631,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="196f-1557-663e-e644" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1504,6 +1647,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1519,6 +1663,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="12b2-7618-4408-2332" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1530,6 +1675,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a63-c1c9-9af0-5195" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1541,6 +1687,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bad1-f317-fd04-feaa" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1552,6 +1699,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15a9-bee6-b368-0aec" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1563,6 +1711,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cb2a-bf8b-90f8-26b9" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1574,6 +1723,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4b24-70d4-1dc9-803b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1585,6 +1735,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4e6d-637e-f0a0-fb2a" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1596,6 +1747,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="acbc-f6e4-116a-f2b7" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1607,6 +1759,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aed7-cfcb-c124-7c37" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1618,6 +1771,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="56dd-ce0a-2014-166a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1629,6 +1783,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="42ae-c68c-aeca-1bc3" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1640,6 +1795,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="953c-13f0-a956-0220" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1651,6 +1807,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="352a-b437-62c2-de0b" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1662,6 +1819,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1678,6 +1836,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d69-3d34-46b3-0b54" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1686,6 +1845,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2458-10d8-0e07-cc8f" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1694,6 +1854,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7b27-ff5e-3b0b-5173" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1702,6 +1863,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66e8-bf64-bad5-60f9" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1710,6 +1872,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="975e-1b78-5729-8b43" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1718,6 +1881,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac25-f080-2f4a-58b1" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1726,6 +1890,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="463a-f2a4-e416-734f" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1734,6 +1899,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4935-2ec0-67f8-cb7f" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1742,6 +1908,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="07d0-516a-15ac-1e25" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1750,6 +1917,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3781-f80c-6ae5-0fca" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1758,6 +1926,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f42-b3af-8638-4571" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1766,6 +1935,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a5d9-f06a-51fe-811b" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1774,6 +1944,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9c27-a795-17f7-cd2d" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1782,6 +1953,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1797,6 +1969,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4b8e-ae24-28a3-c2bd" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1805,6 +1978,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0df8-3fd1-3e60-3867" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1813,6 +1987,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b43-77fb-18cb-2e7b" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1821,6 +1996,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7c07-682c-a1c0-15bd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1829,6 +2005,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b680-7489-cd91-2c6d" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1837,6 +2014,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91ce-b4eb-de7b-3621" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1845,6 +2023,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1866,6 +2045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="177.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1873,9 +2053,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5dec-1724-fd5c-0163" name="Wraith (on foot) [154 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="7eb9-7a67-22f6-e9c8" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="ec66-5b83-d1fe-54b8" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -1898,6 +2082,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="154.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1914,6 +2099,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1867-f2f8-a378-f738" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -1922,6 +2108,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="25.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="35a1-8e76-7687-6192" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -1930,6 +2117,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="50.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -1948,6 +2136,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd84-c64d-7d66-5108" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1956,6 +2145,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1972,6 +2162,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="82af-0103-caca-8956" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1980,6 +2171,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1996,6 +2188,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="23.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2012,6 +2205,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b18-4c6e-39eb-ae3c" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2020,6 +2214,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fb45-9141-fb7f-6de2" name="Mace" hidden="false" collective="false" type="upgrade">
@@ -2028,6 +2223,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2052,6 +2248,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2068,6 +2265,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="e0c5-589a-65b3-c7a1" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -2076,6 +2274,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="fe41-49d8-036a-fef1" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2084,6 +2283,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="1ff8-9fb2-cf10-e59c" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -2099,6 +2299,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -2108,6 +2309,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a029-d7c0-5c3c-7e49" name="Bodyguards in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2125,6 +2327,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2141,6 +2344,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="ed41-fdea-2349-5f0d" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -2149,6 +2353,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="3526-9de4-f0e1-4001" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2157,6 +2362,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="9dc3-0f00-5678-3cc7" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -2172,6 +2378,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -2181,6 +2388,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2196,6 +2404,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9932-004e-20c5-92f2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2204,6 +2413,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7742-26ba-a4eb-e23d" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2212,6 +2422,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="810b-d7cf-aa42-75f4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2220,6 +2431,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="272b-3da8-1c84-dc3d" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2228,6 +2440,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98f6-2089-f743-6263" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2236,6 +2449,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2cb7-af31-f2bb-7715" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2244,6 +2458,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2260,6 +2475,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="74b3-f4e2-03a0-6ac7" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2268,6 +2484,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4be2-7c60-d34a-5691" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2276,6 +2493,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="33d0-035d-3761-a0d6" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2284,6 +2502,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cef6-2e74-cb9a-ca10" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2292,6 +2511,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="295d-e544-e761-a369" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2300,6 +2520,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e241-6fe5-02b8-2d36" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2308,6 +2529,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="39e4-8b30-8672-c1d1" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2316,6 +2538,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac9a-6910-c0cf-b8da" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2324,6 +2547,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b54-386c-00ed-5f30" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2332,6 +2556,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="813c-fe61-0c92-984b" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2340,6 +2565,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd28-40d5-3d2f-bd9d" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2348,6 +2574,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44e7-40a3-9244-5940" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2356,6 +2583,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0fc6-47e1-f063-2916" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2364,6 +2592,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2379,6 +2608,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="37ef-9217-1bb9-3b06" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2390,6 +2620,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbec-fd38-2827-d778" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2401,6 +2632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd99-23b5-cc31-11f1" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2412,6 +2644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e097-9d0e-0063-6cff" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2423,6 +2656,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2275-148a-6181-4329" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2434,6 +2668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a41d-827c-bbe2-a921" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2445,6 +2680,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f1c-2fc7-0dc8-fd65" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2456,6 +2692,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d886-9571-ddbb-f4e0" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2467,6 +2704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c1dd-ba4a-4cf5-0f3f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2478,6 +2716,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="267f-1e40-27a7-8211" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2489,6 +2728,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f32-d244-ed20-55b3" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2500,6 +2740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8696-1ce2-cb64-ccdc" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2511,6 +2752,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="05b6-1b13-5c1c-5561" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2522,6 +2764,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2529,9 +2772,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d07b-3258-0b1e-a537" name="Wraith Riding Helhorse [189 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="45bd-b984-d92c-dbb3" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="91e7-e372-1fd0-d557" name="Mounted Unit" hidden="false" targetId="mounted unit" primary="false"/>
@@ -2553,6 +2800,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="166.0"/>
+            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2569,6 +2817,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b1a9-0a78-8d14-9c35" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -2577,6 +2826,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6b25-b0cc-9f5c-6afd" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -2585,6 +2835,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2601,6 +2852,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ca37-4a87-3491-4d41" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -2609,6 +2861,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2625,6 +2878,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce29-d194-ab26-81b2" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -2633,6 +2887,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2649,6 +2904,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="28f3-c794-8eed-7b25" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2657,6 +2913,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d4d-cb0b-995a-0585" name="Mace" hidden="false" collective="false" type="upgrade">
@@ -2665,6 +2922,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2682,6 +2940,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="29.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2697,6 +2956,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1175-e72d-0fe5-c739" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2705,6 +2965,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7477-6219-c9ef-d14d" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2713,6 +2974,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f40-0913-b262-33fa" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2721,6 +2983,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1d7a-d068-3c62-6daa" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2729,6 +2992,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebef-8123-e201-8174" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2737,6 +3001,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b68-3e1e-552e-3481" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2745,6 +3010,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2761,6 +3027,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8a0d-7802-d789-112a" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2769,6 +3036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1994-dae3-7b91-c95a" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2777,6 +3045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c9de-e98f-d096-2f5b" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2785,6 +3054,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="47fd-00e3-00bc-3754" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2793,6 +3063,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4938-07d7-b281-fbd3" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2801,6 +3072,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6775-1810-75ff-893a" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2809,6 +3081,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="841d-cc91-6f92-4626" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2817,6 +3090,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="31fb-1fb0-0f50-ebd7" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2825,6 +3099,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89a2-03bd-5a17-adc6" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2833,6 +3108,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d75a-2bef-6624-23d3" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2841,6 +3117,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c4b7-cd81-3274-c6c8" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2849,6 +3126,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fb42-7b1d-ed60-531b" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2857,6 +3135,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0e1-9ef7-143e-3226" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2865,6 +3144,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2880,6 +3160,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1790-a22e-e5c0-4aac" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2891,6 +3172,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a240-a0b6-b709-9bc0" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2902,6 +3184,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6a3e-469b-ef3a-3dd5" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2913,6 +3196,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02af-95d7-3e51-e2e1" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2924,6 +3208,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88b7-556d-7a92-b490" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2935,6 +3220,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c2e3-a6bd-f1c1-fd4d" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2946,6 +3232,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dfe8-bbe9-9906-9766" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2957,6 +3244,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8200-f338-49bd-c399" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2968,6 +3256,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd79-c598-2391-ca60" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2979,6 +3268,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d2c-a06b-fa6e-a2dd" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2990,6 +3280,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="97f1-9c77-f48c-91bb" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -3001,6 +3292,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eb9e-c9f2-d160-ffa8" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -3012,6 +3304,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee95-8402-c091-8ced" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -3023,6 +3316,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3030,9 +3324,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4e74-e623-34ea-f67d" name="Undead Champion [81 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bac-4242-05e0-cfdf" type="max"/>
       </constraints>
@@ -3057,6 +3355,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3866-bc5f-d64e-d32b" name="Undead Champion in Heavy Armour" hidden="false" collective="false" type="model">
@@ -3066,6 +3365,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="84.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3082,6 +3382,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="43b0-f1f8-152d-d4e9" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -3090,6 +3391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a1a6-096c-4595-95a8" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -3098,6 +3400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7168-61e9-69ea-bf4c" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -3106,6 +3409,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="03a0-3858-f9b7-4f56" name="Warhammer" hidden="false" collective="false" type="upgrade">
@@ -3114,6 +3418,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3130,6 +3435,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="77cd-e38b-2d7f-aeb0" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -3138,6 +3444,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="091a-d947-ee93-7746" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -3146,6 +3453,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3162,6 +3470,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2fab-807b-d2fd-01dd" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -3170,6 +3479,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3186,6 +3496,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a857-faab-d553-6816" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -3194,6 +3505,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3209,6 +3521,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2434-44ec-aea7-356b" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -3217,6 +3530,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0703-83b4-924b-5409" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -3225,6 +3539,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c932-7843-6904-8f85" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -3233,6 +3548,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="133f-05ef-d747-96bd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -3241,6 +3557,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fb04-3e53-ecf0-9a00" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -3249,6 +3566,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="edc2-0f64-7e7a-78a4" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -3257,6 +3575,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3264,9 +3583,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b40f-b67e-0346-aea0" name="Skeleton Guard [59 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c9f-1b12-88f5-5405" type="max"/>
       </constraints>
@@ -3297,6 +3620,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="bc98-5f32-1d99-c47b" name="Skeleton Guard Leader" hidden="false" collective="false" type="model">
@@ -3310,6 +3634,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3317,6 +3642,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b094-e9e9-7a19-a405" name="Skeleton Guard in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -3333,6 +3659,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9502-18f2-04ca-e650" name="Skeleton Guard Leader" hidden="false" collective="false" type="model">
@@ -3346,6 +3673,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3353,6 +3681,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3369,6 +3698,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2443-fc4f-e88f-c5e2" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -3384,6 +3714,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a7f6-bc4e-bf28-e0dd" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -3392,6 +3723,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd66-2887-ff72-9a1b" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -3400,6 +3732,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cca2-8ca9-82c7-1ed0" name="Massive Maces" hidden="false" collective="false" type="upgrade">
@@ -3408,6 +3741,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="364e-6313-c8f0-a0b0" name="Warhammer" hidden="false" collective="false" type="upgrade">
@@ -3416,6 +3750,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1220-d1b7-09d7-96f5" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -3424,6 +3759,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3440,6 +3776,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7199-fd53-0016-65aa" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -3455,6 +3792,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3462,9 +3800,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="165e-1098-6932-7727" name="Skeleton Warriors [57 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="71f4-6078-6130-8c07" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>
@@ -3485,6 +3827,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8592-067a-f084-d6b1" name="Skeleton Warrior" hidden="false" collective="false" type="model">
@@ -3497,6 +3840,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3513,6 +3857,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b671-cb4e-ed0a-7f97" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -3521,6 +3866,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="00d9-b41a-cdbc-a3a7" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -3529,6 +3875,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3545,6 +3892,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1962-2943-ccd6-534d" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -3560,6 +3908,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3567,9 +3916,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="039c-a3c5-412d-a575" name="Skeleton Archers [57 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="b088-fa94-5701-bcd5" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="d790-9b4d-a574-732f" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
@@ -3598,6 +3951,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="41c0-95ab-6847-5fa6" name="Skeleton Archer Leader" hidden="false" collective="false" type="model">
@@ -3611,6 +3965,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3618,6 +3973,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="00c5-20fd-2c3c-7b1f" name="Archers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -3634,6 +3990,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="35ff-f223-4db5-7ae8" name="Skeleton Archer Leader" hidden="false" collective="false" type="model">
@@ -3647,6 +4004,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3654,6 +4012,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3670,6 +4029,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0808-d599-69a9-d82f" name="Crossbow" hidden="false" collective="false" type="upgrade">
@@ -3685,6 +4045,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3701,6 +4062,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6d37-9931-fa7b-fc8c" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -3716,6 +4078,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3723,9 +4086,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="72ae-4775-16bd-ddbe" name="Zombies [25]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="33cb-f07a-743e-e245" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>
@@ -3753,6 +4120,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3760,6 +4128,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="39af-0533-b2a2-c84e" name="Zombie (Upgraded to RES 6) (7 pts each)" hidden="false" collective="false" type="upgrade">
@@ -3776,6 +4145,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3783,6 +4153,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3790,9 +4161,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="33f0-db6e-95bb-d78e" name="Wights [102 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="7f8d-61aa-3d81-bb88" name="Spectral Undead" hidden="false" targetId="3dfb-f407-ff46-9b1f" type="rule"/>
         <infoLink id="92f4-3f81-9fc2-fa1d" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -3813,6 +4188,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e09-01da-cf4f-e23a" name="Wight Leader" hidden="false" collective="false" type="model">
@@ -3826,6 +4202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="38.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3842,6 +4219,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cce6-d9f2-8d75-17c2" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -3850,6 +4228,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="739e-5804-418c-0d2f" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -3858,6 +4237,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3880,6 +4260,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3887,9 +4268,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c5cd-75ca-cc12-0ac4" name="Skeleton Riders [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="67fd-480a-2e36-d781" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
         <infoLink id="7070-6832-01ef-c6b7" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
@@ -3918,6 +4303,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c990-b202-8ef3-5083" name="Skeleton Rider Leader" hidden="false" collective="false" type="model">
@@ -3931,6 +4317,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="38.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3938,6 +4325,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8115-2bde-b0c6-5235" name="Skeleton Riders in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -3954,6 +4342,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="31a8-4114-45fe-d577" name="Skeleton Rider Leader" hidden="false" collective="false" type="model">
@@ -3967,6 +4356,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="40.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3974,6 +4364,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3990,6 +4381,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c8e-17e6-da75-af56" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -3998,6 +4390,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b1b-8381-5aa4-0d75" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -4013,6 +4406,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4035,6 +4429,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4051,6 +4446,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbe9-602e-5e86-0b67" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4066,6 +4462,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4073,9 +4470,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3876-8378-f299-3c94" name="Skeleton Knights [102 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="820f-3f8e-fab6-dad8" name="Lance" hidden="false" targetId="e601-dcfc-7485-2164" type="profile"/>
         <infoLink id="92a8-908e-8165-b7ce" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
@@ -4098,6 +4499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="195e-b58e-5923-2b4a" name="Skeleton Knights" hidden="false" collective="false" type="model">
@@ -4110,6 +4512,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4126,6 +4529,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="52ad-fb00-6e8f-11f9" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4141,6 +4545,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4148,9 +4553,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8f1c-6486-2c2b-8e30" name="Skeleton Chariot [117 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="2bc4-d669-be6a-070e" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="aad5-aed8-b690-ddce" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
@@ -4173,6 +4582,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4191,6 +4601,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2da7-4f9f-e1a0-03b2" name="2x Helhorses  (HtH Attack SV1)" hidden="false" collective="false" type="upgrade">
@@ -4206,6 +4617,7 @@
                         <selectionEntry id="a493-a41f-bde2-d1f6" name="4x Helhorses" hidden="false" collective="false" type="upgrade">
                           <costs>
                             <cost name="pts" typeId="points" value="12.0"/>
+                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -4213,6 +4625,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="12.0"/>
+                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -4231,6 +4644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a97b-ad7c-4c3e-2f82" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4239,6 +4653,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4254,6 +4669,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4270,6 +4686,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="00c9-a1eb-7fb7-194e" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -4278,6 +4695,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7c1b-7ad2-a0b3-f3cf" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -4286,6 +4704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4308,6 +4727,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4324,6 +4744,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="107.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4331,9 +4752,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ff2a-d62f-8cd7-456d" name="Carrion Beast [153 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df3b-9e33-acc3-ff39" type="max"/>
       </constraints>
@@ -4361,6 +4786,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="153.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4386,6 +4812,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="2.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4402,6 +4829,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="95a6-266f-fb40-4620" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -4410,6 +4838,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8e13-1cad-e994-c3b4" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -4418,6 +4847,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4425,6 +4855,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4441,6 +4872,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f3a-7de2-1c85-d81b" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4449,6 +4881,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4456,9 +4889,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8d33-9051-6b4e-dfff" name="Skeleton Bolt Thrower [60 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="de6d-62f8-ee52-ad4a" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>
@@ -4486,6 +4923,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4493,6 +4931,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="038e-7662-b893-60c4" name="Skeleton Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -4509,6 +4948,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4516,6 +4956,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4539,6 +4980,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f92c-c6dd-f7df-ecf6" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -4547,6 +4989,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4563,6 +5006,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f18-7a90-9046-ba68" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -4571,6 +5015,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4587,6 +5032,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e835-7b09-a23d-e58e" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4602,6 +5048,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4619,6 +5066,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4626,9 +5074,13 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="302f-44fd-1451-bdb0" name="Skeleton Stone Thrower [72 pts]" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
+      </modifiers>
       <infoLinks>
         <infoLink id="a53d-ac12-d2cc-06a4" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
         <infoLink id="070c-7b9d-5397-5a0d" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
@@ -4657,6 +5109,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4664,6 +5117,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b110-b36f-7517-5d74" name="Skeleton Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -4680,6 +5134,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
+                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4687,6 +5142,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4710,6 +5166,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8115-bcf3-7161-84d1" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -4718,6 +5175,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4734,6 +5192,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2fa8-00d9-76a0-efc8" name="Large stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -4742,6 +5201,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4758,6 +5218,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7a86-35ee-07fc-2a61" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4773,6 +5234,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4788,6 +5250,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4804,6 +5267,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
+                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4811,6 +5275,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Undead.cat
+++ b/Undead.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e5b3-ac3f-4947-9875" name="Undead" revision="3" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="e5b3-ac3f-4947-9875" name="Undead" revision="4" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="be7a-2982-bed2-d5b1" name="Necromancer" hidden="false" collective="false" targetId="837f-5310-663b-e80c" type="selectionEntry"/>
     <entryLink id="7019-c706-1279-e7a8" name="Liche" hidden="false" collective="false" targetId="c169-7c00-8d5e-beb4" type="selectionEntry"/>
@@ -21,9 +21,6 @@
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="837f-5310-663b-e80c" name="Necromancer [81 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="810c-be4f-9e3b-7273" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="11b5-c350-01ea-967a" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -44,7 +41,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -61,7 +58,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="21a1-3820-5a30-d96e" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -70,7 +67,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bdf8-377f-9a77-e3ef" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -79,7 +76,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -96,7 +93,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -113,7 +110,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7770-041b-eeaf-b262" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -122,7 +119,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="428d-2d79-ff02-79a7" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -131,7 +128,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -148,7 +145,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f7a-f18c-65dc-3575" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -157,7 +154,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e08-334d-6302-a693" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -166,7 +163,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -183,7 +180,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="23.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -208,7 +205,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -225,7 +222,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="44d9-481c-dd4d-84ad" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -234,7 +231,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="4125-5792-c0d2-d540" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -243,7 +240,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="fd63-4726-ffaa-406a" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -259,7 +256,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -269,7 +266,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="915f-a17d-ea5f-f21c" name="Bodyguards in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -287,7 +284,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -304,7 +301,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="b902-934a-9abf-b4d8" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -313,7 +310,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="6ce5-a5b6-e630-a54e" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -322,7 +319,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="0003-aa2c-a842-4ee6" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -338,7 +335,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -348,7 +345,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -365,7 +362,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2672-6938-6681-fdd9" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -374,7 +371,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1267-e860-d6b3-566d" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -383,7 +380,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4ff9-0f62-c458-5e25" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -392,7 +389,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="87ef-2150-f4dd-4be0" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -401,7 +398,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f29-518f-7ca5-3bfd" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -410,7 +407,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7380-3ada-e966-d906" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -419,7 +416,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8d14-f52c-3401-9d3a" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -428,7 +425,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ca44-49ee-2831-c65a" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -437,7 +434,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="40b8-64e0-7ef6-264f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -446,7 +443,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2a33-e79b-fea5-f483" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -455,7 +452,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d822-74a3-91ec-a505" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -464,7 +461,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d511-9e64-6d4a-93dc" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -473,7 +470,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="df89-a591-08b8-040e" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -482,7 +479,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -498,7 +495,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aa2b-8d0c-58ad-8b89" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -510,7 +507,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b8c7-11b0-1b25-4802" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -522,7 +519,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="165e-eb4d-02fd-0599" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -534,7 +531,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="19cf-6597-7124-06bc" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -546,7 +543,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d7a6-d5dc-51a4-b991" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -558,7 +555,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3436-5ef5-f81a-631e" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -570,7 +567,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="473f-e90f-77c4-9ea0" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -582,7 +579,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="90df-d6ce-68a6-8bef" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -594,7 +591,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fde8-15e4-7fae-8f20" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -606,7 +603,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="58c7-7c78-400f-eb1e" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -618,7 +615,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6a1b-8082-47f5-13ca" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -630,7 +627,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbcf-7ee5-4f1a-3a16" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -642,7 +639,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c822-3fb3-2260-9009" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -654,7 +651,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -670,7 +667,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5c3e-1ece-17fa-e976" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -679,7 +676,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7cee-ce4a-451a-d58d" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -688,7 +685,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="615d-f52b-782d-4986" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -697,7 +694,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="06c0-d7cc-0b6b-d154" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -706,7 +703,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a345-6b9c-2ea4-d077" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -715,7 +712,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2e80-0d7b-9d5f-a171" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -724,7 +721,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -732,13 +729,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c169-7c00-8d5e-beb4" name="Liche [95 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="43d0-ae8a-ca79-df32" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="efe9-7ace-9588-c8c6" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -759,7 +753,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -784,7 +778,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -801,7 +795,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="3bd1-a6f3-486d-a92c" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -810,7 +804,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="ee3e-3174-42dd-b2a4" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -819,7 +813,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="822a-8df4-d037-8dd4" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -835,7 +829,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -845,7 +839,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9056-fc54-a741-306f" name="Bodyguards in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -863,7 +857,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -880,7 +874,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="03b6-423f-4623-97ce" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -889,7 +883,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="c22a-47ad-2735-f312" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -898,7 +892,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="dbd5-2a45-e7c6-e166" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -914,7 +908,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -924,7 +918,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -941,7 +935,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e84-f420-70f9-b752" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -950,7 +944,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d021-e873-06b2-5f28" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -959,7 +953,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -976,7 +970,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5705-70d2-5c2c-8d9e" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -985,7 +979,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d12a-9fd4-b6fc-6cf5" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -994,7 +988,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1011,7 +1005,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="40ce-415d-d751-724c" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1020,7 +1014,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62c7-b8e9-f82d-79bc" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1029,7 +1023,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1046,7 +1040,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="23.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1063,7 +1057,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a0cb-910b-8b5f-f70c" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1072,7 +1066,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b769-ec2c-3cc6-445f" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1081,7 +1075,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="51ea-3891-9e4a-a1b7" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1090,7 +1084,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6e32-007e-a5e4-6164" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1099,7 +1093,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7e90-9c34-2343-bb60" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1108,7 +1102,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66a4-af77-1228-8748" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1117,7 +1111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3401-1960-5a55-d7ed" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1126,7 +1120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="663f-654c-c50c-6d69" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1135,7 +1129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9e6f-1ae8-2e72-f3c1" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1144,7 +1138,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="da26-42a5-bf43-ed81" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1153,7 +1147,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f286-1325-49a7-fad4" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1162,7 +1156,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f40a-036a-ba28-e70b" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1171,7 +1165,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="07f3-6cc1-ebff-879c" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1180,7 +1174,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1196,7 +1190,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ec64-758b-ce37-86be" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1208,7 +1202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c5ba-7573-1d2d-c482" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1220,7 +1214,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5826-6978-560d-ab1e" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1232,7 +1226,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a539-af09-2bcf-a17e" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1244,7 +1238,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0253-a01c-eafa-2855" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1256,7 +1250,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fdb3-9cd6-52ae-1533" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1268,7 +1262,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fcfc-0924-c21a-a3e2" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1280,7 +1274,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e503-70a6-b910-76ed" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1292,7 +1286,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="62ef-4e27-ecb7-5b9e" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1304,7 +1298,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c119-b2cb-7016-7dff" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1316,7 +1310,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="245c-b517-cc20-ea7d" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1328,7 +1322,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6315-5e42-87a5-1b47" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1340,7 +1334,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8c43-ee24-062b-9348" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1352,7 +1346,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1368,7 +1362,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="269d-3044-59bb-5285" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1377,7 +1371,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0c9b-746c-44e6-edb5" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1386,7 +1380,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fa64-df9e-f330-df4f" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1395,7 +1389,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7485-211d-b4e4-7002" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -1404,7 +1398,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="96db-2703-a03d-57c4" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -1413,7 +1407,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f2b-4c97-12bf-3479" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -1422,7 +1416,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1430,13 +1424,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3825-19e7-b8da-c98f" name="Liche Riding Chariot [182 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="59b4-c112-71af-79cc" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="23e0-5b06-a1dc-0624" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
@@ -1457,7 +1448,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="177.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1475,7 +1466,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1491,7 +1482,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1508,7 +1499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b6ec-e914-ea35-b93e" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -1517,7 +1508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ab9c-40b3-5968-30cc" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -1526,7 +1517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1543,7 +1534,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="954f-f156-324e-fb39" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -1552,7 +1543,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="12.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8abb-6a46-16f1-b26c" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -1561,7 +1552,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="24.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1578,7 +1569,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="73f8-6dbf-634d-4810" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -1587,7 +1578,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd24-e36d-5122-cf04" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -1596,7 +1587,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1613,7 +1604,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15a8-6253-1e1a-a0ac" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -1622,7 +1613,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a092-6880-ccf9-ad5d" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -1631,7 +1622,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="196f-1557-663e-e644" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -1647,7 +1638,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1663,7 +1654,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="12b2-7618-4408-2332" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1675,7 +1666,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1a63-c1c9-9af0-5195" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1687,7 +1678,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bad1-f317-fd04-feaa" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1699,7 +1690,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="15a9-bee6-b368-0aec" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1711,7 +1702,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cb2a-bf8b-90f8-26b9" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1723,7 +1714,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4b24-70d4-1dc9-803b" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1735,7 +1726,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4e6d-637e-f0a0-fb2a" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1747,7 +1738,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="acbc-f6e4-116a-f2b7" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1759,7 +1750,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="aed7-cfcb-c124-7c37" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1771,7 +1762,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="56dd-ce0a-2014-166a" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1783,7 +1774,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="42ae-c68c-aeca-1bc3" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1795,7 +1786,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="953c-13f0-a956-0220" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1807,7 +1798,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="352a-b437-62c2-de0b" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1819,7 +1810,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1836,7 +1827,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d69-3d34-46b3-0b54" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -1845,7 +1836,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2458-10d8-0e07-cc8f" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -1854,7 +1845,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7b27-ff5e-3b0b-5173" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -1863,7 +1854,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="66e8-bf64-bad5-60f9" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -1872,7 +1863,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="975e-1b78-5729-8b43" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -1881,7 +1872,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac25-f080-2f4a-58b1" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -1890,7 +1881,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="463a-f2a4-e416-734f" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -1899,7 +1890,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4935-2ec0-67f8-cb7f" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -1908,7 +1899,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="07d0-516a-15ac-1e25" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -1917,7 +1908,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3781-f80c-6ae5-0fca" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -1926,7 +1917,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6f42-b3af-8638-4571" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -1935,7 +1926,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a5d9-f06a-51fe-811b" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -1944,7 +1935,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9c27-a795-17f7-cd2d" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -1953,7 +1944,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -1969,7 +1960,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4b8e-ae24-28a3-c2bd" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -1978,7 +1969,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0df8-3fd1-3e60-3867" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -1987,7 +1978,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b43-77fb-18cb-2e7b" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -1996,7 +1987,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7c07-682c-a1c0-15bd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2005,7 +1996,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b680-7489-cd91-2c6d" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2014,7 +2005,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="91ce-b4eb-de7b-3621" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2023,7 +2014,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2045,7 +2036,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="177.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2053,13 +2044,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5dec-1724-fd5c-0163" name="Wraith (on foot) [154 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="7eb9-7a67-22f6-e9c8" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="ec66-5b83-d1fe-54b8" name="Warrior Unit" hidden="false" targetId="warrior unit" primary="false"/>
@@ -2082,7 +2070,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="154.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2099,7 +2087,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="1867-f2f8-a378-f738" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -2108,7 +2096,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="25.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="35a1-8e76-7687-6192" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -2117,7 +2105,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="50.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -2136,7 +2124,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd84-c64d-7d66-5108" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -2145,7 +2133,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2162,7 +2150,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="82af-0103-caca-8956" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -2171,7 +2159,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2188,7 +2176,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="23.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2205,7 +2193,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b18-4c6e-39eb-ae3c" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2214,7 +2202,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fb45-9141-fb7f-6de2" name="Mace" hidden="false" collective="false" type="upgrade">
@@ -2223,7 +2211,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2248,7 +2236,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2265,7 +2253,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="e0c5-589a-65b3-c7a1" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -2274,7 +2262,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="fe41-49d8-036a-fef1" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2283,7 +2271,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="1ff8-9fb2-cf10-e59c" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -2299,7 +2287,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -2309,7 +2297,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a029-d7c0-5c3c-7e49" name="Bodyguards in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -2327,7 +2315,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="12.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -2344,7 +2332,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="ed41-fdea-2349-5f0d" name="Axes" hidden="false" collective="false" type="upgrade">
@@ -2353,7 +2341,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="3526-9de4-f0e1-4001" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -2362,7 +2350,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="9dc3-0f00-5678-3cc7" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -2378,7 +2366,7 @@
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -2388,7 +2376,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2404,7 +2392,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9932-004e-20c5-92f2" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2413,7 +2401,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7742-26ba-a4eb-e23d" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2422,7 +2410,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="810b-d7cf-aa42-75f4" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2431,7 +2419,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="272b-3da8-1c84-dc3d" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2440,7 +2428,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="98f6-2089-f743-6263" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -2449,7 +2437,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2cb7-af31-f2bb-7715" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -2458,7 +2446,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2475,7 +2463,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="74b3-f4e2-03a0-6ac7" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2484,7 +2472,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4be2-7c60-d34a-5691" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2493,7 +2481,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="33d0-035d-3761-a0d6" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2502,7 +2490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cef6-2e74-cb9a-ca10" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2511,7 +2499,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="295d-e544-e761-a369" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2520,7 +2508,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e241-6fe5-02b8-2d36" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2529,7 +2517,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="39e4-8b30-8672-c1d1" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2538,7 +2526,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ac9a-6910-c0cf-b8da" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2547,7 +2535,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1b54-386c-00ed-5f30" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2556,7 +2544,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="813c-fe61-0c92-984b" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2565,7 +2553,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dd28-40d5-3d2f-bd9d" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2574,7 +2562,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="44e7-40a3-9244-5940" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2583,7 +2571,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0fc6-47e1-f063-2916" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2592,7 +2580,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2608,7 +2596,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="37ef-9217-1bb9-3b06" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -2620,7 +2608,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbec-fd38-2827-d778" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -2632,7 +2620,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bd99-23b5-cc31-11f1" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -2644,7 +2632,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e097-9d0e-0063-6cff" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -2656,7 +2644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2275-148a-6181-4329" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -2668,7 +2656,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a41d-827c-bbe2-a921" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -2680,7 +2668,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9f1c-2fc7-0dc8-fd65" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -2692,7 +2680,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d886-9571-ddbb-f4e0" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -2704,7 +2692,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c1dd-ba4a-4cf5-0f3f" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -2716,7 +2704,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="267f-1e40-27a7-8211" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -2728,7 +2716,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f32-d244-ed20-55b3" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -2740,7 +2728,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8696-1ce2-cb64-ccdc" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -2752,7 +2740,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="05b6-1b13-5c1c-5561" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -2764,7 +2752,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2772,13 +2760,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d07b-3258-0b1e-a537" name="Wraith Riding Helhorse [189 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="45bd-b984-d92c-dbb3" name="New CategoryLink" hidden="false" targetId="warlord unit" primary="true"/>
         <categoryLink id="91e7-e372-1fd0-d557" name="Mounted Unit" hidden="false" targetId="mounted unit" primary="false"/>
@@ -2800,7 +2785,7 @@
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="166.0"/>
-            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2817,7 +2802,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b1a9-0a78-8d14-9c35" name="Magic Level 2" hidden="false" collective="false" type="upgrade">
@@ -2826,7 +2811,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6b25-b0cc-9f5c-6afd" name="Magic Level 3" hidden="false" collective="false" type="upgrade">
@@ -2835,7 +2820,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="50.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2852,7 +2837,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ca37-4a87-3491-4d41" name="Tough 3" hidden="false" collective="false" type="upgrade">
@@ -2861,7 +2846,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2878,7 +2863,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ce29-d194-ab26-81b2" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -2887,7 +2872,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="14.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2904,7 +2889,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="28f3-c794-8eed-7b25" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -2913,7 +2898,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3d4d-cb0b-995a-0585" name="Mace" hidden="false" collective="false" type="upgrade">
@@ -2922,7 +2907,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2940,7 +2925,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="29.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2956,7 +2941,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1175-e72d-0fe5-c739" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -2965,7 +2950,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7477-6219-c9ef-d14d" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -2974,7 +2959,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2f40-0913-b262-33fa" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -2983,7 +2968,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1d7a-d068-3c62-6daa" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -2992,7 +2977,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ebef-8123-e201-8174" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -3001,7 +2986,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="9b68-3e1e-552e-3481" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -3010,7 +2995,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3027,7 +3012,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8a0d-7802-d789-112a" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -3036,7 +3021,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1994-dae3-7b91-c95a" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -3045,7 +3030,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c9de-e98f-d096-2f5b" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -3054,7 +3039,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="47fd-00e3-00bc-3754" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -3063,7 +3048,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="4938-07d7-b281-fbd3" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -3072,7 +3057,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6775-1810-75ff-893a" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -3081,7 +3066,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="841d-cc91-6f92-4626" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -3090,7 +3075,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="31fb-1fb0-0f50-ebd7" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -3099,7 +3084,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="89a2-03bd-5a17-adc6" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -3108,7 +3093,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="d75a-2bef-6624-23d3" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -3117,7 +3102,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c4b7-cd81-3274-c6c8" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -3126,7 +3111,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fb42-7b1d-ed60-531b" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -3135,7 +3120,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c0e1-9ef7-143e-3226" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -3144,7 +3129,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3160,7 +3145,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1790-a22e-e5c0-4aac" name="Aura of Timidity" hidden="false" collective="false" type="upgrade">
@@ -3172,7 +3157,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a240-a0b6-b709-9bc0" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
@@ -3184,7 +3169,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6a3e-469b-ef3a-3dd5" name="Chill Wind" hidden="false" collective="false" type="upgrade">
@@ -3196,7 +3181,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="02af-95d7-3e51-e2e1" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
@@ -3208,7 +3193,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="88b7-556d-7a92-b490" name="Endow Strength" hidden="false" collective="false" type="upgrade">
@@ -3220,7 +3205,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c2e3-a6bd-f1c1-fd4d" name="Enchanted Shield" hidden="false" collective="false" type="upgrade">
@@ -3232,7 +3217,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="dfe8-bbe9-9906-9766" name="Wake the Dead" hidden="false" collective="false" type="upgrade">
@@ -3244,7 +3229,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8200-f338-49bd-c399" name="Sorcerer&apos;s Shield" hidden="false" collective="false" type="upgrade">
@@ -3256,7 +3241,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd79-c598-2391-ca60" name="Surge" hidden="false" collective="false" type="upgrade">
@@ -3268,7 +3253,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5d2c-a06b-fa6e-a2dd" name="Lightning Bolt" hidden="false" collective="false" type="upgrade">
@@ -3280,7 +3265,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="97f1-9c77-f48c-91bb" name="Bamboozle Beastie" hidden="false" collective="false" type="upgrade">
@@ -3292,7 +3277,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="eb9e-c9f2-d160-ffa8" name="Enfeeble Foe" hidden="false" collective="false" type="upgrade">
@@ -3304,7 +3289,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="ee95-8402-c091-8ced" name="Sorcerous Battle!" hidden="false" collective="false" type="upgrade">
@@ -3316,7 +3301,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3324,13 +3309,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4e74-e623-34ea-f67d" name="Undead Champion [81 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bac-4242-05e0-cfdf" type="max"/>
       </constraints>
@@ -3355,7 +3337,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="81.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="3866-bc5f-d64e-d32b" name="Undead Champion in Heavy Armour" hidden="false" collective="false" type="model">
@@ -3365,7 +3347,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="84.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3382,7 +3364,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="43b0-f1f8-152d-d4e9" name="Huge Sword" hidden="false" collective="false" type="upgrade">
@@ -3391,7 +3373,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a1a6-096c-4595-95a8" name="Big Axe" hidden="false" collective="false" type="upgrade">
@@ -3400,7 +3382,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7168-61e9-69ea-bf4c" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -3409,7 +3391,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="03a0-3858-f9b7-4f56" name="Warhammer" hidden="false" collective="false" type="upgrade">
@@ -3418,7 +3400,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3435,7 +3417,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="77cd-e38b-2d7f-aeb0" name="Wound 2" hidden="false" collective="false" type="upgrade">
@@ -3444,7 +3426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="091a-d947-ee93-7746" name="Wound 3" hidden="false" collective="false" type="upgrade">
@@ -3453,7 +3435,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="32.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3470,7 +3452,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2fab-807b-d2fd-01dd" name="Tough 2" hidden="false" collective="false" type="upgrade">
@@ -3479,7 +3461,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3496,7 +3478,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a857-faab-d553-6816" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -3505,7 +3487,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="2.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3521,7 +3503,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2434-44ec-aea7-356b" name="Helm Cleaver" hidden="false" collective="false" type="upgrade">
@@ -3530,7 +3512,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0703-83b4-924b-5409" name="War Bringer" hidden="false" collective="false" type="upgrade">
@@ -3539,7 +3521,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c932-7843-6904-8f85" name="Battle Smiter" hidden="false" collective="false" type="upgrade">
@@ -3548,7 +3530,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="133f-05ef-d747-96bd" name="Bow of Burning Gold" hidden="false" collective="false" type="upgrade">
@@ -3557,7 +3539,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fb04-3e53-ecf0-9a00" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
@@ -3566,7 +3548,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="edc2-0f64-7e7a-78a4" name="Skull Crusher" hidden="false" collective="false" type="upgrade">
@@ -3575,7 +3557,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="15.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3583,13 +3565,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b40f-b67e-0346-aea0" name="Skeleton Guard [59 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c9f-1b12-88f5-5405" type="max"/>
       </constraints>
@@ -3620,7 +3599,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="bc98-5f32-1d99-c47b" name="Skeleton Guard Leader" hidden="false" collective="false" type="model">
@@ -3634,7 +3613,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3642,7 +3621,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b094-e9e9-7a19-a405" name="Skeleton Guard in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -3659,7 +3638,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="9502-18f2-04ca-e650" name="Skeleton Guard Leader" hidden="false" collective="false" type="model">
@@ -3673,7 +3652,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3681,7 +3660,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3698,7 +3677,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2443-fc4f-e88f-c5e2" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -3714,7 +3693,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a7f6-bc4e-bf28-e0dd" name="Huge Swords" hidden="false" collective="false" type="upgrade">
@@ -3723,7 +3702,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cd66-2887-ff72-9a1b" name="Big Axes" hidden="false" collective="false" type="upgrade">
@@ -3732,7 +3711,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cca2-8ca9-82c7-1ed0" name="Massive Maces" hidden="false" collective="false" type="upgrade">
@@ -3741,7 +3720,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="364e-6313-c8f0-a0b0" name="Warhammer" hidden="false" collective="false" type="upgrade">
@@ -3750,7 +3729,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1220-d1b7-09d7-96f5" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -3759,7 +3738,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3776,7 +3755,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7199-fd53-0016-65aa" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -3792,7 +3771,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3800,13 +3779,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="165e-1098-6932-7727" name="Skeleton Warriors [57 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="71f4-6078-6130-8c07" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>
@@ -3827,7 +3803,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8592-067a-f084-d6b1" name="Skeleton Warrior" hidden="false" collective="false" type="model">
@@ -3840,7 +3816,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="9.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3857,7 +3833,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b671-cb4e-ed0a-7f97" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -3866,7 +3842,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="00d9-b41a-cdbc-a3a7" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -3875,7 +3851,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3892,7 +3868,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1962-2943-ccd6-534d" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -3908,7 +3884,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3916,13 +3892,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="039c-a3c5-412d-a575" name="Skeleton Archers [57 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="b088-fa94-5701-bcd5" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
         <infoLink id="d790-9b4d-a574-732f" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
@@ -3951,7 +3924,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="9.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="41c0-95ab-6847-5fa6" name="Skeleton Archer Leader" hidden="false" collective="false" type="model">
@@ -3965,7 +3938,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="21.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -3973,7 +3946,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="00c5-20fd-2c3c-7b1f" name="Archers in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -3990,7 +3963,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="11.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="35ff-f223-4db5-7ae8" name="Skeleton Archer Leader" hidden="false" collective="false" type="model">
@@ -4004,7 +3977,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="23.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4012,7 +3985,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4029,7 +4002,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0808-d599-69a9-d82f" name="Crossbow" hidden="false" collective="false" type="upgrade">
@@ -4045,7 +4018,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4062,7 +4035,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="6d37-9931-fa7b-fc8c" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4078,7 +4051,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4086,13 +4059,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="72ae-4775-16bd-ddbe" name="Zombies [25]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="33cb-f07a-743e-e245" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>
@@ -4120,7 +4090,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4128,7 +4098,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="39af-0533-b2a2-c84e" name="Zombie (Upgraded to RES 6) (7 pts each)" hidden="false" collective="false" type="upgrade">
@@ -4145,7 +4115,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="7.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4153,7 +4123,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4161,13 +4131,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="33f0-db6e-95bb-d78e" name="Wights [102 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="7f8d-61aa-3d81-bb88" name="Spectral Undead" hidden="false" targetId="3dfb-f407-ff46-9b1f" type="rule"/>
         <infoLink id="92f4-3f81-9fc2-fa1d" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
@@ -4188,7 +4155,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="16.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0e09-01da-cf4f-e23a" name="Wight Leader" hidden="false" collective="false" type="model">
@@ -4202,7 +4169,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="38.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4219,7 +4186,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cce6-d9f2-8d75-17c2" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -4228,7 +4195,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="739e-5804-418c-0d2f" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -4237,7 +4204,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4260,7 +4227,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4268,13 +4235,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c5cd-75ca-cc12-0ac4" name="Skeleton Riders [72 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="67fd-480a-2e36-d781" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
         <infoLink id="7070-6832-01ef-c6b7" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
@@ -4303,7 +4267,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="17.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="c990-b202-8ef3-5083" name="Skeleton Rider Leader" hidden="false" collective="false" type="model">
@@ -4317,7 +4281,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="38.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4325,7 +4289,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8115-2bde-b0c6-5235" name="Skeleton Riders in Medium Armour" hidden="false" collective="false" type="upgrade">
@@ -4342,7 +4306,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="19.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="31a8-4114-45fe-d577" name="Skeleton Rider Leader" hidden="false" collective="false" type="model">
@@ -4356,7 +4320,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="40.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4364,7 +4328,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4381,7 +4345,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2c8e-17e6-da75-af56" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -4390,7 +4354,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8b1b-8381-5aa4-0d75" name="Lances" hidden="false" collective="false" type="upgrade">
@@ -4406,7 +4370,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4429,7 +4393,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4446,7 +4410,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="cbe9-602e-5e86-0b67" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4462,7 +4426,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4470,13 +4434,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3876-8378-f299-3c94" name="Skeleton Knights [102 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="820f-3f8e-fab6-dad8" name="Lance" hidden="false" targetId="e601-dcfc-7485-2164" type="profile"/>
         <infoLink id="92a8-908e-8165-b7ce" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
@@ -4499,7 +4460,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="195e-b58e-5923-2b4a" name="Skeleton Knights" hidden="false" collective="false" type="model">
@@ -4512,7 +4473,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="30.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4529,7 +4490,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="52ad-fb00-6e8f-11f9" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4545,7 +4506,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4553,13 +4514,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8f1c-6486-2c2b-8e30" name="Skeleton Chariot [117 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="2bc4-d669-be6a-070e" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
         <infoLink id="aad5-aed8-b690-ddce" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
@@ -4582,7 +4540,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4601,7 +4559,7 @@
                   </infoLinks>
                   <costs>
                     <cost name="pts" typeId="points" value="0.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
                 <selectionEntry id="2da7-4f9f-e1a0-03b2" name="2x Helhorses  (HtH Attack SV1)" hidden="false" collective="false" type="upgrade">
@@ -4617,7 +4575,7 @@
                         <selectionEntry id="a493-a41f-bde2-d1f6" name="4x Helhorses" hidden="false" collective="false" type="upgrade">
                           <costs>
                             <cost name="pts" typeId="points" value="12.0"/>
-                            <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -4625,7 +4583,7 @@
                   </selectionEntryGroups>
                   <costs>
                     <cost name="pts" typeId="points" value="12.0"/>
-                    <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                    <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -4644,7 +4602,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="a97b-ad7c-4c3e-2f82" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4653,7 +4611,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4669,7 +4627,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="25.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4686,7 +4644,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="00c9-a1eb-7fb7-194e" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -4695,7 +4653,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7c1b-7ad2-a0b3-f3cf" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -4704,7 +4662,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4727,7 +4685,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4744,7 +4702,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="107.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4752,13 +4710,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="ff2a-d62f-8cd7-456d" name="Carrion Beast [153 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df3b-9e33-acc3-ff39" type="max"/>
       </constraints>
@@ -4786,7 +4741,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="153.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4812,7 +4767,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="2.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4829,7 +4784,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="95a6-266f-fb40-4620" name="Axe" hidden="false" collective="false" type="upgrade">
@@ -4838,7 +4793,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                     <selectionEntry id="8e13-1cad-e994-c3b4" name="Spear" hidden="false" collective="false" type="upgrade">
@@ -4847,7 +4802,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4855,7 +4810,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4872,7 +4827,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="0f3a-7de2-1c85-d81b" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -4881,7 +4836,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4889,13 +4844,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8d33-9051-6b4e-dfff" name="Skeleton Bolt Thrower [60 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="de6d-62f8-ee52-ad4a" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>
@@ -4923,7 +4875,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4931,7 +4883,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="038e-7662-b893-60c4" name="Skeleton Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -4948,7 +4900,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -4956,7 +4908,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -4980,7 +4932,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="f92c-c6dd-f7df-ecf6" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -4989,7 +4941,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5006,7 +4958,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="1f18-7a90-9046-ba68" name="Large Bolt Thrower" hidden="false" collective="false" type="upgrade">
@@ -5015,7 +4967,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="21.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5032,7 +4984,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="e835-7b09-a23d-e58e" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -5048,7 +5000,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5066,7 +5018,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5074,13 +5026,10 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="302f-44fd-1451-bdb0" name="Skeleton Stone Thrower [72 pts]" hidden="false" collective="false" type="unit">
-      <modifiers>
-        <modifier type="increment" field="0b16-4fe4-4ad1-b2d6" value="1.0"/>
-      </modifiers>
       <infoLinks>
         <infoLink id="a53d-ac12-d2cc-06a4" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
         <infoLink id="070c-7b9d-5397-5a0d" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
@@ -5109,7 +5058,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="6.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -5117,7 +5066,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="b110-b36f-7517-5d74" name="Skeleton Crew in Light Armour" hidden="false" collective="false" type="upgrade">
@@ -5134,7 +5083,7 @@
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="8.0"/>
-                        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
                       </costs>
                     </selectionEntry>
                   </selectionEntries>
@@ -5142,7 +5091,7 @@
               </selectionEntryGroups>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5166,7 +5115,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8115-bcf3-7161-84d1" name="Daggers" hidden="false" collective="false" type="upgrade">
@@ -5175,7 +5124,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5192,7 +5141,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2fa8-00d9-76a0-efc8" name="Large stone Thrower" hidden="false" collective="false" type="upgrade">
@@ -5201,7 +5150,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="27.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5218,7 +5167,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="7a86-35ee-07fc-2a61" name="Spectral Undead" hidden="false" collective="false" type="upgrade">
@@ -5234,7 +5183,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5250,7 +5199,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="10.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5267,7 +5216,7 @@
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
-                <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+                <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -5275,7 +5224,7 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" Order Dice" typeId="0b16-4fe4-4ad1-b2d6" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="1.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Undead.cat
+++ b/Undead.cat
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="e5b3-ac3f-4947-9875" name="Undead" revision="1" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
-  <publications>
-    <publication id="e5b3-ac3f-pubN65537" name="Warlords of Erehwon"/>
-  </publications>
+<catalogue id="e5b3-ac3f-4947-9875" name="Undead" revision="2" battleScribeVersion="2.02" authorName="The3dwargamer" authorContact="the3dwargamer@outlook.com" authorUrl="https://www.facebook.com/3dwargamer/" library="false" gameSystemId="cffa-cd51-33d5-b2c6" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="be7a-2982-bed2-d5b1" name="Necromancer" hidden="false" collective="false" targetId="837f-5310-663b-e80c" type="selectionEntry"/>
     <entryLink id="7019-c706-1279-e7a8" name="Liche" hidden="false" collective="false" targetId="c169-7c00-8d5e-beb4" type="selectionEntry"/>
@@ -13,12 +10,12 @@
     <entryLink id="deb6-fe4c-11e3-75c9" name="Skeleton Guard" hidden="false" collective="false" targetId="b40f-b67e-0346-aea0" type="selectionEntry"/>
     <entryLink id="263f-fbe0-8885-3f46" name="Skeleton Warriors [57]" hidden="false" collective="false" targetId="165e-1098-6932-7727" type="selectionEntry"/>
     <entryLink id="5a48-d5aa-5c9c-b86c" name="Skeleton Archers [67]" hidden="false" collective="false" targetId="039c-a3c5-412d-a575" type="selectionEntry"/>
-    <entryLink id="78b9-096a-3e1a-9b0e" name="Zombies" hidden="false" collective="false" targetId="72ae-4775-16bd-ddbe" type="selectionEntry"/>
+    <entryLink id="78b9-096a-3e1a-9b0e" name="Zombies [25]" hidden="false" collective="false" targetId="72ae-4775-16bd-ddbe" type="selectionEntry"/>
     <entryLink id="322b-aa6d-2a25-2093" name="Wights [102 pts]" hidden="false" collective="false" targetId="33f0-db6e-95bb-d78e" type="selectionEntry"/>
     <entryLink id="b6b0-60f8-7ee7-6f3d" name="Skeleton Riders [72 pts]" hidden="false" collective="false" targetId="c5cd-75ca-cc12-0ac4" type="selectionEntry"/>
     <entryLink id="4be7-093e-0b6f-b777" name="Skeleton Knights" hidden="false" collective="false" targetId="3876-8378-f299-3c94" type="selectionEntry"/>
     <entryLink id="a680-6b07-139c-c88b" name="Skeleton Chariot" hidden="false" collective="false" targetId="8f1c-6486-2c2b-8e30" type="selectionEntry"/>
-    <entryLink id="281b-8a82-e6fa-4d56" name="Carrion Beast [133 pts]" hidden="false" collective="false" targetId="ff2a-d62f-8cd7-456d" type="selectionEntry"/>
+    <entryLink id="281b-8a82-e6fa-4d56" name="Carrion Beast [153 pts]" hidden="false" collective="false" targetId="ff2a-d62f-8cd7-456d" type="selectionEntry"/>
     <entryLink id="eb10-2645-72fb-7eea" name="Skeleton Bolt Thrower [60 pts]" hidden="false" collective="false" targetId="8d33-9051-6b4e-dfff" type="selectionEntry"/>
     <entryLink id="e68b-8892-3907-5ea5" name="Skeleton Stone Thrower [72 pts]" hidden="false" collective="false" targetId="302f-44fd-1451-bdb0" type="selectionEntry"/>
   </entryLinks>
@@ -692,6 +689,7 @@
                 <infoLink id="9994-dfeb-3b29-1bd5" name="Undead Army Special Rule" hidden="false" targetId="6650-1e8e-9f7d-d242" type="rule"/>
                 <infoLink id="c228-3831-ceb8-3bf2" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
                 <infoLink id="3df3-d159-c9e2-fe2d" name="Liche" hidden="false" targetId="9527-115d-c679-3a2d" type="profile"/>
+                <infoLink id="e940-1c30-acc8-ba99" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="95.0"/>
@@ -1324,7 +1322,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fb2-5cc6-02c6-158d" type="min"/>
               </constraints>
               <infoLinks>
-                <infoLink id="f221-29f3-f331-6152" name="Liche" hidden="false" targetId="bec0-28d8-d8ca-5aa5" type="profile"/>
+                <infoLink id="f221-29f3-f331-6152" name="Liche (riding chariot)" hidden="false" targetId="bec0-28d8-d8ca-5aa5" type="profile"/>
                 <infoLink id="1af4-2193-1201-bd0b" name="Command" hidden="false" targetId="b0ed-8f0b-633c-2f06" type="rule"/>
                 <infoLink id="4110-76a1-4ba0-bcf9" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
                 <infoLink id="a7b7-45d1-81f3-30a5" name="Undead Army Special Rule" hidden="false" targetId="6650-1e8e-9f7d-d242" type="rule"/>
@@ -1343,7 +1341,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5339-8200-53fc-11db" type="min"/>
               </constraints>
               <infoLinks>
-                <infoLink id="49c1-41c5-57c6-cae5" name="Skeleton Crew" hidden="false" targetId="ea23-a4fc-a287-2fcd" type="profile"/>
+                <infoLink id="49c1-41c5-57c6-cae5" name="Skeleton Crew (Chariot)" hidden="false" targetId="ea23-a4fc-a287-2fcd" type="profile"/>
                 <infoLink id="6f1e-159c-4b80-63e2" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
               </infoLinks>
               <costs>
@@ -1405,7 +1403,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f56-6bed-ef8a-cbb0" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="0ef1-6f7c-b27d-60b0" name="Wound" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="0ef1-6f7c-b27d-60b0" name="Wound 1" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="a50b-f1da-d6ee-3cf1" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
               </infoLinks>
@@ -1437,7 +1435,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3b5-a0cf-45d3-47f6" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ee59-54cb-d8da-ba6a" name="Tough" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="ee59-54cb-d8da-ba6a" name="Tough 1" hidden="false" collective="false" type="upgrade">
               <infoLinks>
                 <infoLink id="7694-b92b-8510-7619" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
               </infoLinks>
@@ -1851,6 +1849,27 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
+        <selectionEntryGroup id="da68-1b1f-543c-2ef5" name="Chariot Model" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="bd6c-11ae-8b16-a9dc" name="Chariot" hidden="false" collective="false" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dea1-5ab4-bfc0-eb90" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e7d-a05f-6c65-a80c" type="min"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6021-a11c-aabe-1958" name="Chariot with Liche and Crew, pulled by Helhorses" hidden="false" targetId="8148-887f-6070-e2b6" type="profile"/>
+                <infoLink id="8228-f0c8-f4ee-2e19" name="Fast 6" hidden="false" targetId="7753-3806-9cf1-0a6c" type="rule"/>
+                <infoLink id="892f-0d83-e48c-7848" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+                <infoLink id="e786-e88c-8134-ce43" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+                <infoLink id="8d46-8a6c-ab9a-8dda" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
+                <infoLink id="814a-46c1-0f7d-a2cf" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="177.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -1875,6 +1894,7 @@
                 <infoLink id="c596-80bb-5a7d-7a46" name="Spectral Undead" hidden="false" targetId="3dfb-f407-ff46-9b1f" type="rule"/>
                 <infoLink id="3f14-4cb4-8ddd-8f9a" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
                 <infoLink id="9e16-310d-60f3-2c68" name="Wraith" hidden="false" targetId="2178-4098-7de9-b223" type="profile"/>
+                <infoLink id="7dbf-0580-8d35-81a8" name="Undead Army Special Rule" hidden="false" targetId="6650-1e8e-9f7d-d242" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="154.0"/>
@@ -2528,6 +2548,8 @@
             <infoLink id="589e-f918-b907-9068" name="Deathly Chill" hidden="false" targetId="c738-3360-de3b-34a9" type="rule"/>
             <infoLink id="11c2-da63-9aa2-4e87" name="Spectral Undead" hidden="false" targetId="3dfb-f407-ff46-9b1f" type="rule"/>
             <infoLink id="6745-68dd-5f5c-5f53" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
+            <infoLink id="dfcc-a750-b53f-cf37" name="Undead Army Special Rule" hidden="false" targetId="6650-1e8e-9f7d-d242" type="rule"/>
+            <infoLink id="f1b0-0d9e-7765-13cc" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="points" value="166.0"/>
@@ -2656,6 +2678,7 @@
               <infoLinks>
                 <infoLink id="d819-87ed-0c1f-12a4" name="Cursed Spirits Mounted" hidden="false" targetId="070e-5a4a-143b-286a" type="profile"/>
                 <infoLink id="5d32-62a4-fe8d-69f0" name="Spirit" hidden="false" targetId="78d3-886d-5fc6-bac4" type="rule"/>
+                <infoLink id="34a2-1c69-8f3d-489d" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="29.0"/>
@@ -3013,6 +3036,11 @@
       <constraints>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bac-4242-05e0-cfdf" type="max"/>
       </constraints>
+      <infoLinks>
+        <infoLink id="559a-98f0-4bf4-24ef" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
+        <infoLink id="2546-2905-35dc-988b" name="Hero" hidden="false" targetId="566e-a1c6-9f62-3218" type="rule"/>
+        <infoLink id="cd71-edf3-3a69-e233" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="9664-75f3-e1b2-1aa0" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -3025,7 +3053,6 @@
           <selectionEntries>
             <selectionEntry id="bbb2-5afb-43d0-3e2f" name="Undead Champion in Medium Armour" hidden="false" collective="false" type="model">
               <infoLinks>
-                <infoLink id="1558-7325-a77b-44e2" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
                 <infoLink id="5b99-e331-c926-4c8a" name="Undead Champion" hidden="false" targetId="57b5-f959-5aa5-dc95" type="profile"/>
               </infoLinks>
               <costs>
@@ -3034,7 +3061,6 @@
             </selectionEntry>
             <selectionEntry id="3866-bc5f-d64e-d32b" name="Undead Champion in Heavy Armour" hidden="false" collective="false" type="model">
               <infoLinks>
-                <infoLink id="fa07-4351-f839-ea4a" name="Dread" hidden="false" targetId="0bf9-a070-b56b-ca4e" type="rule"/>
                 <infoLink id="9039-2c8a-a3c4-edf5" name="Undead Champion (Hvy armour)" hidden="false" targetId="41d0-c73b-090f-f2b0" type="profile"/>
                 <infoLink id="2381-11bc-fc95-d7fd" name="Heavily Laden" hidden="false" targetId="1a97-76e9-e64e-7701" type="rule"/>
               </infoLinks>
@@ -3241,6 +3267,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="b40f-b67e-0346-aea0" name="Skeleton Guard [59 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="38c5-3aba-74ec-e37e" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="f7bf-01f2-feba-0832" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -3433,6 +3462,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="165e-1098-6932-7727" name="Skeleton Warriors [57 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="71f4-6078-6130-8c07" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="f4aa-e683-a32e-8c9c" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -3537,6 +3569,7 @@
     <selectionEntry id="039c-a3c5-412d-a575" name="Skeleton Archers [57 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="b088-fa94-5701-bcd5" name="Sword" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
+        <infoLink id="d790-9b4d-a574-732f" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0c4d-f797-0524-2c19" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
@@ -3690,6 +3723,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="72ae-4775-16bd-ddbe" name="Zombies [25]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="33cb-f07a-743e-e245" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="660f-a6e3-132d-2818" name="New CategoryLink" hidden="false" targetId="warrior unit" primary="true"/>
       </categoryLinks>
@@ -3852,7 +3888,8 @@
     </selectionEntry>
     <selectionEntry id="c5cd-75ca-cc12-0ac4" name="Skeleton Riders [72 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
-        <infoLink id="c848-f1a5-118a-9537" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="67fd-480a-2e36-d781" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+        <infoLink id="7070-6832-01ef-c6b7" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="d2ca-f575-ecbf-406e" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
@@ -3938,7 +3975,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d73f-d22e-5d12-4466" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="c19c-3e2c-ccf2-48c9">
+        <selectionEntryGroup id="d73f-d22e-5d12-4466" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="c19c-3e2c-ccf2-48c9">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c810-f4f3-f0ac-6d9f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6266-271a-a461-5206" type="max"/>
@@ -4038,7 +4075,8 @@
     <selectionEntry id="3876-8378-f299-3c94" name="Skeleton Knights [102 pts]" hidden="false" collective="false" type="unit">
       <infoLinks>
         <infoLink id="820f-3f8e-fab6-dad8" name="Lance" hidden="false" targetId="e601-dcfc-7485-2164" type="profile"/>
-        <infoLink id="e274-8582-e78b-cce3" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
+        <infoLink id="92a8-908e-8165-b7ce" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+        <infoLink id="7de0-c6f2-1a84-e929" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="eb6f-5f5a-c085-854c" name="New CategoryLink" hidden="false" targetId="mounted unit" primary="true"/>
@@ -4053,13 +4091,13 @@
               </constraints>
               <infoLinks>
                 <infoLink id="4d3f-be42-419b-8ab1" name="Skeleton Knight Leader, Riding Helhorse" hidden="false" targetId="fd4c-8543-b256-8ddc" type="profile"/>
-                <infoLink id="884a-dfb8-edb8-8712" name="Tough" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
+                <infoLink id="884a-dfb8-edb8-8712" name="Tough 1" hidden="false" targetId="b9e1-fea5-9095-b1cf" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="195e-b58e-5923-2b4a" name="Skelton Knights" hidden="false" collective="false" type="model">
+            <selectionEntry id="195e-b58e-5923-2b4a" name="Skeleton Knights" hidden="false" collective="false" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1cd-c333-7ed5-2498" type="min"/>
                 <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ce1-20c0-afcf-4e6d" type="max"/>
@@ -4110,6 +4148,12 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="8f1c-6486-2c2b-8e30" name="Skeleton Chariot [117 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="2bc4-d669-be6a-070e" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
+        <infoLink id="aad5-aed8-b690-ddce" name="Irresistible Charge" hidden="false" targetId="86b2-7051-4b5c-d149" type="rule"/>
+        <infoLink id="1355-24a3-cd88-133a" name="Fast 8" hidden="false" targetId="105b-036d-9a8f-edac" type="rule"/>
+        <infoLink id="a46b-493c-8f7c-71cd" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="0e3e-3d1f-885c-8019" name="New CategoryLink" hidden="false" targetId="239f-4e2f-785f-7869" primary="true"/>
       </categoryLinks>
@@ -4146,9 +4190,9 @@
                     <cost name="pts" typeId="points" value="0.0"/>
                   </costs>
                 </selectionEntry>
-                <selectionEntry id="2da7-4f9f-e1a0-03b2" name="2x Helhorses  (HTH Attack SV1)" hidden="false" collective="false" type="upgrade">
+                <selectionEntry id="2da7-4f9f-e1a0-03b2" name="2x Helhorses  (HtH Attack SV1)" hidden="false" collective="false" type="upgrade">
                   <infoLinks>
-                    <infoLink id="c6e4-855d-0e4f-c1f0" name="Helhorses" hidden="false" targetId="58fe-f4ea-426e-ca44" type="profile"/>
+                    <infoLink id="c6e4-855d-0e4f-c1f0" name="Helhorses" hidden="false" targetId="61b7-a187-ea30-5207" type="profile"/>
                   </infoLinks>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="26f0-df22-30dc-9c70" name="Upgrade to 4 Helhorses" hidden="false" collective="false">
@@ -4211,7 +4255,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="d751-b064-be4f-2855" name="Crew HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="ba43-44cd-c86b-bd82">
+        <selectionEntryGroup id="d751-b064-be4f-2855" name="Crew HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="ba43-44cd-c86b-bd82">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ce3-2e3c-3eb9-78fe" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3241-ab78-303d-485b" type="max"/>
@@ -4287,6 +4331,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="ff2a-d62f-8cd7-456d" name="Carrion Beast [153 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="c67a-dac0-08fd-a208" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="c0f8-97b3-f6eb-bd30" name="New CategoryLink" hidden="false" targetId="ad3c-fc35-4ea7-7a70" primary="true"/>
       </categoryLinks>
@@ -4302,9 +4349,9 @@
                 <infoLink id="e222-4c47-9284-c2aa" name="Carrion Beast with rocks" hidden="false" targetId="7d0c-a2e7-67fc-544d" type="profile"/>
                 <infoLink id="607e-5a86-e9f9-1851" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
                 <infoLink id="d74e-1ea7-2b02-0aa3" name="Flies" hidden="false" targetId="1d07-520b-6918-03fd" type="rule"/>
-                <infoLink id="3dba-65f8-b49d-05fc" name="Fast" hidden="false" targetId="c246-93aa-3909-26ee" type="rule"/>
-                <infoLink id="8aba-3581-9f6f-776a" name="Wound" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
+                <infoLink id="8aba-3581-9f6f-776a" name="Wound 1" hidden="false" targetId="8784-9f2f-1a5b-be21" type="rule"/>
                 <infoLink id="c633-8d91-a9a1-0062" name="Rock dropped by Carrion Beast" hidden="false" targetId="f54b-ae0e-9cdc-020e" type="profile"/>
+                <infoLink id="f051-18db-194e-3f3c" name="Fast 10" hidden="false" targetId="0034-82ae-f695-d446" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="153.0"/>
@@ -4337,7 +4384,7 @@
                     </selectionEntry>
                   </selectionEntries>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="03bc-d1e4-da0e-1aa8" name="Skeleton Rider HTH weapon" hidden="false" collective="false" defaultSelectionEntryId="8e26-e336-22b2-9558">
+                <selectionEntryGroup id="03bc-d1e4-da0e-1aa8" name="Skeleton Rider HtH weapon" hidden="false" collective="false" defaultSelectionEntryId="8e26-e336-22b2-9558">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3af-97e0-c89e-244e" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ec5-d8b8-fade-41f2" type="max"/>
@@ -4406,6 +4453,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="8d33-9051-6b4e-dfff" name="Skeleton Bolt Thrower [60 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="de6d-62f8-ee52-ad4a" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="cd5f-1e30-afea-aff1" name="Artillery Unit" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -4464,7 +4514,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8ef1-f77a-b0f6-17b4" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="f92c-c6dd-f7df-ecf6">
+        <selectionEntryGroup id="8ef1-f77a-b0f6-17b4" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="f92c-c6dd-f7df-ecf6">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c2c-a6a7-8f30-6feb" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed67-df07-9ff6-0b8e" type="min"/>
@@ -4559,7 +4609,7 @@
               </constraints>
               <infoLinks>
                 <infoLink id="c9c2-d153-7f74-9f3a" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="d700-99bc-e822-3de6" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
+                <infoLink id="80a1-76ff-c384-185b" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="42.0"/>
@@ -4573,6 +4623,10 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="302f-44fd-1451-bdb0" name="Skeleton Stone Thrower [72 pts]" hidden="false" collective="false" type="unit">
+      <infoLinks>
+        <infoLink id="a53d-ac12-d2cc-06a4" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
+        <infoLink id="070c-7b9d-5397-5a0d" name="Slow 3" hidden="false" targetId="9d78-2294-d4fd-9efd" type="rule"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="b33b-3ea1-9086-86e7" name="Artillery Unit" hidden="false" targetId="art unit" primary="true"/>
       </categoryLinks>
@@ -4631,7 +4685,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="8ea5-402d-53f6-06c3" name="HTH Weapons" hidden="false" collective="false" defaultSelectionEntryId="8115-bcf3-7161-84d1">
+        <selectionEntryGroup id="8ea5-402d-53f6-06c3" name="HtH Weapons" hidden="false" collective="false" defaultSelectionEntryId="8115-bcf3-7161-84d1">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae65-2c2d-3bb0-e3f4" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7792-6142-58f0-f258" type="min"/>
@@ -4741,7 +4795,6 @@
               </constraints>
               <infoLinks>
                 <infoLink id="66e6-20ef-930d-3af6" name="Large" hidden="false" targetId="7f3d-fbf8-9f49-2031" type="rule"/>
-                <infoLink id="39f6-6a3c-6720-6068" name="Slow" hidden="false" targetId="4d2b-eef9-9776-1480" type="rule"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="54.0"/>
@@ -4764,7 +4817,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">10</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Command, 2xHTH, Wound, Magic Level 1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 2xHtH, Wound, Magic Level X</characteristic>
       </characteristics>
     </profile>
     <profile id="6a6f-393b-f5a6-22ae" name="Skeleton Bodyguard in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -4786,7 +4839,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">3</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Spirit, 1xHTH SV1, Exchange of missiles SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Spirit, 1xHtH SV1, Exchange of missiles SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="9a44-bb44-383a-db33" name="Skeleton Bodyguard in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -4808,7 +4861,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">10</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Command, 2xHTH, Undead, Wound, Magic Level 1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 2xHtH, Undead, Wound X, Magic Level X</characteristic>
       </characteristics>
     </profile>
     <profile id="8148-887f-6070-e2b6" name="Chariot with Liche and Crew, pulled by Helhorses" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -4819,10 +4872,10 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">10</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough, Fast 6, Irresistable Charge, Undead</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Tough 1, Fast 6, Irresistable Charge, Undead</characteristic>
       </characteristics>
     </profile>
-    <profile id="bec0-28d8-d8ca-5aa5" name="Liche" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="bec0-28d8-d8ca-5aa5" name="Liche (riding chariot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">[5]</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
@@ -4830,7 +4883,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">[6]</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">10</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough], Command, 2xHTH, Undead, [Wound], Magic Level 1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">[Tough X], Command, 2xHtH, Undead, [Wound X], Magic Level X, [on foot only]</characteristic>
       </characteristics>
     </profile>
     <profile id="ea23-a4fc-a287-2fcd" name="Skeleton Crew (Chariot)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -4839,20 +4892,9 @@
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">5</characteristic>
         <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61">5</characteristic>
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
-        <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
-        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
+        <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
+        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Undead</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="58fe-f4ea-426e-ca44" name="Helhorses" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
-      <characteristics>
-        <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">-</characteristic>
-        <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">-</characteristic>
-        <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61">-</characteristic>
-        <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
-        <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
-        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Undead, 1xHTH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="2178-4098-7de9-b223" name="Wraith" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -4863,7 +4905,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">10</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">10</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 2, Command, 3xHTH, Deathly Chill, Spectral Undead, Dread, Wound 2, Magic Level 1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, 3xHtH, Deathly Chill, Spectral Undead, Dread, Wound X, Magic Level X</characteristic>
       </characteristics>
     </profile>
     <profile id="8517-edcf-fb4a-875a" name="Wraith, Riding Helhorse" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -4874,7 +4916,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">10</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">10</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 2, Command, Fast 8, 3xHTH Deathly Chill, Spectral undead, Dread, Wound 2, Magic Level 1, Helhorse 1xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Command, Fast 8, 3xHtH Deathly Chill, Spectral undead, Dread, Wound X, Magic Level X, Helhorse 1xHtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="57b5-f959-5aa5-dc95" name="Undead Champion" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -4885,7 +4927,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(8)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Wound, 3xHTH, Undead, Dread, Hero</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Wound X, 3xHtH, Undead, Dread, Hero</characteristic>
       </characteristics>
     </profile>
     <profile id="41d0-c73b-090f-f2b0" name="Undead Champion (Hvy armour)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -4896,7 +4938,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">9</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Wound, 3xHTH, Undead Dread, Hero</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough X, Wound X, 3xHtH, Undead Dread, Hero</characteristic>
       </characteristics>
     </profile>
     <profile id="f40c-5c8d-fa27-40ac" name="Skeleton Guard Leader" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -4907,7 +4949,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Undead</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Undead</characteristic>
       </characteristics>
     </profile>
     <profile id="e438-fdd1-ac8b-a3c0" name="Skeleton Guard" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -4929,7 +4971,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Undead</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Undead</characteristic>
       </characteristics>
     </profile>
     <profile id="d3a0-ccd3-a405-e828" name="Skeleton Warrior" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -4951,7 +4993,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Undead</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Undead</characteristic>
       </characteristics>
     </profile>
     <profile id="ed61-0a43-e4b1-9c08" name="Skeleton Archer" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -4973,18 +5015,18 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">3</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">2</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">5</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Zombie, 1xHTH SV0, Undead</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Zombie, 1xHtH SV0, Undead</characteristic>
       </characteristics>
     </profile>
     <profile id="c1ba-bc3d-5cab-0b07" name="Zombies (Upgraded RES)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
-        <characteristic name="Ag" typeId="b787-94dd-0cef-abb7"/>
-        <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69"/>
-        <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61"/>
-        <characteristic name="Res" typeId="d916-9ec8-dd33-7873"/>
-        <characteristic name="Init" typeId="7313-a059-134c-8199"/>
-        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb"/>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e"/>
+        <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">2</characteristic>
+        <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">2</characteristic>
+        <characteristic name="Str" typeId="fcb5-8bd5-6767-fa61">3</characteristic>
+        <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
+        <characteristic name="Init" typeId="7313-a059-134c-8199">2</characteristic>
+        <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">5</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Zombie, 1xHtH SV0, Undead</characteristic>
       </characteristics>
     </profile>
     <profile id="4f9c-cdfc-9eff-5eb9" name="Wight Leader" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -4995,7 +5037,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">7</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">7</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Spectral Undead, Dread</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Spectral Undead, Dread</characteristic>
       </characteristics>
     </profile>
     <profile id="a4e5-1eda-0284-a26c" name="Wight" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -5039,7 +5081,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Undead, Fast 8, Helhorse 1xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Undead, Fast 8, Helhorse 1xHtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="3568-52bd-9a01-3d17" name="Skeleton Knight, riding Helhorse" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -5050,7 +5092,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6(9)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Undead, Fast 8, Helhorse 1xHTH SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Undead, Fast 8, Helhorse 1xHtH SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="1f37-f56d-cc75-6515" name="Skeleton Chariot (Crew + 2xUndead Steads)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -5094,7 +5136,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">-</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">-</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">-</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Undead, HTH Attack SV1</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Undead, HtH Attack SV1</characteristic>
       </characteristics>
     </profile>
     <profile id="7d0c-a2e7-67fc-544d" name="Carrion Beast with rocks" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -5105,7 +5147,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">8</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">8</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Flies, Fast 10, 3xHTH SV3, 3xDrop SV3, Wound, Undead</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Large, Flies, Fast 10, 3xHtH SV3, 3xDrop SV3, Wound, Undead</characteristic>
       </characteristics>
     </profile>
     <profile id="122f-323d-895b-9b14" name="Skeleton Rider (carrion beast)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -5160,7 +5202,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(7)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">8</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Undead</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Undead</characteristic>
       </characteristics>
     </profile>
     <profile id="0921-57ee-85b0-346f" name="Skeleton Archer in Light Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -5182,7 +5224,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">5(6)</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">5</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">7</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough, Undead</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Tough 1, Undead</characteristic>
       </characteristics>
     </profile>
     <profile id="b6ec-cac4-032c-3986" name="Skeleton Rider in Medium Armour" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
@@ -5229,7 +5271,7 @@
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Undead, Large, Slow 3</characteristic>
       </characteristics>
     </profile>
-    <profile id="070e-5a4a-143b-286a" name="Cursed Spirits Mounted" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
+    <profile id="070e-5a4a-143b-286a" name="Cursed Spirits (mounted)" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">
       <characteristics>
         <characteristic name="Ag" typeId="b787-94dd-0cef-abb7">5</characteristic>
         <characteristic name="Acc" typeId="efac-8fd0-5d23-7d69">6</characteristic>
@@ -5237,7 +5279,7 @@
         <characteristic name="Res" typeId="d916-9ec8-dd33-7873">6</characteristic>
         <characteristic name="Init" typeId="7313-a059-134c-8199">3</characteristic>
         <characteristic name="Co" typeId="a7e4-65ad-5a57-90bb">3</characteristic>
-        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Spirit, 1xHTH SV1, Exchange of missiles SV1, Fast 8</characteristic>
+        <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">Spirit, 1xHtH SV1, Exchange of missiles SV1, Fast 8</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Undead.cat
+++ b/Undead.cat
@@ -3267,6 +3267,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="b40f-b67e-0346-aea0" name="Skeleton Guard [59 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c9f-1b12-88f5-5405" type="max"/>
+      </constraints>
       <infoLinks>
         <infoLink id="38c5-3aba-74ec-e37e" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>
@@ -3530,7 +3533,7 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="9661-78d5-6da4-8dea" name="Undead type" hidden="false" collective="false">
+        <selectionEntryGroup id="9661-78d5-6da4-8dea" name="Undead type" hidden="false" collective="false" defaultSelectionEntryId="7553-7309-6942-4deb">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b59e-107c-2ee1-8254" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e04b-2bd6-1a98-7fb6" type="max"/>
@@ -4331,6 +4334,9 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="ff2a-d62f-8cd7-456d" name="Carrion Beast [153 pts]" hidden="false" collective="false" type="unit">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df3b-9e33-acc3-ff39" type="max"/>
+      </constraints>
       <infoLinks>
         <infoLink id="c67a-dac0-08fd-a208" name="Undead" hidden="false" targetId="e5df-1d6a-1034-7c77" type="rule"/>
       </infoLinks>

--- a/Undead.cat
+++ b/Undead.cat
@@ -227,7 +227,7 @@
                         </selectionEntry>
                         <selectionEntry id="44d9-481c-dd4d-84ad" name="Axes" hidden="false" collective="false" type="upgrade">
                           <infoLinks>
-                            <infoLink id="8a8a-1315-4547-b6ea" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                            <infoLink id="8a8a-1315-4547-b6ea" name="axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
@@ -306,7 +306,7 @@
                         </selectionEntry>
                         <selectionEntry id="b902-934a-9abf-b4d8" name="Axes" hidden="false" collective="false" type="upgrade">
                           <infoLinks>
-                            <infoLink id="395f-5e5e-3f7f-9bdb" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                            <infoLink id="395f-5e5e-3f7f-9bdb" name="axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
@@ -800,7 +800,7 @@
                         </selectionEntry>
                         <selectionEntry id="3bd1-a6f3-486d-a92c" name="Axes" hidden="false" collective="false" type="upgrade">
                           <infoLinks>
-                            <infoLink id="bea2-ce28-f6ce-9d54" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                            <infoLink id="bea2-ce28-f6ce-9d54" name="axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
@@ -879,7 +879,7 @@
                         </selectionEntry>
                         <selectionEntry id="03b6-423f-4623-97ce" name="Axes" hidden="false" collective="false" type="upgrade">
                           <infoLinks>
-                            <infoLink id="3023-e49c-b944-0b3d" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                            <infoLink id="3023-e49c-b944-0b3d" name="axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
@@ -1609,7 +1609,7 @@
             </selectionEntry>
             <selectionEntry id="15a8-6253-1e1a-a0ac" name="Axes" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="cdf1-ef22-1543-ea38" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="cdf1-ef22-1543-ea38" name="axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2198,7 +2198,7 @@
             </selectionEntry>
             <selectionEntry id="1b18-4c6e-39eb-ae3c" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="ac5a-a05c-574f-ea35" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="ac5a-a05c-574f-ea35" name="axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -2258,7 +2258,7 @@
                         </selectionEntry>
                         <selectionEntry id="e0c5-589a-65b3-c7a1" name="Axes" hidden="false" collective="false" type="upgrade">
                           <infoLinks>
-                            <infoLink id="2019-b10a-45e9-c4b1" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                            <infoLink id="2019-b10a-45e9-c4b1" name="axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
@@ -2337,7 +2337,7 @@
                         </selectionEntry>
                         <selectionEntry id="ed41-fdea-2349-5f0d" name="Axes" hidden="false" collective="false" type="upgrade">
                           <infoLinks>
-                            <infoLink id="fe07-b7de-52f3-d8c7" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                            <infoLink id="fe07-b7de-52f3-d8c7" name="axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
                           </infoLinks>
                           <costs>
                             <cost name="pts" typeId="points" value="0.0"/>
@@ -2894,7 +2894,7 @@
             </selectionEntry>
             <selectionEntry id="28f3-c794-8eed-7b25" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="9344-668a-c749-b8eb" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="9344-668a-c749-b8eb" name="axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -4191,7 +4191,7 @@
             </selectionEntry>
             <selectionEntry id="cce6-d9f2-8d75-17c2" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="212f-97f7-5885-ca1a" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="212f-97f7-5885-ca1a" name="axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -4649,7 +4649,7 @@
             </selectionEntry>
             <selectionEntry id="00c9-a1eb-7fb7-194e" name="Axe" hidden="false" collective="false" type="upgrade">
               <infoLinks>
-                <infoLink id="c0e9-4c2d-4930-c48c" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                <infoLink id="c0e9-4c2d-4930-c48c" name="axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
               </infoLinks>
               <costs>
                 <cost name="pts" typeId="points" value="0.0"/>
@@ -4789,7 +4789,7 @@
                     </selectionEntry>
                     <selectionEntry id="95a6-266f-fb40-4620" name="Axe" hidden="false" collective="false" type="upgrade">
                       <infoLinks>
-                        <infoLink id="d256-002c-4dad-0425" name="axe" hidden="false" targetId="a1ad-5715-ceb1-e77e" type="profile"/>
+                        <infoLink id="d256-002c-4dad-0425" name="axe" hidden="false" targetId="2447-8f38-dd07-d089" type="profile"/>
                       </infoLinks>
                       <costs>
                         <cost name="pts" typeId="points" value="0.0"/>

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="cffa-cd51-33d5-b2c6" name="Warlords of Erehwon" revision="1" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="cffa-cd51-33d5-b2c6" name="Warlords of Erehwon" revision="2" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
-    <publication id="cffa-cd51-pubN65537" name="Warlords of Erehwon"/>
+    <publication id="cffa-cd51-pubN65537" name="WoE HC"/>
   </publications>
   <costTypes>
     <costType id="points" name="pts" defaultCostLimit="-1.0"/>
@@ -221,58 +221,57 @@
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedRules>
-    <rule id="b9e1-fea5-9095-b1cf" name="Tough" hidden="false">
+    <rule id="b9e1-fea5-9095-b1cf" name="Tough" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
-Re-roll a failed RES test.  Only one failed RES test can be re-rolled at a time from a single shooting/HTH attack.</description>
+Re-roll a failed RES test. Only one failed RES test can be re-rolled at a time from a single shooting/HTH attack.</description>
     </rule>
-    <rule id="8784-9f2f-1a5b-be21" name="Wound" hidden="false">
+    <rule id="8784-9f2f-1a5b-be21" name="Wound 1" publicationId="cffa-cd51-pubN65537" page="80" hidden="false">
       <description>
 Model can sustain 1 wound instead of dying immediately.
 Each sustained wound counts as a permanent pin that can&apos;t be removed.
-Unit can still be auto-destroyed by pins.
-</description>
+Unit can still be auto-destroyed by pins.</description>
     </rule>
-    <rule id="90e2-5b2c-1fc8-0e8c" name="Magic Level 1" hidden="false">
+    <rule id="90e2-5b2c-1fc8-0e8c" name="Magic Level 1" publicationId="cffa-cd51-pubN65537" page="86" hidden="false">
       <description>
 Spell Caster/Wizard Level 1.</description>
     </rule>
-    <rule id="487f-dc82-bce1-c0f6" name="Tough 2" hidden="false">
+    <rule id="487f-dc82-bce1-c0f6" name="Tough 2" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
 Re-roll two failed RES tests from a single attack. A die may only be re-rolled once, you must accept the second result.</description>
     </rule>
-    <rule id="45bb-28cf-94fd-f899" name="Zealous" hidden="false">
+    <rule id="45bb-28cf-94fd-f899" name="Zealous" publicationId="cffa-cd51-pubN65537" page="81" hidden="false">
       <description>
 Ignore Pins when taking a break test. Re-Roll failed order test.</description>
     </rule>
-    <rule id="1a97-76e9-e64e-7701" name="Heavily Laden" hidden="false">
+    <rule id="1a97-76e9-e64e-7701" name="Heavily Laden" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
 Cannot Sprint.</description>
     </rule>
-    <rule id="4a91-87e6-88c5-5e1d" name="Magic Level 2" hidden="false">
+    <rule id="4a91-87e6-88c5-5e1d" name="Magic Level 2" publicationId="cffa-cd51-pubN65537" page="86" hidden="false">
       <description>
 Spell Caster/Wizard Level 2.</description>
     </rule>
-    <rule id="2e1b-4169-af1f-71e5" name="Magic Level 3" hidden="false">
+    <rule id="2e1b-4169-af1f-71e5" name="Magic Level 3" publicationId="cffa-cd51-pubN65537" page="86" hidden="false">
       <description>
 Spell Caster/Wizard Level 3.</description>
     </rule>
-    <rule id="78d3-886d-5fc6-bac4" name="Spirit" hidden="false">
+    <rule id="78d3-886d-5fc6-bac4" name="Spirit" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
       <description>
 Can be sacrificed for a re-roll. Destroyed if wizard is slain.</description>
     </rule>
-    <rule id="d055-98ce-6f28-1600" name="Deadeye Shot" hidden="false">
+    <rule id="d055-98ce-6f28-1600" name="Deadeye Shot" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
 Re-roll one missed shot.</description>
     </rule>
-    <rule id="160b-fca8-adb7-3d5b" name="Pavisse" hidden="false">
+    <rule id="160b-fca8-adb7-3d5b" name="Pavisse" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
-Cannot be given Run order. -3 Agility. Counts as cover with +2 Res bonus.</description>
+Cannot be given Run order. -3 Agility. Counts as in cover with +2 Res bonus.</description>
     </rule>
-    <rule id="8a4d-4dea-f005-ddc5" name="Surly" hidden="false">
+    <rule id="8a4d-4dea-f005-ddc5" name="Surly" publicationId="cffa-cd51-pubN65537" page="75" hidden="false">
       <description>
 Cannot benefit from Command, Hero abilities.</description>
     </rule>
-    <rule id="7f3d-fbf8-9f49-2031" name="Large" hidden="false">
+    <rule id="7f3d-fbf8-9f49-2031" name="Large" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
 Can draw LOS to body. (+1) to hit shooting. Can draw LOS over non-large models.</description>
     </rule>
@@ -280,15 +279,15 @@ Can draw LOS to body. (+1) to hit shooting. Can draw LOS over non-large models.<
       <description>
 Increase from Tough to Tough 2.</description>
     </rule>
-    <rule id="b0ed-8f0b-633c-2f06" name="Command" hidden="false">
+    <rule id="b0ed-8f0b-633c-2f06" name="Command" publicationId="cffa-cd51-pubN65537" page="64" hidden="false">
       <description>
 Friendly units within 10&quot; can use the model&apos;s CO stat to take command based tests.</description>
     </rule>
-    <rule id="a447-d495-b7ab-1477" name="Divine Intervention" hidden="false">
+    <rule id="a447-d495-b7ab-1477" name="Divine Intervention" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
 Can steal an order dice from an enemy unit within 20&quot; with successful Command test. If fail, take 1 pin instead. Max 1 attempt in any turn.</description>
     </rule>
-    <rule id="342b-a482-cb16-67e0" name="Wound 2" hidden="false">
+    <rule id="342b-a482-cb16-67e0" name="Wound 2" publicationId="cffa-cd51-pubN65537" page="80" hidden="false">
       <description>
 Model can sustain 2 wounds instead of dying immediately.
 Each sustained wound counts as a permanent pin that can&apos;t be removed.
@@ -298,11 +297,11 @@ Unit can still be auto-destroyed by pins.</description>
       <description>
 May initiate a &apos;Challenge to the death&apos;.</description>
     </rule>
-    <rule id="3536-db5c-4e89-87d7" name="Tough 3" hidden="false">
+    <rule id="3536-db5c-4e89-87d7" name="Tough 3" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
 Re-roll three failed RES tests from a single attack. A die may only be re-rolled once, you must accept the second result.</description>
     </rule>
-    <rule id="2724-2057-e745-23a3" name="Wound 3" hidden="false">
+    <rule id="2724-2057-e745-23a3" name="Wound 3" publicationId="cffa-cd51-pubN65537" page="80" hidden="false">
       <description>
 Model can sustain 3 wounds instead of dying immediately.
 Each sustained wound counts as a permanent pin that can&apos;t be removed.
@@ -312,206 +311,263 @@ Unit can still be auto-destroyed by pins.</description>
       <description>
 Friendly units within 10&quot; can use the model&apos;s Init stat to take Reaction Tests.</description>
     </rule>
-    <rule id="83d2-f89c-33a4-258d" name="Follow" hidden="false">
+    <rule id="83d2-f89c-33a4-258d" name="Follow" publicationId="cffa-cd51-pubN65537" page="69" hidden="false">
       <description>
 Friendly un-pinned units within 5&quot; can follow the unit&apos;s order immediately.</description>
     </rule>
-    <rule id="1c49-276e-425d-0999" name="Frenzied Charge" hidden="false">
+    <rule id="1c49-276e-425d-0999" name="Frenzied Charge" publicationId="cffa-cd51-pubN65537" page="69" hidden="false">
       <description>
 +1 Extra Attack when charging.</description>
     </rule>
-    <rule id="c3b6-8870-61d6-7aaf" name="Savage" hidden="false">
+    <rule id="c3b6-8870-61d6-7aaf" name="Savage" publicationId="cffa-cd51-pubN65537" page="73" hidden="false">
       <description>
 Re-Roll STR to hit in first round of combat in game.</description>
     </rule>
-    <rule id="86b2-7051-4b5c-d149" name="Irresistible Charge" hidden="false">
+    <rule id="86b2-7051-4b5c-d149" name="Irresistible Charge" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
 D3 SV bonus when charging.</description>
     </rule>
-    <rule id="1d07-520b-6918-03fd" name="Flies" hidden="false">
+    <rule id="1d07-520b-6918-03fd" name="Flies" publicationId="cffa-cd51-pubN65537" page="68" hidden="false">
       <description>
 Move over any terrain/obstacle without test or penalty.
-Enemy cannot charge/countercharge or follow-on in combat unless they can also fly, or if flyers are down.</description>
+Enemy cannot charge/countercharge or follow-on in combat unless they can also fly, unless flyers are down.</description>
     </rule>
-    <rule id="5e63-c99b-00b4-24eb" name="Vengeful" hidden="false">
+    <rule id="5e63-c99b-00b4-24eb" name="Vengeful" publicationId="cffa-cd51-pubN65537" page="77" hidden="false">
       <description>
 If unit wins the first round of close combat then it MUST elect to fight a follow on combat where it can do so.
 In follow-on combat, vengeful troops always fight with double their attacks.</description>
     </rule>
-    <rule id="e5df-1d6a-1034-7c77" name="Undead" hidden="false">
+    <rule id="e5df-1d6a-1034-7c77" name="Undead" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
 Cannot be routed.
 Auto-resist choking attacks.
-Immune to Dread
-Immune to Terror</description>
+Immune to Dread.
+Immune to Terror.</description>
     </rule>
-    <rule id="fd2c-3cba-cafa-62aa" name="Zombie Master" hidden="false">
+    <rule id="fd2c-3cba-cafa-62aa" name="Zombie Master" publicationId="cffa-cd51-pubN65537" page="81" hidden="false">
       <description>
 Can use Hero/Follow/Command rules for Zombie units.</description>
     </rule>
-    <rule id="3dfb-f407-ff46-9b1f" name="Spectral Undead" hidden="false">
+    <rule id="3dfb-f407-ff46-9b1f" name="Spectral Undead" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
       <description>
 In addition to Undead rule, also hits from flaming attacks are ignored (auto-resisted) and inflict no pins.
 All difficult ground/obstacles count as open terrain for movement.</description>
     </rule>
-    <rule id="c738-3360-de3b-34a9" name="Deathly Chill" hidden="false">
+    <rule id="c738-3360-de3b-34a9" name="Deathly Chill" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
 No armour bonus allowed.</description>
     </rule>
-    <rule id="0bf9-a070-b56b-ca4e" name="Dread" hidden="false">
+    <rule id="0bf9-a070-b56b-ca4e" name="Dread" publicationId="cffa-cd51-pubN65537" page="66" hidden="false">
       <description>
-(-1) to hit shooting/close combat.
-(-1) to break test if defeated by enemy with Dread.</description>
+-1 to hit shooting/close combat.
+-1 to break test if defeated by enemy with Dread.</description>
     </rule>
-    <rule id="612a-20b6-14a2-97e4" name="Zombie" hidden="false">
+    <rule id="612a-20b6-14a2-97e4" name="Zombie" publicationId="cffa-cd51-pubN65537" page="81" hidden="false">
       <description>
 A failed order test is an advance order and not down.  
 Cannot sprint.
 Cannot benefit from the Hero/Follow/Command unless character is Zombie Master.</description>
     </rule>
-    <rule id="4d2b-eef9-9776-1480" name="Slow" hidden="false">
+    <rule id="4d2b-eef9-9776-1480" name="Slow" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
       <description>
 Move at the basic rate indicated.</description>
     </rule>
-    <rule id="c246-93aa-3909-26ee" name="Fast" hidden="false">
+    <rule id="c246-93aa-3909-26ee" name="Fast" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>
 Move at the basic rate indicated.</description>
     </rule>
-    <rule id="79ff-cb92-cea8-886f" name="Howling Horror Ammunition" hidden="false">
+    <rule id="79ff-cb92-cea8-886f" name="Howling Horror Ammunition" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
 Target suffers D3 additional pins.</description>
     </rule>
-    <rule id="a8bf-f48c-1b08-58e6" name="Unstoppable" hidden="false">
+    <rule id="a8bf-f48c-1b08-58e6" name="Unstoppable" publicationId="cffa-cd51-pubN65537" page="77" hidden="false">
       <description>
 Shot penetrates the unit hit and can strike others beyond so long as the target is hit each time.</description>
     </rule>
-    <rule id="6650-1e8e-9f7d-d242" name="Undead Army Special Rule" hidden="false">
+    <rule id="6650-1e8e-9f7d-d242" name="Undead Army Special Rule" publicationId="cffa-cd51-pubN65537" page="226" hidden="false">
       <description>
 If your warlord is slain, then no further pins are removed from your units. Orders can still be issued as normal.</description>
     </rule>
-    <rule id="0056-a41e-408e-1673" name="Disciplined" hidden="false">
+    <rule id="0056-a41e-408e-1673" name="Disciplined" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
 Lose all pins when pass a rally test.</description>
     </rule>
-    <rule id="93f9-d132-d71b-ab39" name="Shieldwall" hidden="false">
+    <rule id="93f9-d132-d71b-ab39" name="Shieldwall" publicationId="cffa-cd51-pubN65537" page="73" hidden="false">
       <description>
-In shieldwall formation cannot sprint and suffer -1 AG and INIT. 
--1 to hit ranged and HTH.</description>
+In shieldwall formation cannot sprint and suffer -1 Agility and Initiative. 
+Enemy suffers -1 to hit in ranged and hand-to-hand.</description>
     </rule>
-    <rule id="0b0f-1de6-7017-9097" name="Berserk" hidden="false">
+    <rule id="0b0f-1de6-7017-9097" name="Berserk" publicationId="cffa-cd51-pubN65537" page="62" hidden="false">
       <description>
 Until defeated or fail a break test, double attacks in HTH. Automatically pass orders to charge.</description>
     </rule>
-    <rule id="5da1-1bfa-9b8d-6b82" name="MoD2" hidden="false">
+    <rule id="5da1-1bfa-9b8d-6b82" name="MoD2" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
 Unit has 2 Order Dice.</description>
     </rule>
-    <rule id="1e90-54e2-dd77-c4e3" name="Rapid Sprint" hidden="false">
+    <rule id="1e90-54e2-dd77-c4e3" name="Rapid Sprint" publicationId="cffa-cd51-pubN65537" page="73" hidden="false">
       <description>
 Sprint at 4M.</description>
     </rule>
-    <rule id="45b3-c028-8c8c-43ae" name="Stampede" hidden="false">
+    <rule id="45b3-c028-8c8c-43ae" name="Stampede" publicationId="cffa-cd51-pubN65537" page="75" hidden="false">
       <description>
 Stampede on failed order test of 10. D10&quot;+2M in direction shown by dice.
 Each unit in path is attacked as if charged. unit goes down and gains 1 pin per unit trampled.</description>
     </rule>
-    <rule id="2b40-80c8-12cf-8f44" name="Crazed Psychotics" hidden="false">
+    <rule id="2b40-80c8-12cf-8f44" name="Crazed Psychotics" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
 Automatically pass charge orders, cannot be routed, immune to fear and terror.</description>
     </rule>
-    <rule id="8eba-5940-fd9b-254c" name="Drop" hidden="false">
+    <rule id="8eba-5940-fd9b-254c" name="Drop" publicationId="cffa-cd51-pubN65537" page="66" hidden="false">
       <description>
 Drop attacks ignore cover modifiers.</description>
     </rule>
-    <rule id="b61d-3471-1ce6-6878" name="Fire" hidden="false">
+    <rule id="b61d-3471-1ce6-6878" name="Fire" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>
 Fire attacks add an extra pin to targets they hit.</description>
     </rule>
-    <rule id="57f2-e9b1-c3c1-7c74" name="Mechanical Genius" hidden="false">
+    <rule id="57f2-e9b1-c3c1-7c74" name="Mechanical Genius" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
 Add +1 ACC to all artillery in 10&quot;, +/-1 from any Monstrosity (machine) damage chart result within 10&quot;.</description>
     </rule>
-    <rule id="182e-9b37-17f3-5b45" name="Ramshackle Contraption" hidden="false">
+    <rule id="182e-9b37-17f3-5b45" name="Ramshackle Contraption" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
 On a failed order result of a 10 roll on the Monstrosity damage chart.</description>
     </rule>
-    <rule id="4440-376a-8093-35b8" name="Stubborn" hidden="false">
+    <rule id="4440-376a-8093-35b8" name="Stubborn" publicationId="cffa-cd51-pubN65537" page="75" hidden="false">
       <description>
 Recover +1 pin each time an order test is taken.</description>
     </rule>
-    <rule id="4808-d708-bb73-97e8" name="Enchanted Steed" hidden="false">
+    <rule id="4808-d708-bb73-97e8" name="Enchanted Steed" publicationId="cffa-cd51-pubN65537" page="66" hidden="false">
       <description>
 All water terrain counts as open terrain and adds +1 RES to mounted units.</description>
     </rule>
-    <rule id="6a8d-ef1b-6f78-e15c" name="Haughty Disdain" hidden="false">
+    <rule id="6a8d-ef1b-6f78-e15c" name="Haughty Disdain" publicationId="cffa-cd51-pubN65537" page="69" hidden="false">
       <description>
 Automatically pass first Break Test.</description>
     </rule>
-    <rule id="e1f3-7817-0e4e-5cb9" name="Woodsman" hidden="false">
+    <rule id="e1f3-7817-0e4e-5cb9" name="Woodsman" publicationId="cffa-cd51-pubN65537" page="80" hidden="false">
       <description>
-Difficult terrain counts as open terrain.</description>
+Wooded terrain counts as open terrain. +1 RES cover bonus in wooden terrain.</description>
     </rule>
-    <rule id="dcb2-de55-1fca-e0a8" name="Stealthy" hidden="false">
+    <rule id="dcb2-de55-1fca-e0a8" name="Stealthy" publicationId="cffa-cd51-pubN65537" page="75" hidden="false">
       <description>
 Re-roll missile hits if in cover.</description>
     </rule>
-    <rule id="9855-31c9-3745-714d" name="Baleful Glare" hidden="false">
+    <rule id="9855-31c9-3745-714d" name="Baleful Glare" publicationId="cffa-cd51-pubN65537" page="62" hidden="false">
       <description>
 Ranged Attack 20&quot;, No damage but inflicts 1+D3 pins and unit takes a Break test.</description>
     </rule>
-    <rule id="53b9-a3e9-0e9f-2d77" name="Venomous" hidden="false">
+    <rule id="53b9-a3e9-0e9f-2d77" name="Venomous" publicationId="cffa-cd51-pubN65537" page="77" hidden="false">
       <description>
 Add one hit if any hits are scored.</description>
     </rule>
-    <rule id="37e8-d658-01a9-6916" name="Flaming Breath" hidden="false">
+    <rule id="37e8-d658-01a9-6916" name="Flaming Breath" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>
-Ranged Attack 20&quot;. Fire Attack. As Stats.</description>
+Ranged Attack 20&quot;. Fire Attack (+1 pin). As Stats.</description>
     </rule>
-    <rule id="087e-dfda-76c2-09bf" name="Blundering" hidden="false">
+    <rule id="087e-dfda-76c2-09bf" name="Blundering" publicationId="cffa-cd51-pubN65537" page="63" hidden="false">
       <description>
 Cannot Sprint. Must test Agility for a run. Crosses obstacles as chariot/artillery.</description>
     </rule>
-    <rule id="0a0c-ed4c-9647-4398" name="Regenerate" hidden="false">
+    <rule id="0a0c-ed4c-9647-4398" name="Regenerate" publicationId="cffa-cd51-pubN65537" page="73" hidden="false">
       <description>
 Re-roll failed RES and take pin if successful.</description>
     </rule>
-    <rule id="14ff-225a-4ec5-f56d" name="Beastly Breath" hidden="false">
+    <rule id="14ff-225a-4ec5-f56d" name="Beastly Breath" publicationId="cffa-cd51-pubN65537" page="62" hidden="false">
       <description>
 D6 Ranged attacks, 20&quot;, SV3 Choking.</description>
     </rule>
-    <rule id="46d2-d008-8225-bcff" name="Chunder" hidden="false">
+    <rule id="46d2-d008-8225-bcff" name="Chunder" publicationId="cffa-cd51-pubN65537" page="64" hidden="false">
       <description>
 Ranged Attack 10&quot;, Opponent&apos;s RES 5.  Chunder goes empty on a roll of 6+.</description>
     </rule>
-    <rule id="583a-fa53-11ff-7b40" name="Terror" hidden="false">
+    <rule id="583a-fa53-11ff-7b40" name="Terror" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
 A unit within 15&quot; removes NO pins when making an order test. 
 A unit failing a break test within 5&quot; is automatically destroyed.
 A routing unit within 5&quot; is automatically destroyed.
 Terrifying units and units with the Crazed Psychotic/Undead rules are immune to terror.</description>
     </rule>
-    <rule id="7ff2-1650-fc0e-5a3a" name="Choking" hidden="false">
+    <rule id="7ff2-1650-fc0e-5a3a" name="Choking" publicationId="cffa-cd51-pubN65537" page="64" hidden="false">
       <description>
 No armour bonus or cover bonus allowed.</description>
+    </rule>
+    <rule id="ae37-06b2-7f4c-ec52" name="Allied Monster" publicationId="cffa-cd51-pubN65537" page="62" hidden="false">
+      <description>
+Cannot benefit from Command, Hero, or Follow special rules.</description>
+    </rule>
+    <rule id="2e98-ee7b-558a-81ef" name="Bound Monster" publicationId="cffa-cd51-pubN65537" page="63" hidden="false">
+      <description>
+Cannot benefit from Command, Hero, or Follow special rules.
+Take D6 pins if a 10 is rolled for its order test. Can be auto-destroyed via pins as a result.</description>
+    </rule>
+    <rule id="3a29-1b97-6c21-75e7" name="Flaming Wheel" publicationId="cffa-cd51-pubN65537" page="68" hidden="false">
+      <description>
+Max move of 1M.
+Difficult terrain and obstacles count as impassable.
+Fire order to shoot (or rather push).</description>
+    </rule>
+    <rule id="a8ca-ba71-db97-bc20" name="MoD3" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
+      <description>
+Unit has 3 Order Dice.</description>
+    </rule>
+    <rule id="9d78-2294-d4fd-9efd" name="Slow 3" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
+      <description>
+Move at a base rate of 3&quot;.</description>
+    </rule>
+    <rule id="ade7-83de-c555-3df3" name="Slow 4" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
+      <description>
+Move at a base rate of 4&quot;.</description>
+    </rule>
+    <rule id="7753-3806-9cf1-0a6c" name="Fast 6" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
+      <description>
+Move at a base rate of 6&quot;.</description>
+    </rule>
+    <rule id="105b-036d-9a8f-edac" name="Fast 8" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
+      <description>
+Move at a base rate of 8&quot;.</description>
+    </rule>
+    <rule id="0034-82ae-f695-d446" name="Fast 10" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
+      <description>
+Move at a base rate of 10&quot;.</description>
+    </rule>
+    <rule id="6016-006f-a999-c64c" name="Whirling Dervishes" publicationId="cffa-cd51-pubN65537" page="77" hidden="false">
+      <description>
+Loose unit formation: Stay at least 1&quot; apart, max 2&quot;.
+Can only be given Run order (including Sprint).
+On result of 10 for order test, move randomly. Touching other units counts as charge.
+Re-roll all shooting hits on unit.
+Enemies don&apos;t counter-attack in close combat. Saved hits (successful RES rolls) count as casualties for the dervish unit.
+Unit is automatically destroyed if close combat is not won.
+Consolidation move is random, may initiate immediate combat if touching different unit than that just fought. 
+May make consolidation move through unit it just fought.</description>
+    </rule>
+    <rule id="e2ce-cefd-9949-02fd" name="Wild Monster" publicationId="cffa-cd51-pubN65537" page="80" hidden="false">
+      <description>
+Goes wild if 10 is rolled for order test.
+Add D6 pins to check for auto-destruction as normal. If not auto-destroyed, remove all pins.
+Replace all order dice by one die of different color.
+When order die is drawn, players dice for control.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="2447-8f38-dd07-d089" name="Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Str +1</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">STR +1</characteristic>
       </characteristics>
     </profile>
     <profile id="f47a-0e7b-e210-5d54" name="Stave" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Str +1</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">STR +1</characteristic>
       </characteristics>
     </profile>
     <profile id="abab-c6f8-5036-1cb4" name="Mace" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 Str</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR</characteristic>
       </characteristics>
     </profile>
     <profile id="6132-3227-d7f3-41ee" name="Massive Mace" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
@@ -529,7 +585,7 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="595c-60a6-3a30-b259" name="Halberds" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 Str</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR</characteristic>
       </characteristics>
     </profile>
     <profile id="c79a-48d1-9b48-2c68" name="Spear" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
@@ -601,13 +657,13 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="f367-10de-49e2-acff" name="Heavy Armour" hidden="false" typeId="726e-70e6-d94e-c9ac" typeName="Armour Profile">
       <characteristics>
         <characteristic name="Res" typeId="f05e-0dc4-2f61-ffb6">5(8)</characteristic>
-        <characteristic name="Special" typeId="b446-8296-adef-b370">-</characteristic>
+        <characteristic name="Special" typeId="b446-8296-adef-b370"></characteristic>
       </characteristics>
     </profile>
     <profile id="1f70-2881-7206-2fe9" name="Cudgel" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">-</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
       </characteristics>
     </profile>
     <profile id="ef46-1d4c-7c9d-d938" name="Pitchfork, Bills, or Glaives" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
@@ -637,7 +693,7 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="3f74-469a-cb98-f949" name="Scourge" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">-Can also be &apos;cracked&apos; during the exchange of missiles.</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Can also be &apos;cracked&apos; during the exchange of missiles.</characteristic>
       </characteristics>
     </profile>
     <profile id="ba80-a4f2-4c92-7844" name="Small Bolt Thrower" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
@@ -685,7 +741,7 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="556d-4839-8be4-b724" name="Hair Shirt" hidden="false" typeId="726e-70e6-d94e-c9ac" typeName="Armour Profile">
       <characteristics>
         <characteristic name="Res" typeId="f05e-0dc4-2f61-ffb6">5(6)</characteristic>
-        <characteristic name="Special" typeId="b446-8296-adef-b370">-</characteristic>
+        <characteristic name="Special" typeId="b446-8296-adef-b370"></characteristic>
       </characteristics>
     </profile>
     <profile id="2221-3571-075e-ae84" name="Morning Star" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
@@ -697,43 +753,43 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="4f07-5005-3329-5095" name="Chain Mace" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Armour +1 Max bonus.</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Armour +1 Max  bonus.</characteristic>
       </characteristics>
     </profile>
     <profile id="a1ad-5715-ceb1-e77e" name="Axe" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 Strength</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR</characteristic>
       </characteristics>
     </profile>
     <profile id="41c3-e1df-53b7-ed79" name="Huge Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">-</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
       </characteristics>
     </profile>
     <profile id="e977-49ab-1207-d301" name="Big Axe" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">-</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
       </characteristics>
     </profile>
     <profile id="8aea-0ac0-030a-5da1" name="Improbably Vast Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">3</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">-Heavily Laden</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Heavily Laden</characteristic>
       </characteristics>
     </profile>
     <profile id="91a1-fed7-8323-b2c8" name="Bloomin&apos; big axe" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">3</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">-Heavily Laden</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Heavily Laden</characteristic>
       </characteristics>
     </profile>
     <profile id="0b17-24e8-fb18-654e" name="Club" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">-</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
       </characteristics>
     </profile>
     <profile id="7723-e7c2-30a5-43ee" name="Chariot Scythes" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
@@ -763,7 +819,7 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="88d0-6821-ceff-0382" name="Rocks (HTH)" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Can also be thrown as ranged weapon</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Can also be thrown as ranged weapon.</characteristic>
       </characteristics>
     </profile>
     <profile id="c6ac-d307-29c2-4ef1" name="Handgun" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
@@ -826,7 +882,7 @@ No armour bonus or cover bonus allowed.</description>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
         <characteristic name="Range Extreme" typeId="49d3-642a-08be-5817">-</characteristic>
         <characteristic name="Strike Value" typeId="47c7-dced-6203-6b76">6</characteristic>
-        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">1xDrop SV6 Fire, Unstoppable</characteristic>
+        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">1xDrop SV6, Fire, Unstoppable</characteristic>
       </characteristics>
     </profile>
     <profile id="c44d-adb8-ec8a-3dd4" name="Rock dropped by Eagle" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
@@ -910,7 +966,7 @@ No armour bonus or cover bonus allowed.</description>
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">9</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">20&quot;</characteristic>
-        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">Enemy unit within range and LOS (same as shooting)</characteristic>
+        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">Enemy unit within range and LOS (same as shooting).</characteristic>
         <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">D3 + casters Magic Level hits caused, resolved at Strike Value 1 and Fire Attacks.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
@@ -919,16 +975,16 @@ No armour bonus or cover bonus allowed.</description>
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">20&quot;</characteristic>
-        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">Enemy in Range and LOS (same as shooting attack)</characteristic>
-        <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">D3 + Casters magic level hits, resolved at Strike Value 1 and as a Deathly Chill Ranged Attack.  (cannot affect models with undead or spectral undead rule)</characteristic>
+        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">Enemy in Range and LOS (same as shooting attack).</characteristic>
+        <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">D3 + Casters magic level hits, resolved at Strike Value 1 and as a Deathly Chill Ranged Attack. Cannot affect models with undead or spectral undead rule.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
     </profile>
     <profile id="096e-2da4-2cdd-6c4d" name="(Spell) Peculiar Portal" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
-        <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8 minus 1 for every 10&quot; of distance between caster and target</characteristic>
+        <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8 minus 1 for every 10&quot; of distance between caster and target.</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">N/A</characteristic>
-        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">(any enemy unit on tabletop)</characteristic>
+        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">Any enemy unit on tabletop.</characteristic>
         <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">Unit is removed from current position and repositioned by the OWNING player at the player&apos;s table edge or if there is no player&apos;s edge then an edge nominated by the caster.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
@@ -945,7 +1001,7 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="29a5-e36b-7b3f-c197" name="(Spell) Enchanted Shield" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8</characteristic>
-        <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per Magic Level</characteristic>
+        <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per Magic Level.</characteristic>
         <characteristic name="Target" typeId="878a-e6bf-fe34-2254">Any Friendly unit in range, LOS is NOT required.  Can be cast on wizards own unit. </characteristic>
         <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">Any ranged attack upon the unit will automatically miss on any ACC roll other than a 1.  Only affects attacks where an ACC check is made, would not affect things like Fiery balls where no ACC check is made.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Lasts until End of Turn</characteristic>
@@ -954,8 +1010,8 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="dd16-8e55-111c-118c" name="(Spell) Aura of Courage" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8</characteristic>
-        <characteristic name="Range" typeId="74f4-f123-678d-019c">All Friendly Units within 10&quot;</characteristic>
-        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">All Friendly Units within 10&quot;</characteristic>
+        <characteristic name="Range" typeId="74f4-f123-678d-019c">All Friendly Units within 10&quot;.</characteristic>
+        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">All Friendly Units within 10&quot;.</characteristic>
         <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">Roll a D6 and add Wizards Magic Level.  You can remove this total number of pins from the target units.  It does not have to be distributed evenly, you get to decide which pins are removed from where.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
@@ -963,8 +1019,8 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="dd4e-402d-e03c-f841" name="(Spell) Aura of Timidity" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8</characteristic>
-        <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; for Magic Level 1, 20&quot; for Magic Level 2, 30&quot; for Magic Level 3</characteristic>
-        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">All enemy units within applicable Range</characteristic>
+        <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; for Magic Level 1, 20&quot; for Magic Level 2, 30&quot; for Magic Level 3.</characteristic>
+        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">All enemy units within applicable Range.</characteristic>
         <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">Roll a D6 and add casters Magic Level.  You can distribute this total number of pins amongst the units affected.  You can distribute them how you like, it does NOT have to be evenly.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
@@ -972,7 +1028,7 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="5cf5-b784-0eca-19aa" name="(Spell) Wake the Dead" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8</characteristic>
-        <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per magic level of caster</characteristic>
+        <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per magic level of caster.</characteristic>
         <characteristic name="Target" typeId="878a-e6bf-fe34-2254">Friendly Undead Warrior unit of either skeletons or zombies with five models or fewer.</characteristic>
         <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">Roll a D6 and add casters Magic Level.  This is the number of Additional warriors that join the unit.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
@@ -981,7 +1037,7 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="ae9d-c50e-6667-48f3" name="(Spell) Sorcerer&apos;s Shield" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">7</characteristic>
-        <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per Magic Level</characteristic>
+        <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per Magic Level.</characteristic>
         <characteristic name="Target" typeId="878a-e6bf-fe34-2254">All Friendly units within Range, including casters own unit.</characteristic>
         <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">Any shooting attack upon a unit affected by spell will automatically miss on any ACC roll other than a 1.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Lasts until end of the turn.  Also ended immediately if the caster Moves, attempts to dispel an enemy&apos;s spell or is killed.</characteristic>
@@ -990,7 +1046,7 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="0a25-272c-9462-1696" name="(Spell) Surge" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">7</characteristic>
-        <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; (For undead wizards and necromancers the range is 10&quot; per magic level)</characteristic>
+        <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; (for undead wizards and necromancers the range is 10&quot; per magic level).</characteristic>
         <characteristic name="Target" typeId="878a-e6bf-fe34-2254">Any friendly unit that has one or more order dice played already that turn.  LOS is NOT required.  Cannot be cast on casters own unit.</characteristic>
         <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">One order dice is removed from the unit and returned to the dice bag.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
@@ -999,7 +1055,7 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="4de4-3f21-99b0-3c0d" name="(Spell) Lightning Bolt" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">7</characteristic>
-        <characteristic name="Range" typeId="74f4-f123-678d-019c">30&quot; from caster</characteristic>
+        <characteristic name="Range" typeId="74f4-f123-678d-019c">30&quot; from caster.</characteristic>
         <characteristic name="Target" typeId="878a-e6bf-fe34-2254">Any unit in Range, NO LOS necessary.  If cast on unit with multiple models, pick the specific model that is the target.</characteristic>
         <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">Causes 1 hit.  Roll a D3 and add casters Magic Level, this is the SV of the bolt.   Once hit has been resolved and a pin has been added for being hit by a ranged missile, the unit must take a BREAK TEST.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
@@ -1009,7 +1065,7 @@ No armour bonus or cover bonus allowed.</description>
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">7</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per Magic Level of caster.</characteristic>
-        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">An enemy unit of monsters or a monstrosity within Range and LOS. (same as shooting)</characteristic>
+        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">An enemy unit of monsters or a monstrosity within Range and LOS (same as shooting attack).</characteristic>
         <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">If the unit has any order dice remaining in dice bag, take them all from the bag at once and give them to the unit as DOWN orders.  Any order dice already on the unit are instead changed to DOWN.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
@@ -1026,7 +1082,7 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="5528-567d-5eab-533e" name="(Spell) Sorcerous Battle!" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">6</characteristic>
-        <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per Magic level of Caster</characteristic>
+        <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per Magic level of caster.</characteristic>
         <characteristic name="Target" typeId="878a-e6bf-fe34-2254">Opposing Wizard Unit.  NO LOS necessary.</characteristic>
         <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">Each Wizard rolls a D6 and adds their Magic Level.  Highest total wins. The loser suffers a pin.  The winner can then decide whether to continue the duel or end it.  Repeat until a wizards reaches their pin break point or the winner declares an end to the spell.  If the results are a tie at any time then both wizards receive a pin and the duel continues.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
@@ -1035,7 +1091,7 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="6f59-6125-456e-38c3" name="Naginata" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">-</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
       </characteristics>
     </profile>
     <profile id="c35f-a7c3-0b86-a39f" name="Nunchaku" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
@@ -1047,7 +1103,7 @@ No armour bonus or cover bonus allowed.</description>
     <profile id="7ae9-8e9a-85e9-e68b" name="Hanbo, Cane, Scroll or Tea Service" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">-</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
       </characteristics>
     </profile>
     <profile id="bdba-151e-81e7-3b45" name="Shuriken" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -333,8 +333,7 @@ Unit can still be auto-destroyed by pins.</description>
     </rule>
     <rule id="90e2-5b2c-1fc8-0e8c" name="Magic Level 1" publicationId="cffa-cd51-pubN65537" page="86" hidden="false">
       <description>
-Spell Caster/Wizard Level 1.
-</description>
+Spell Caster/Wizard Level 1.</description>
     </rule>
     <rule id="487f-dc82-bce1-c0f6" name="Tough 2" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
@@ -351,18 +350,15 @@ Cannot Sprint.</description>
     </rule>
     <rule id="4a91-87e6-88c5-5e1d" name="Magic Level 2" publicationId="cffa-cd51-pubN65537" page="86" hidden="false">
       <description>
-Spell Caster/Wizard Level 2.
-</description>
+Spell Caster/Wizard Level 2.</description>
     </rule>
     <rule id="2e1b-4169-af1f-71e5" name="Magic Level 3" publicationId="cffa-cd51-pubN65537" page="86" hidden="false">
       <description>
-Spell Caster/Wizard Level 3.
-</description>
+Spell Caster/Wizard Level 3.</description>
     </rule>
     <rule id="78d3-886d-5fc6-bac4" name="Spirit" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
       <description>
-Can be sacrificed for a reroll. Destroyed if wizard is slain.
-</description>
+Can be sacrificed for a reroll. Destroyed if wizard is slain.</description>
     </rule>
     <rule id="d055-98ce-6f28-1600" name="Deadeye Shot" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
@@ -379,8 +375,7 @@ Cannot benefit from Command, Hero abilities.</description>
     </rule>
     <rule id="7f3d-fbf8-9f49-2031" name="Large" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
-Can draw LOS to body. +1 to hit when shooting at model. Can draw LOS over non-large models.
-</description>
+Can draw LOS to body. +1 to hit when shooting at model. Can draw LOS over non-large models.</description>
     </rule>
     <rule id="e406-ffab-b352-fc9b" name="Insufferably Sactimonious" hidden="false">
       <description>
@@ -868,7 +863,7 @@ Requires Fire Order to shoot. Does not gain +1 to hit from Aimed Shot.</descript
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">20-30&quot;</characteristic>
         <characteristic name="Range Extreme" typeId="49d3-642a-08be-5817">30-40&quot;</characteristic>
         <characteristic name="Strike Value" typeId="47c7-dced-6203-6b76">3</characteristic>
-        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Fire order to shoot, 3X Ranged SV3</characteristic>
+        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Fire order to shoot, 3x Ranged SV3</characteristic>
       </characteristics>
     </profile>
     <profile id="fbdf-a3cf-f1d1-8d05" name="Large Bolt Thrower" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -73,7 +73,7 @@
     <categoryEntry id="art unit" name="Artillery Unit" hidden="false"/>
     <categoryEntry id="hero unit" name="Hero Unit" hidden="false">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39c8-2edc-5461-fe0e" type="max"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39c8-2edc-5461-fe0e" type="max"/>
       </constraints>
     </categoryEntry>
     <categoryEntry id="ad3c-fc35-4ea7-7a70" name="Monster Unit" hidden="false"/>
@@ -81,6 +81,11 @@
     <categoryEntry id="239f-4e2f-785f-7869" name="Chariot Unit" hidden="false"/>
     <categoryEntry id="8efa-298b-b165-ef8b" name="Montrosity Unit" hidden="false"/>
     <categoryEntry id="c820-d327-811d-1144" name="Swarm Unit" hidden="false"/>
+    <categoryEntry id="af51-60b9-09ce-ed3f" name="Guard Unit" hidden="false">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b9d-80dc-9b92-1b41" type="max"/>
+      </constraints>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
     <forceEntry id="7ea6-a6ef-2ab9-ec1b" name="Army" hidden="false">
@@ -101,6 +106,11 @@
         <categoryLink id="9eef-ba48-1046-0bf3" name="Chariot Unit" hidden="false" targetId="239f-4e2f-785f-7869" primary="false"/>
         <categoryLink id="6a40-5161-bb63-34cd" name="Montrosity Unit" hidden="false" targetId="8efa-298b-b165-ef8b" primary="false"/>
         <categoryLink id="35cd-2ccb-f41b-356f" name="Swarm Unit" hidden="false" targetId="c820-d327-811d-1144" primary="false"/>
+        <categoryLink id="1785-9dd1-d441-319d" name="Guard Unit" hidden="false" targetId="af51-60b9-09ce-ed3f" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7569-f54d-9d55-fe5d" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
   </forceEntries>
@@ -237,6 +247,78 @@
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="04c0-42c1-8864-cf22" name="Magic Weapons" hidden="false" collective="false">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6370-7bdd-f80f-31db" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="2662-1897-7b10-499b" name="Battle Smiter Sword" page="" hidden="false" collective="false" type="upgrade">
+          <infoLinks>
+            <infoLink id="1be3-c8b5-d621-5a67" name="Battle Smiter Sword" hidden="false" targetId="454c-1957-36be-2d2b" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a389-5084-94b1-68b1" name="Bow of Burning Gold" page="" hidden="false" collective="false" type="upgrade">
+          <infoLinks>
+            <infoLink id="84c9-9338-8d25-ea95" name="Bow of Burning Gold" hidden="false" targetId="9f0d-4729-2ca1-43d8" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="20.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ec53-4987-7902-6b75" name="War Bringer Sword" hidden="false" collective="false" type="upgrade">
+          <infoLinks>
+            <infoLink id="0f7d-846a-6980-d602" name="War Bringer Sword" hidden="false" targetId="190e-3de5-0e71-c97f" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="27e4-3dd3-a978-6d45" name="Skull Crusher Hammer" hidden="false" collective="false" type="upgrade">
+          <infoLinks>
+            <infoLink id="9fd2-5884-2e2b-3c6e" name="Skull Crusher Hammer" hidden="false" targetId="caa2-6cf1-8c8f-2f66" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="79e3-1afc-6f0e-9442" name="Lightning Spear" hidden="false" collective="false" type="upgrade">
+          <infoLinks>
+            <infoLink id="f1c2-4824-0783-0802" name="Lightning Spear" hidden="false" targetId="d305-e931-5819-04bb" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4b51-d887-4003-7bd7" name="Helm Cleaver Sword" hidden="false" collective="false" type="upgrade">
+          <infoLinks>
+            <infoLink id="fc5a-ff93-aff7-04e8" name="Helm Cleaver Sword" hidden="false" targetId="3246-1376-d94d-d544" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="20.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9272-7674-7d81-e2f1" name="Foe Striker Sword" hidden="false" collective="false" type="upgrade">
+          <infoLinks>
+            <infoLink id="cab4-8461-c499-d690" name="Foe Striker Sword" hidden="false" targetId="193c-09f8-234d-adab" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="b9e1-fea5-9095-b1cf" name="Tough 1" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
@@ -364,9 +446,7 @@ Move the initiating unit first and resolve its action, then do the same for each
     </rule>
     <rule id="c3b6-8870-61d6-7aaf" name="Savage" publicationId="cffa-cd51-pubN65537" page="73" hidden="false">
       <description>
-Reroll all misses in first round of combat in game.
-
-</description>
+Reroll all misses in first round of combat in game.</description>
     </rule>
     <rule id="86b2-7051-4b5c-d149" name="Irresistible Charge" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
@@ -1025,31 +1105,31 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Armour +1 Max Bonus</characteristic>
       </characteristics>
     </profile>
-    <profile id="193c-09f8-234d-adab" name="(Magic Weapon) Foe Striker Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
+    <profile id="193c-09f8-234d-adab" name="Foe Striker Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR</characteristic>
       </characteristics>
     </profile>
-    <profile id="3246-1376-d94d-d544" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
+    <profile id="3246-1376-d94d-d544" name="Helm Cleaver Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">3</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR</characteristic>
       </characteristics>
     </profile>
-    <profile id="190e-3de5-0e71-c97f" name="(Magic Weapon) War Bringer Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
+    <profile id="190e-3de5-0e71-c97f" name="War Bringer Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR, HtH Attacks +1</characteristic>
       </characteristics>
     </profile>
-    <profile id="454c-1957-36be-2d2b" name="(Magic Weapon) Battle Smiter Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
+    <profile id="454c-1957-36be-2d2b" name="Battle Smiter Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+2 STR</characteristic>
       </characteristics>
     </profile>
-    <profile id="caa2-6cf1-8c8f-2f66" name="(Magic Weapon) Skull Crusher Hammer" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="caa2-6cf1-8c8f-2f66" name="Skull Crusher Hammer" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -1058,7 +1138,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">+1 STR in HtH only, Magically Returns to hand of user if thrown. Can be used in Exchange of Missiles.</characteristic>
       </characteristics>
     </profile>
-    <profile id="d305-e931-5819-04bb" name="(Magic Weapon) Lightning Spear" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="d305-e931-5819-04bb" name="Lightning Spear" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">(Exchange of Missiles only)</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -1067,7 +1147,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">HtH weapon that can be thrown in Exchange of Missiles.</characteristic>
       </characteristics>
     </profile>
-    <profile id="9f0d-4729-2ca1-43d8" name="(Magic Weapon) Bow of Burning Gold" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="9f0d-4729-2ca1-43d8" name="Bow of Burning Gold" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-30&quot;</characteristic>
@@ -1076,7 +1156,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">ACC +1</characteristic>
       </characteristics>
     </profile>
-    <profile id="dd49-722d-5180-e75d" name="(Spell) Fiery Balls" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="dd49-722d-5180-e75d" name="Fiery Balls" publicationId="cffa-cd51-pubN65537" page="88" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">9</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">20&quot;</characteristic>
@@ -1085,7 +1165,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
     </profile>
-    <profile id="d6c5-70ce-86e8-e635" name="(Spell) Chill Wind" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="d6c5-70ce-86e8-e635" name="Chill Wind" publicationId="cffa-cd51-pubN65537" page="89" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">20&quot;</characteristic>
@@ -1094,7 +1174,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
     </profile>
-    <profile id="096e-2da4-2cdd-6c4d" name="(Spell) Peculiar Portal" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="096e-2da4-2cdd-6c4d" name="Peculiar Portal" publicationId="cffa-cd51-pubN65537" page="89" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8 minus 1 for every 10&quot; of distance between caster and target.</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">N/A</characteristic>
@@ -1103,7 +1183,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
     </profile>
-    <profile id="a1be-15b4-9c73-9b6f" name="(Spell) Endow Strength" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="a1be-15b4-9c73-9b6f" name="Endow Strength" publicationId="cffa-cd51-pubN65537" page="89" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">Cast upon Wizard and also automatically affects all friendly units in HtH combat within 10&quot; of the wizard.</characteristic>
@@ -1112,7 +1192,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Lasts until the end of turn.  Also immediately ends if the caster moves, attempts to dispel and enemy spell, or is killed. (does NOT end if caster is in HtH fighting)</characteristic>
       </characteristics>
     </profile>
-    <profile id="29a5-e36b-7b3f-c197" name="(Spell) Enchanted Shield" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="29a5-e36b-7b3f-c197" name="Enchanted Shield" publicationId="cffa-cd51-pubN65537" page="92" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per Magic Level.</characteristic>
@@ -1121,16 +1201,16 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Lasts until End of Turn</characteristic>
       </characteristics>
     </profile>
-    <profile id="dd16-8e55-111c-118c" name="(Spell) Aura of Courage" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="dd16-8e55-111c-118c" name="Aura of Courage" publicationId="cffa-cd51-pubN65537" page="92" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">All Friendly Units within 10&quot;.</characteristic>
         <characteristic name="Target" typeId="878a-e6bf-fe34-2254">All Friendly Units within 10&quot;.</characteristic>
-        <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">Roll a D6 and add Wizards Magic Level.  You can remove this total number of pins from the target units.  It does not have to be distributed evenly, you get to decide which pins are removed from where.</characteristic>
+        <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">Roll a D6 and add Magic Level.  You can remove this total number of pins from the target units.  It does not have to be distributed evenly, you get to decide which pins are removed from where.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
     </profile>
-    <profile id="dd4e-402d-e03c-f841" name="(Spell) Aura of Timidity" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="dd4e-402d-e03c-f841" name="Aura of Timidity" publicationId="cffa-cd51-pubN65537" page="92" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; for Magic Level 1, 20&quot; for Magic Level 2, 30&quot; for Magic Level 3.</characteristic>
@@ -1139,7 +1219,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
     </profile>
-    <profile id="5cf5-b784-0eca-19aa" name="(Spell) Wake the Dead" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="5cf5-b784-0eca-19aa" name="Wake the Dead" publicationId="cffa-cd51-pubN65537" page="93" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per magic level of caster.</characteristic>
@@ -1148,7 +1228,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
     </profile>
-    <profile id="ae9d-c50e-6667-48f3" name="(Spell) Sorcerer&apos;s Shield" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="ae9d-c50e-6667-48f3" name="Sorcerer&apos;s Shield" publicationId="cffa-cd51-pubN65537" page="93" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">7</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per Magic Level.</characteristic>
@@ -1157,7 +1237,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Lasts until end of the turn.  Also ended immediately if the caster Moves, attempts to dispel an enemy&apos;s spell or is killed.</characteristic>
       </characteristics>
     </profile>
-    <profile id="0a25-272c-9462-1696" name="(Spell) Surge" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="0a25-272c-9462-1696" name="Surge" publicationId="cffa-cd51-pubN65537" page="93" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">7</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; (for undead wizards and necromancers the range is 10&quot; per magic level).</characteristic>
@@ -1166,7 +1246,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
     </profile>
-    <profile id="4de4-3f21-99b0-3c0d" name="(Spell) Lightning Bolt" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="4de4-3f21-99b0-3c0d" name="Lightning Bolt" publicationId="cffa-cd51-pubN65537" page="94" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">7</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">30&quot; from caster.</characteristic>
@@ -1175,7 +1255,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
     </profile>
-    <profile id="b2eb-08fa-19f7-0fe1" name="(Spell) Bamboozle Beastie" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="b2eb-08fa-19f7-0fe1" name="Bamboozle Beastie" publicationId="cffa-cd51-pubN65537" page="94" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">7</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per Magic Level of caster.</characteristic>
@@ -1184,7 +1264,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
     </profile>
-    <profile id="b1eb-7ae0-4936-b755" name="(Spell) Enfeeble Foe" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="b1eb-7ae0-4936-b755" name="Enfeeble Foe" publicationId="cffa-cd51-pubN65537" page="95" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">6</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot;</characteristic>
@@ -1193,7 +1273,7 @@ Restores Agility and Initiative to previous values (usually included in the stat
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Lasts until end of turn, also ends immediately if the caster moves, attempts to dispel an enemy&apos;s spell or is Killed.</characteristic>
       </characteristics>
     </profile>
-    <profile id="5528-567d-5eab-533e" name="(Spell) Sorcerous Battle!" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
+    <profile id="5528-567d-5eab-533e" name="Sorcerous Battle!" publicationId="cffa-cd51-pubN65537" page="95" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">6</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot; per Magic level of caster.</characteristic>

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="cffa-cd51-33d5-b2c6" name="Warlords of Erehwon" revision="4" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="cffa-cd51-33d5-b2c6" name="Warlords of Erehwon" revision="5" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="cffa-cd51-pubN65537" name="WoE"/>
   </publications>
@@ -362,7 +362,7 @@ Can be sacrificed for a reroll. Destroyed if wizard is slain.</description>
     </rule>
     <rule id="d055-98ce-6f28-1600" name="Deadeye Shot" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
-Re-roll one missed attack.</description>
+Re-roll one missed shooting attack.</description>
     </rule>
     <rule id="160b-fca8-adb7-3d5b" name="Pavise" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
@@ -702,7 +702,8 @@ Cancels Heavily Laden.
 Restores Agility and Initiative to previous values (usually included in the stat line).</description>
     </rule>
     <rule id="7751-622a-b896-4874" name="Overhead" publicationId="cffa-cd51-pubN65537" page="32" hidden="false">
-      <description>Uses 3&quot; template. All units under template are hit, divide hits evenly between units. 
+      <description>
+Uses 3&quot; template. All units under template are hit, divide hits evenly between units. 
 Allocate hits first to models under template then to others in unit.
 On miss, roll D10 to deviate: move template as many inches in direction shown by die. 
 When shooting blind (without LOS): Hits on a 1, misses are ignored and have no effect.</description>
@@ -710,6 +711,9 @@ When shooting blind (without LOS): Hits on a 1, misses are ignored and have no e
     <rule id="d2a3-26b0-f825-e454" name="Fire Order to Shoot" publicationId="cffa-cd51-pubN65537" page="28" hidden="false">
       <description>
 Requires Fire Order to shoot. Does not gain +1 to hit from Aimed Shot.</description>
+    </rule>
+    <rule id="c2ce-a18c-2d45-d817" name="Ferocious Charge" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
+      <description>+1 to strength when charging. Does not apply to follow-on combat.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -722,7 +722,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="2447-8f38-dd07-d089" name="Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
+    <profile id="2447-8f38-dd07-d089" name="Sword or Axe" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">STR +1</characteristic>
@@ -926,7 +926,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Armour +1 Max  bonus.</characteristic>
       </characteristics>
     </profile>
-    <profile id="a1ad-5715-ceb1-e77e" name="Axe" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
+    <profile id="a1ad-5715-ceb1-e77e" name="Delete" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR</characteristic>

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -368,8 +368,7 @@ Can be sacrificed for a reroll. Destroyed if wizard is slain.
     </rule>
     <rule id="d055-98ce-6f28-1600" name="Deadeye Shot" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
-Re-roll one missed attack.
-</description>
+Re-roll one missed attack.</description>
     </rule>
     <rule id="160b-fca8-adb7-3d5b" name="Pavise" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
@@ -392,8 +391,7 @@ Increase from Tough to Tough 2.
     </rule>
     <rule id="b0ed-8f0b-633c-2f06" name="Command" publicationId="cffa-cd51-pubN65537" page="64" hidden="false">
       <description>
-Friendly units within 10&quot; can use the model&apos;s CO stat to take command based tests.
-</description>
+Friendly units within 10&quot; can use the model&apos;s CO stat to take command based tests.</description>
     </rule>
     <rule id="a447-d495-b7ab-1477" name="Divine Intervention" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
@@ -491,8 +489,7 @@ All difficult ground/obstacles count as open terrain for movement.
     </rule>
     <rule id="c738-3360-de3b-34a9" name="Deathly Chill" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
-Attacks ignore armour.
-</description>
+Attacks ignore armour.</description>
     </rule>
     <rule id="0bf9-a070-b56b-ca4e" name="Dread" publicationId="cffa-cd51-pubN65537" page="66" hidden="false">
       <description>
@@ -539,8 +536,7 @@ If your warlord is slain, then no further pins are removed from your units. Orde
     <rule id="0056-a41e-408e-1673" name="Disciplined" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
 Lose all pins when passing a Rally test. 
-Routing units lose all pins if passing a Command test due to nearby units making a Rally order.
-</description>
+Routing units lose all pins if passing a Command test due to nearby units making a Rally order.</description>
     </rule>
     <rule id="93f9-d132-d71b-ab39" name="Shieldwall" publicationId="cffa-cd51-pubN65537" page="73" hidden="false">
       <description>
@@ -551,8 +547,7 @@ Enemy suffers -1 to hit in ranged and HtH.
     </rule>
     <rule id="0b0f-1de6-7017-9097" name="Berserk" publicationId="cffa-cd51-pubN65537" page="62" hidden="false">
       <description>
-Until defeated or fail a break test: double attacks in HtH and automatically pass orders to charge including reactions.
-</description>
+Until defeated or fail a break test: double attacks in HtH and automatically pass orders to charge including reactions.</description>
     </rule>
     <rule id="5da1-1bfa-9b8d-6b82" name="MoD2" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
@@ -572,9 +567,7 @@ Unit goes down and gains 1 pin per unit trampled.
     </rule>
     <rule id="2b40-80c8-12cf-8f44" name="Crazed Psychotics" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
-Automatically pass charge orders. Cannot be routed. Immune to Dread and Terror.
-
-</description>
+Automatically pass charge orders. Cannot be routed. Immune to Dread and Terror.</description>
     </rule>
     <rule id="8eba-5940-fd9b-254c" name="Drop" publicationId="cffa-cd51-pubN65537" page="66" hidden="false">
       <description>
@@ -588,49 +581,40 @@ Fire attacks add an extra pin to targets they hit.</description>
     <rule id="57f2-e9b1-c3c1-7c74" name="Mechanical Genius" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
 Add +1 ACC to all artillery attacks in 10&quot;. 
-+/-1 for any Monstrosity (machine) damage chart result within 10&quot;.
-</description>
++/-1 for any Monstrosity (machine) damage chart result within 10&quot;.</description>
     </rule>
     <rule id="182e-9b37-17f3-5b45" name="Ramshackle Contraption" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
-On a failed order result of a 10 roll on the Monstrosity damage chart.
-</description>
+On a failed order result of a 10 roll on the Monstrosity damage chart.</description>
     </rule>
     <rule id="4440-376a-8093-35b8" name="Stubborn" publicationId="cffa-cd51-pubN65537" page="75" hidden="false">
       <description>
-Remove +1 pin if order test is successful.
-</description>
+Remove +1 pin if order test is successful.</description>
     </rule>
     <rule id="4808-d708-bb73-97e8" name="Enchanted Steed" publicationId="cffa-cd51-pubN65537" page="66" hidden="false">
       <description>
 All water terrain counts as open terrain and adds +1 RES to mounted units.
-Reroll failed RES tests against shooting attacks (does not apply to chariots).
-</description>
+Reroll failed RES tests against shooting attacks (does not apply to chariots).</description>
     </rule>
     <rule id="6a8d-ef1b-6f78-e15c" name="Haughty Disdain" publicationId="cffa-cd51-pubN65537" page="69" hidden="false">
       <description>
-Automatically pass first Break Test in the game.
-</description>
+Automatically pass first Break Test in the game.</description>
     </rule>
     <rule id="e1f3-7817-0e4e-5cb9" name="Woodsman" publicationId="cffa-cd51-pubN65537" page="80" hidden="false">
       <description>
-Wooded terrain counts as open terrain. +1 RES cover bonus in wooden terrain.
-</description>
+Wooded terrain counts as open terrain. +1 RES cover bonus in wooden terrain.</description>
     </rule>
     <rule id="dcb2-de55-1fca-e0a8" name="Stealthy" publicationId="cffa-cd51-pubN65537" page="75" hidden="false">
       <description>
-Re-roll shooting hits against unit if in cover.
-</description>
+Re-roll shooting hits against unit if in cover.</description>
     </rule>
     <rule id="9855-31c9-3745-714d" name="Baleful Glare" publicationId="cffa-cd51-pubN65537" page="62" hidden="false">
       <description>
-Ranged Attack 20&quot;. No damage but inflicts 1+D3 pins and unit takes a Break test.
-</description>
+Ranged Attack 20&quot;. No damage but inflicts 1+D3 pins and unit takes a Break test.</description>
     </rule>
     <rule id="53b9-a3e9-0e9f-2d77" name="Venomous" publicationId="cffa-cd51-pubN65537" page="77" hidden="false">
       <description>
-Add one hit if any hits are scored.
-</description>
+Add one hit if any hits are scored.</description>
     </rule>
     <rule id="37e8-d658-01a9-6916" name="Flaming Breath" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>
@@ -638,47 +622,39 @@ Ranged Attack 20&quot;. Fire Attack (+1 pin). As Stats.</description>
     </rule>
     <rule id="087e-dfda-76c2-09bf" name="Blundering" publicationId="cffa-cd51-pubN65537" page="63" hidden="false">
       <description>
-Cannot Sprint. Must test Agility for a Run action. Crosses obstacles as chariot/artillery.
-</description>
+Cannot Sprint. Must test Agility for a Run action. Crosses obstacles as chariot/artillery.</description>
     </rule>
     <rule id="0a0c-ed4c-9647-4398" name="Regenerate" publicationId="cffa-cd51-pubN65537" page="73" hidden="false">
       <description>
-Must re-roll one failed RES test per attack and take pin if successful. Does not work against Fire attacks.
-</description>
+Must re-roll one failed RES test per attack and take pin if successful. Does not work against Fire attacks.</description>
     </rule>
     <rule id="14ff-225a-4ec5-f56d" name="Beastly Breath" publicationId="cffa-cd51-pubN65537" page="62" hidden="false">
       <description>
-D6 Ranged attacks, 20&quot;, SV3 Choking.
-</description>
+D6 Ranged attacks, 20&quot;, SV3 Choking.</description>
     </rule>
     <rule id="46d2-d008-8225-bcff" name="Chunder" publicationId="cffa-cd51-pubN65537" page="64" hidden="false">
       <description>
-Ranged Attack 10&quot;. Opponent&apos;s RES is always 5.  Chunder goes empty on a roll of 6+.
-</description>
+Ranged Attack 10&quot;. Opponent&apos;s RES is always 5.  Chunder goes empty on a roll of 6+.</description>
     </rule>
     <rule id="583a-fa53-11ff-7b40" name="Terror" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
 A unit within 15&quot; removes NO pins when making an order test. 
 A unit failing a break test within 5&quot; is automatically destroyed.
 A routing unit within 5&quot; is automatically destroyed.
-Terrifying units and units with the Crazed Psychotic/Undead rules are immune to terror.
-</description>
+Terrifying units and units with the Crazed Psychotic/Undead rules are immune to terror.</description>
     </rule>
     <rule id="7ff2-1650-fc0e-5a3a" name="Choking" publicationId="cffa-cd51-pubN65537" page="64" hidden="false">
       <description>
-No armour bonus or cover bonus allowed.
-</description>
+No armour bonus or cover bonus allowed.</description>
     </rule>
     <rule id="ae37-06b2-7f4c-ec52" name="Allied Monster" publicationId="cffa-cd51-pubN65537" page="62" hidden="false">
       <description>
-Cannot benefit from Command, Hero, or Follow special rules.
-</description>
+Cannot benefit from Command, Hero, or Follow special rules.</description>
     </rule>
     <rule id="2e98-ee7b-558a-81ef" name="Bound Monster" publicationId="cffa-cd51-pubN65537" page="63" hidden="false">
       <description>
 Cannot benefit from Command, Hero, or Follow special rules.
-Take D6 pins if a 10 is rolled for its order test. Can be auto-destroyed via pins as a result.
-</description>
+Take D6 pins if a 10 is rolled for its order test. Can be auto-destroyed via pins as a result.</description>
     </rule>
     <rule id="3a29-1b97-6c21-75e7" name="Flaming Wheel" publicationId="cffa-cd51-pubN65537" page="68" hidden="false">
       <description>
@@ -688,30 +664,25 @@ Fire order to shoot (or rather push).</description>
     </rule>
     <rule id="a8ca-ba71-db97-bc20" name="MoD3" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
-Unit has 3 Order Dice. See page 56 for rules.
-</description>
+Unit has 3 Order Dice.</description>
     </rule>
     <rule id="9d78-2294-d4fd-9efd" name="Slow 3" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
       <description>
-Move at a base rate of 3&quot;.
-</description>
+Move at a base rate of 3&quot;.</description>
     </rule>
     <rule id="ade7-83de-c555-3df3" name="Slow 4" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
       <description>
-Move at a base rate of 4&quot;.
-</description>
+Move at a base rate of 4&quot;.</description>
     </rule>
     <rule id="7753-3806-9cf1-0a6c" name="Fast 6" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>
 Move at a base rate of 6&quot;.
-Reroll shooting hits against unit if it has a Run order.
-</description>
+Reroll shooting hits against unit if it has a Run order.</description>
     </rule>
     <rule id="105b-036d-9a8f-edac" name="Fast 8" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>
 Move at a base rate of 8&quot;.
-Reroll shooting hits against unit if it has a Run order.
-</description>
+Reroll shooting hits against unit if it has a Run order.</description>
     </rule>
     <rule id="0034-82ae-f695-d446" name="Fast 10" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>
@@ -727,22 +698,25 @@ Re-roll all shooting hits on unit.
 Enemies don&apos;t attack in close combat. Saved hits (successful RES rolls) count as casualties for the dervish unit.
 Unit is automatically destroyed if close combat is not won.
 Consolidation move is random, may initiate immediate combat if touching different unit than that just fought. 
-May make consolidation move through unit it just fought.
-</description>
+May make consolidation move through unit it just fought.</description>
     </rule>
     <rule id="e2ce-cefd-9949-02fd" name="Wild Monster" publicationId="cffa-cd51-pubN65537" page="80" hidden="false">
       <description>
 Goes wild if 10 is rolled for order test.
 Add D6 pins to check for auto-destruction as normal. If not auto-destroyed, remove all pins.
 Replace all order dice by one die of different color.
-When order die is drawn, players dice for control.
-</description>
+When order die is drawn, players dice for control.</description>
     </rule>
     <rule id="03c8-e023-d3fe-8b64" name="Warhorse" publicationId="cffa-cd51-pubN65537" page="77" hidden="false">
       <description>
 Cancels Heavily Laden.
-Restores Agility and Initiative to previous values (usually included in the stat line).
-</description>
+Restores Agility and Initiative to previous values (usually included in the stat line).</description>
+    </rule>
+    <rule id="7751-622a-b896-4874" name="Overhead" publicationId="cffa-cd51-pubN65537" page="32" hidden="false">
+      <description>Uses 3&quot; template. All units under template are hit, divide hits evenly between units. 
+Allocate hits first to models under template then to others in unit.
+On miss, roll D10 to deviate: move template as many inches in direction shown by die. 
+When shooting blind (without LOS): Hits on a 1, misses are ignored and have no effect.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -329,8 +329,7 @@ Re-roll a failed RES test. Only one failed RES test can be re-rolled at a time f
       <description>
 Model can sustain 1 wound instead of dying immediately.
 Each sustained wound counts as a permanent pin that can&apos;t be removed.
-Unit can still be auto-destroyed by pins.
-</description>
+Unit can still be auto-destroyed by pins.</description>
     </rule>
     <rule id="90e2-5b2c-1fc8-0e8c" name="Magic Level 1" publicationId="cffa-cd51-pubN65537" page="86" hidden="false">
       <description>
@@ -344,8 +343,7 @@ Re-roll two failed RES tests from a single attack. A die may only be re-rolled o
     </rule>
     <rule id="45bb-28cf-94fd-f899" name="Zealous" publicationId="cffa-cd51-pubN65537" page="81" hidden="false">
       <description>
-Ignore pins when taking a break test. Re-Roll failed order test.
-</description>
+Ignore pins when taking a break test. Re-Roll failed order test.</description>
     </rule>
     <rule id="1a97-76e9-e64e-7701" name="Heavily Laden" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
@@ -405,8 +403,7 @@ If successful, unit that the die was stolen from counts as having received an or
       <description>
 Model can sustain 2 wounds instead of dying immediately.
 Each sustained wound counts as a permanent pin that can&apos;t be removed.
-Unit can still be auto-destroyed by pins.
-</description>
+Unit can still be auto-destroyed by pins.</description>
     </rule>
     <rule id="bb63-e7db-89cf-19e6" name="Challenge" publicationId="cffa-cd51-pubN65537" page="64" hidden="false">
       <description>
@@ -422,8 +419,7 @@ Re-roll three failed RES tests from a single attack. A die may only be re-rolled
       <description>
 Model can sustain 3 wounds instead of dying immediately.
 Each sustained wound counts as a permanent pin that can&apos;t be removed.
-Unit can still be auto-destroyed by pins.
-</description>
+Unit can still be auto-destroyed by pins.</description>
     </rule>
     <rule id="566e-a1c6-9f62-3218" name="Hero" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
@@ -478,8 +474,7 @@ Immune to Terror.
     </rule>
     <rule id="fd2c-3cba-cafa-62aa" name="Zombie Master" publicationId="cffa-cd51-pubN65537" page="81" hidden="false">
       <description>
-Can use Hero/Follow/Command rules for Zombie units.
-</description>
+Can use Hero/Follow/Command rules for Zombie units.</description>
     </rule>
     <rule id="3dfb-f407-ff46-9b1f" name="Spectral Undead" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
       <description>
@@ -503,8 +498,7 @@ Unaffected by opponents with Dread.
 A failed order test is an advance order and not down.  
 Cannot sprint.
 Must test Agility after Run order.
-Cannot benefit from the Hero/Follow/Command unless character is Zombie Master.
-</description>
+Cannot benefit from the Hero/Follow/Command unless character is Zombie Master.</description>
     </rule>
     <rule id="4d2b-eef9-9776-1480" name="Slow" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
       <description>
@@ -717,6 +711,10 @@ Restores Agility and Initiative to previous values (usually included in the stat
 Allocate hits first to models under template then to others in unit.
 On miss, roll D10 to deviate: move template as many inches in direction shown by die. 
 When shooting blind (without LOS): Hits on a 1, misses are ignored and have no effect.</description>
+    </rule>
+    <rule id="d2a3-26b0-f825-e454" name="Fire Order to Shoot" publicationId="cffa-cd51-pubN65537" page="28" hidden="false">
+      <description>
+Requires Fire Order to shoot. Does not gain +1 to hit from Aimed Shot.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
@@ -1059,7 +1057,7 @@ When shooting blind (without LOS): Hits on a 1, misses are ignored and have no e
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
         <characteristic name="Range Extreme" typeId="49d3-642a-08be-5817">-</characteristic>
         <characteristic name="Strike Value" typeId="47c7-dced-6203-6b76">3</characteristic>
-        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Drop SV3</characteristic>
+        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">3x Drop SV3</characteristic>
       </characteristics>
     </profile>
     <profile id="50ea-80df-79dd-7d1e" name="Horse" hidden="false" typeId="2f17-7b0c-7f4e-2baf" typeName="Model">

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="cffa-cd51-33d5-b2c6" name="Warlords of Erehwon" revision="5" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="cffa-cd51-33d5-b2c6" name="Warlords of Erehwon" revision="6" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="cffa-cd51-pubN65537" name="WoE"/>
   </publications>
@@ -714,6 +714,11 @@ Requires Fire Order to shoot. Does not gain +1 to hit from Aimed Shot.</descript
     </rule>
     <rule id="c2ce-a18c-2d45-d817" name="Ferocious Charge" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>+1 to strength when charging. Does not apply to follow-on combat.</description>
+    </rule>
+    <rule id="fd29-829f-3cd9-1841" name="Fast 7" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
+      <description>
+Move at a base rate of 7&quot;.
+Reroll shooting hits against unit if it has a Run order.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -223,95 +223,98 @@
   <sharedRules>
     <rule id="b9e1-fea5-9095-b1cf" name="Tough" hidden="false">
       <description>
--Re-roll a failed RES test.  (only one failed RES test can be re-rolled at a time from a single shooting/HTH attack). </description>
+Re-roll a failed RES test.  Only one failed RES test can be re-rolled at a time from a single shooting/HTH attack.</description>
     </rule>
     <rule id="8784-9f2f-1a5b-be21" name="Wound" hidden="false">
       <description>
--A model with the Wound Special rule is not removed as a casualty when it fails a RES test and would otherwise fall casualty. The model becomes &apos;wounded&apos; instead. A wounded model can fight on, but if it fails a further RES test it is removed as a casualty just like any other model.
--Once a unit with the special rule sustains a wound, they can never drop below 1 Pin on the unit.  
--Wound rule does not prevent a unit from auto destruction if it takes pins equal to or greater than their Co stat.</description>
+Model can sustain 1 wound instead of dying immediately.
+Each sustained wound counts as a permanent pin that can&apos;t be removed.
+Unit can still be auto-destroyed by pins.
+</description>
     </rule>
     <rule id="90e2-5b2c-1fc8-0e8c" name="Magic Level 1" hidden="false">
-      <description>-Spell Caster/Wizard </description>
+      <description>
+Spell Caster/Wizard Level 1.</description>
     </rule>
     <rule id="487f-dc82-bce1-c0f6" name="Tough 2" hidden="false">
       <description>
--Re-roll a failed RES test.  (only one failed RES test can be re-rolled at a time from a single shooting/HTH attack).  Tough 2 allows 2 re-rolls.</description>
+Re-roll two failed RES tests from a single attack. A die may only be re-rolled once, you must accept the second result.</description>
     </rule>
     <rule id="45bb-28cf-94fd-f899" name="Zealous" hidden="false">
       <description>
--Ignore Pins when taking a break test. Re-Roll failed order test.</description>
+Ignore Pins when taking a break test. Re-Roll failed order test.</description>
     </rule>
     <rule id="1a97-76e9-e64e-7701" name="Heavily Laden" hidden="false">
-      <description>-Cannot Sprint</description>
+      <description>
+Cannot Sprint.</description>
     </rule>
     <rule id="4a91-87e6-88c5-5e1d" name="Magic Level 2" hidden="false">
-      <description>-Spell Caster/Wizard </description>
+      <description>
+Spell Caster/Wizard Level 2.</description>
     </rule>
     <rule id="2e1b-4169-af1f-71e5" name="Magic Level 3" hidden="false">
-      <description>-Spell Caster/Wizard </description>
+      <description>
+Spell Caster/Wizard Level 3.</description>
     </rule>
     <rule id="78d3-886d-5fc6-bac4" name="Spirit" hidden="false">
-      <description>-Can be sacrificed for a re-roll. Destroyed if wizard is slain.</description>
+      <description>
+Can be sacrificed for a re-roll. Destroyed if wizard is slain.</description>
     </rule>
     <rule id="d055-98ce-6f28-1600" name="Deadeye Shot" hidden="false">
-      <description>-Re-roll one missed shot.</description>
+      <description>
+Re-roll one missed shot.</description>
     </rule>
     <rule id="160b-fca8-adb7-3d5b" name="Pavisse" hidden="false">
       <description>
--Cannot be given Run order.
--3 Agility.
--Counts as cover with +2 Res bonus.</description>
+Cannot be given Run order. -3 Agility. Counts as cover with +2 Res bonus.</description>
     </rule>
     <rule id="8a4d-4dea-f005-ddc5" name="Surly" hidden="false">
       <description>
--Cannot benefit from Command, Hero </description>
+Cannot benefit from Command, Hero abilities.</description>
     </rule>
     <rule id="7f3d-fbf8-9f49-2031" name="Large" hidden="false">
       <description>
-- Can draw LOS to body.
-- (+1) to hit shooting.
--Can draw LOS over non-large models.</description>
+Can draw LOS to body. (+1) to hit shooting. Can draw LOS over non-large models.</description>
     </rule>
     <rule id="e406-ffab-b352-fc9b" name="Insufferably Sactimonious" hidden="false">
       <description>
--Increase from Tough to Tough 2.</description>
+Increase from Tough to Tough 2.</description>
     </rule>
     <rule id="b0ed-8f0b-633c-2f06" name="Command" hidden="false">
       <description>
--Friendly units within 10&quot; can use the model&apos;s CO stat to take command based tests.</description>
+Friendly units within 10&quot; can use the model&apos;s CO stat to take command based tests.</description>
     </rule>
     <rule id="a447-d495-b7ab-1477" name="Divine Intervention" hidden="false">
       <description>
--Can steal an order dice from an enemy unit within 20&quot; with successful Command test. If fail, take 1 pin instead. Max 1 attempt in any turn.</description>
+Can steal an order dice from an enemy unit within 20&quot; with successful Command test. If fail, take 1 pin instead. Max 1 attempt in any turn.</description>
     </rule>
     <rule id="342b-a482-cb16-67e0" name="Wound 2" hidden="false">
       <description>
--A model with the Wound Special rule is not removed as a casualty when it fails a RES test and would otherwise fall casualty. The model becomes &apos;wounded&apos; instead. A wounded model can fight on, but if it fails a further RES test it is removed as a casualty just like any other model.
--Once a unit with the special rule sustains a wound, they can never drop below 1 Pin on the unit. 2 wounds = 2 pins, etc.  
--Wound rule does not prevent a unit from auto destruction if it takes pins equal to or greater than their Co stat.</description>
+Model can sustain 2 wounds instead of dying immediately.
+Each sustained wound counts as a permanent pin that can&apos;t be removed.
+Unit can still be auto-destroyed by pins.</description>
     </rule>
-    <rule id="bb63-e7db-89cf-19e6" name="Challenge" hidden="false">
+    <rule id="bb63-e7db-89cf-19e6" name="Challenge" publicationId="cffa-cd51-pubN65537" page="64" hidden="false">
       <description>
--See page 64, May initiate a &apos;Challenge to the death&apos;</description>
+May initiate a &apos;Challenge to the death&apos;.</description>
     </rule>
     <rule id="3536-db5c-4e89-87d7" name="Tough 3" hidden="false">
       <description>
--Re-roll a failed RES test.  (only one failed RES test can be re-rolled at a time from a single shooting/HTH attack).  Tough 3 allows 3 re-rolls.</description>
+Re-roll three failed RES tests from a single attack. A die may only be re-rolled once, you must accept the second result.</description>
     </rule>
     <rule id="2724-2057-e745-23a3" name="Wound 3" hidden="false">
       <description>
--A model with the Wound Special rule is not removed as a casualty when it fails a RES test and would otherwise fall casualty. The model becomes &apos;wounded&apos; instead. A wounded model can fight on, but if it fails a further RES test it is removed as a casualty just like any other model.
--Once a unit with the special rule sustains a wound, they can never drop below 1 Pin on the unit. 2 wounds = 2 pins, etc.  
--Wound rule does not prevent a unit from auto destruction if it takes pins equal to or greater than their Co stat.</description>
+Model can sustain 3 wounds instead of dying immediately.
+Each sustained wound counts as a permanent pin that can&apos;t be removed.
+Unit can still be auto-destroyed by pins.</description>
     </rule>
-    <rule id="566e-a1c6-9f62-3218" name="Hero" hidden="false">
+    <rule id="566e-a1c6-9f62-3218" name="Hero" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
--Friendly units within 10&quot; can use the model&apos;s Init stat to take Reaction Tests.</description>
+Friendly units within 10&quot; can use the model&apos;s Init stat to take Reaction Tests.</description>
     </rule>
     <rule id="83d2-f89c-33a4-258d" name="Follow" hidden="false">
       <description>
--Friendly un-pinned units within 5&quot; can follow the unit&apos;s order immediately.</description>
+Friendly un-pinned units within 5&quot; can follow the unit&apos;s order immediately.</description>
     </rule>
     <rule id="1c49-276e-425d-0999" name="Frenzied Charge" hidden="false">
       <description>
@@ -325,44 +328,40 @@ Re-Roll STR to hit in first round of combat in game.</description>
       <description>
 D3 SV bonus when charging.</description>
     </rule>
-    <rule id="e291-560d-f0fb-5572" name="Rapid Sprint" hidden="false">
-      <description>
--Sprint at 4M</description>
-    </rule>
     <rule id="1d07-520b-6918-03fd" name="Flies" hidden="false">
       <description>
--Move over any terrain/obstacle without test or penalty.
--Enemy cannot charge/countercharge or follow-on in combat unless they can also fly, or if flyers are down.</description>
+Move over any terrain/obstacle without test or penalty.
+Enemy cannot charge/countercharge or follow-on in combat unless they can also fly, or if flyers are down.</description>
     </rule>
     <rule id="5e63-c99b-00b4-24eb" name="Vengeful" hidden="false">
       <description>
--If unit wins the first round of close combat then it MUST elect to fight a follow on combat where it can do so.
--In follow-on combat, vengeful troops always fight with double their attacks.</description>
+If unit wins the first round of close combat then it MUST elect to fight a follow on combat where it can do so.
+In follow-on combat, vengeful troops always fight with double their attacks.</description>
     </rule>
     <rule id="e5df-1d6a-1034-7c77" name="Undead" hidden="false">
       <description>
--Cannot be routed.
--Auto Resist choking attacks.
--Immune to Dread
--Immune to Terror</description>
+Cannot be routed.
+Auto-resist choking attacks.
+Immune to Dread
+Immune to Terror</description>
     </rule>
     <rule id="fd2c-3cba-cafa-62aa" name="Zombie Master" hidden="false">
       <description>
--Can use Hero/Follow/Command rules for Zombie units.</description>
+Can use Hero/Follow/Command rules for Zombie units.</description>
     </rule>
     <rule id="3dfb-f407-ff46-9b1f" name="Spectral Undead" hidden="false">
       <description>
--In addition to Undead rule, also hits from flaming attacks are ignored (auto-resisted) and inflict no pins.
--All difficult ground/obstacles count as open terrain for movement.</description>
+In addition to Undead rule, also hits from flaming attacks are ignored (auto-resisted) and inflict no pins.
+All difficult ground/obstacles count as open terrain for movement.</description>
     </rule>
     <rule id="c738-3360-de3b-34a9" name="Deathly Chill" hidden="false">
       <description>
--No armour bonus allowed.</description>
+No armour bonus allowed.</description>
     </rule>
     <rule id="0bf9-a070-b56b-ca4e" name="Dread" hidden="false">
       <description>
 (-1) to hit shooting/close combat.
-(-1) to break test if defeated by Dreraded enemy.</description>
+(-1) to break test if defeated by enemy with Dread.</description>
     </rule>
     <rule id="612a-20b6-14a2-97e4" name="Zombie" hidden="false">
       <description>
@@ -388,7 +387,7 @@ Shot penetrates the unit hit and can strike others beyond so long as the target 
     </rule>
     <rule id="6650-1e8e-9f7d-d242" name="Undead Army Special Rule" hidden="false">
       <description>
-In an UNDEAD army, if your warlord is slain, then no further pins are removed from your units. Orders can still be issued as normal.</description>
+If your warlord is slain, then no further pins are removed from your units. Orders can still be issued as normal.</description>
     </rule>
     <rule id="0056-a41e-408e-1673" name="Disciplined" hidden="false">
       <description>
@@ -396,21 +395,20 @@ Lose all pins when pass a rally test.</description>
     </rule>
     <rule id="93f9-d132-d71b-ab39" name="Shieldwall" hidden="false">
       <description>
-In shieldwall formation cannot sprint and suffer -1 AG and INIT.
+In shieldwall formation cannot sprint and suffer -1 AG and INIT. 
 -1 to hit ranged and HTH.</description>
     </rule>
     <rule id="0b0f-1de6-7017-9097" name="Berserk" hidden="false">
       <description>
-Until defeated or fail a break test, double attacks in HTH,
-Automatically pass orders to charge.</description>
+Until defeated or fail a break test, double attacks in HTH. Automatically pass orders to charge.</description>
     </rule>
-    <rule id="5da1-1bfa-9b8d-6b82" name="MOD2" hidden="false">
+    <rule id="5da1-1bfa-9b8d-6b82" name="MoD2" hidden="false">
       <description>
 Unit has 2 Order Dice.</description>
     </rule>
     <rule id="1e90-54e2-dd77-c4e3" name="Rapid Sprint" hidden="false">
       <description>
-Sprint at 4M</description>
+Sprint at 4M.</description>
     </rule>
     <rule id="45b3-c028-8c8c-43ae" name="Stampede" hidden="false">
       <description>
@@ -431,7 +429,7 @@ Fire attacks add an extra pin to targets they hit.</description>
     </rule>
     <rule id="57f2-e9b1-c3c1-7c74" name="Mechanical Genius" hidden="false">
       <description>
-Add +1 ACC of all artillery in 10&quot;, +/-1 from any Monstrosity (machine) damage chart result within 10&quot;</description>
+Add +1 ACC to all artillery in 10&quot;, +/-1 from any Monstrosity (machine) damage chart result within 10&quot;.</description>
     </rule>
     <rule id="182e-9b37-17f3-5b45" name="Ramshackle Contraption" hidden="false">
       <description>
@@ -451,7 +449,7 @@ Automatically pass first Break Test.</description>
     </rule>
     <rule id="e1f3-7817-0e4e-5cb9" name="Woodsman" hidden="false">
       <description>
-Difficult Terrain counts as open terrain.</description>
+Difficult terrain counts as open terrain.</description>
     </rule>
     <rule id="dcb2-de55-1fca-e0a8" name="Stealthy" hidden="false">
       <description>
@@ -479,11 +477,11 @@ Re-roll failed RES and take pin if successful.</description>
     </rule>
     <rule id="14ff-225a-4ec5-f56d" name="Beastly Breath" hidden="false">
       <description>
-D6 Ranged attacks, 20&quot;. SV3 Choking</description>
+D6 Ranged attacks, 20&quot;, SV3 Choking.</description>
     </rule>
     <rule id="46d2-d008-8225-bcff" name="Chunder" hidden="false">
       <description>
-Ranged Attack 10&quot;, Opponent&apos;s RES 5.  Chunder goes empty on a roll of 6+</description>
+Ranged Attack 10&quot;, Opponent&apos;s RES 5.  Chunder goes empty on a roll of 6+.</description>
     </rule>
     <rule id="583a-fa53-11ff-7b40" name="Terror" hidden="false">
       <description>
@@ -494,7 +492,7 @@ Terrifying units and units with the Crazed Psychotic/Undead rules are immune to 
     </rule>
     <rule id="7ff2-1650-fc0e-5a3a" name="Choking" hidden="false">
       <description>
-No armour bonus or cover bonus allowed</description>
+No armour bonus or cover bonus allowed.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -24,7 +24,7 @@
         <characteristicType id="b594-6d78-20b7-82b5" name="Special"/>
       </characteristicTypes>
     </profileType>
-    <profileType id="2c2c-0dd3-c341-b2ef" name="Weapon profile Ranged">
+    <profileType id="2c2c-0dd3-c341-b2ef" name="Weapon Profile Ranged">
       <characteristicTypes>
         <characteristicType id="388b-c232-987e-c292" name="Range Short"/>
         <characteristicType id="93c3-2707-51ef-b304" name="Range Long"/>
@@ -782,7 +782,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
-    <profile id="95e1-d9f2-8182-5835" name="Bow" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="95e1-d9f2-8182-5835" name="Bow" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-20&quot;</characteristic>
@@ -791,7 +791,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="d4c8-3ef2-18de-85c0" name="Longbow" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="d4c8-3ef2-18de-85c0" name="Longbow" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-30&quot;</characteristic>
@@ -806,7 +806,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special" typeId="b446-8296-adef-b370"/>
       </characteristics>
     </profile>
-    <profile id="d39c-4b92-3b2f-a1dc" name="Crossbow" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="d39c-4b92-3b2f-a1dc" name="Crossbow" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-30&quot;</characteristic>
@@ -815,7 +815,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Fire Order to shoot</characteristic>
       </characteristics>
     </profile>
-    <profile id="5690-ead7-6d4a-d2c0" name="Heavy Crossbow" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="5690-ead7-6d4a-d2c0" name="Heavy Crossbow" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-30&quot;</characteristic>
@@ -842,7 +842,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Cancels Charge Bonus</characteristic>
       </characteristics>
     </profile>
-    <profile id="aae2-6321-3b33-079d" name="Sling" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="aae2-6321-3b33-079d" name="Sling" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-20&quot;</characteristic>
@@ -851,7 +851,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">2X Ranged SV0 on Fire order</characteristic>
       </characteristics>
     </profile>
-    <profile id="3e6e-06c9-509a-1716" name="Flaming Wheel" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="3e6e-06c9-509a-1716" name="Flaming Wheel" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">Moves 10&quot; at a time.</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -866,7 +866,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Can also be &apos;cracked&apos; during the exchange of missiles.</characteristic>
       </characteristics>
     </profile>
-    <profile id="ba80-a4f2-4c92-7844" name="Small Bolt Thrower" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="ba80-a4f2-4c92-7844" name="Small Bolt Thrower" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-20&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">20-30&quot;</characteristic>
@@ -875,7 +875,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Fire order to shoot, 3x Ranged SV3</characteristic>
       </characteristics>
     </profile>
-    <profile id="fbdf-a3cf-f1d1-8d05" name="Large Bolt Thrower" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="fbdf-a3cf-f1d1-8d05" name="Large Bolt Thrower" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-20&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">20-40&quot;</characteristic>
@@ -884,7 +884,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Fire order to shoot, Unstoppable</characteristic>
       </characteristics>
     </profile>
-    <profile id="fee6-c34d-8a5d-a9e6" name="Small Stone Thrower" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="fee6-c34d-8a5d-a9e6" name="Small Stone Thrower" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">10-30&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">30-40&quot;</characteristic>
@@ -893,7 +893,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Overhead, Fire order to shoot, D6 Hits</characteristic>
       </characteristics>
     </profile>
-    <profile id="8df4-8bdf-cae3-c0c9" name="Large Stone Thrower" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="8df4-8bdf-cae3-c0c9" name="Large Stone Thrower" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">10-30&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">30-50&quot;</characteristic>
@@ -968,7 +968,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">D6 SV1 Impact hits on charge</characteristic>
       </characteristics>
     </profile>
-    <profile id="f54b-ae0e-9cdc-020e" name="Rock dropped by Carrion Beast" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="f54b-ae0e-9cdc-020e" name="Rock dropped by Carrion Beast" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -977,7 +977,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Drop SV3</characteristic>
       </characteristics>
     </profile>
-    <profile id="d7ff-de60-8b37-fbb7" name="Javelin" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="d7ff-de60-8b37-fbb7" name="Javelin" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -992,7 +992,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Can also be thrown as ranged weapon.</characteristic>
       </characteristics>
     </profile>
-    <profile id="c6ac-d307-29c2-4ef1" name="Handgun" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="c6ac-d307-29c2-4ef1" name="Handgun" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-20&quot;</characteristic>
@@ -1001,7 +1001,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Fire order to shoot</characteristic>
       </characteristics>
     </profile>
-    <profile id="241a-1266-fce9-2638" name="Small Cannon" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="241a-1266-fce9-2638" name="Small Cannon" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-30&quot;</characteristic>
@@ -1010,7 +1010,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Fire order to shoot, Unstoppable</characteristic>
       </characteristics>
     </profile>
-    <profile id="a248-4b9b-1f06-2c5f" name="Large Cannon" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="a248-4b9b-1f06-2c5f" name="Large Cannon" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-50&quot;</characteristic>
@@ -1019,7 +1019,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Fire order to shoot, Unstoppable</characteristic>
       </characteristics>
     </profile>
-    <profile id="fc55-3266-2aa3-9d8a" name="Fire Cannon" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="fc55-3266-2aa3-9d8a" name="Fire Cannon" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-30&quot;</characteristic>
@@ -1028,7 +1028,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Fire order to shoot, Fire attacks, D6 hits</characteristic>
       </characteristics>
     </profile>
-    <profile id="83bd-49e2-6f9b-a638" name="Bombard" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="83bd-49e2-6f9b-a638" name="Bombard" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">10-20&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">20-30&quot;</characteristic>
@@ -1037,7 +1037,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Overhead, Fire order to shoot, D4 hits</characteristic>
       </characteristics>
     </profile>
-    <profile id="8a33-4972-aa2d-d058" name="Bomb" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="8a33-4972-aa2d-d058" name="Bomb" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -1046,7 +1046,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">3x Drop SV4, Fire</characteristic>
       </characteristics>
     </profile>
-    <profile id="fa92-51ea-e2be-fc20" name="Bouncing Bomb" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="fa92-51ea-e2be-fc20" name="Bouncing Bomb" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-20&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -1055,7 +1055,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">1xDrop SV6, Fire, Unstoppable</characteristic>
       </characteristics>
     </profile>
-    <profile id="c44d-adb8-ec8a-3dd4" name="Rock dropped by Eagle" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="c44d-adb8-ec8a-3dd4" name="Rock dropped by Eagle" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -1105,7 +1105,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+2 STR</characteristic>
       </characteristics>
     </profile>
-    <profile id="caa2-6cf1-8c8f-2f66" name="Skull Crusher Hammer" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="caa2-6cf1-8c8f-2f66" name="Skull Crusher Hammer" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -1114,7 +1114,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">+1 STR in HtH only, Magically Returns to hand of user if thrown. Can be used in Exchange of Missiles.</characteristic>
       </characteristics>
     </profile>
-    <profile id="d305-e931-5819-04bb" name="Lightning Spear" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="d305-e931-5819-04bb" name="Lightning Spear" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">(Exchange of Missiles only)</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -1123,7 +1123,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">HtH weapon that can be thrown in Exchange of Missiles.</characteristic>
       </characteristics>
     </profile>
-    <profile id="9f0d-4729-2ca1-43d8" name="Bow of Burning Gold" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="9f0d-4729-2ca1-43d8" name="Bow of Burning Gold" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-30&quot;</characteristic>
@@ -1276,7 +1276,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
-    <profile id="bdba-151e-81e7-3b45" name="Shuriken" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="bdba-151e-81e7-3b45" name="Shuriken" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
@@ -1285,7 +1285,7 @@ Reroll shooting hits against unit if it has a Run order.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="4d4a-8ee3-260b-037b" name="Hand Gun" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
+    <profile id="4d4a-8ee3-260b-037b" name="Hand Gun" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon Profile Ranged">
       <characteristics>
         <characteristic name="Range Short" typeId="388b-c232-987e-c292">0-10&quot;</characteristic>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">10-20&quot;</characteristic>

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="cffa-cd51-33d5-b2c6" name="Warlords of Erehwon" revision="2" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="cffa-cd51-33d5-b2c6" name="Warlords of Erehwon" revision="3" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
-    <publication id="cffa-cd51-pubN65537" name="WoE HC"/>
+    <publication id="cffa-cd51-pubN65537" name="WoE"/>
   </publications>
   <costTypes>
     <costType id="points" name="pts" defaultCostLimit="-1.0"/>
@@ -223,25 +223,30 @@
   <sharedRules>
     <rule id="b9e1-fea5-9095-b1cf" name="Tough" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
-Re-roll a failed RES test. Only one failed RES test can be re-rolled at a time from a single shooting/HTH attack.</description>
+Re-roll a failed RES test. Only one failed RES test can be re-rolled at a time from a single shooting/HTH attack.
+</description>
     </rule>
     <rule id="8784-9f2f-1a5b-be21" name="Wound 1" publicationId="cffa-cd51-pubN65537" page="80" hidden="false">
       <description>
 Model can sustain 1 wound instead of dying immediately.
 Each sustained wound counts as a permanent pin that can&apos;t be removed.
-Unit can still be auto-destroyed by pins.</description>
+Unit can still be auto-destroyed by pins.
+</description>
     </rule>
     <rule id="90e2-5b2c-1fc8-0e8c" name="Magic Level 1" publicationId="cffa-cd51-pubN65537" page="86" hidden="false">
       <description>
-Spell Caster/Wizard Level 1.</description>
+Spell Caster/Wizard Level 1.
+</description>
     </rule>
     <rule id="487f-dc82-bce1-c0f6" name="Tough 2" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
-Re-roll two failed RES tests from a single attack. A die may only be re-rolled once, you must accept the second result.</description>
+Re-roll two failed RES tests from a single attack. A die may only be re-rolled once, you must accept the second result.
+</description>
     </rule>
     <rule id="45bb-28cf-94fd-f899" name="Zealous" publicationId="cffa-cd51-pubN65537" page="81" hidden="false">
       <description>
-Ignore Pins when taking a break test. Re-Roll failed order test.</description>
+Ignore pins when taking a break test. Re-Roll failed order test.
+</description>
     </rule>
     <rule id="1a97-76e9-e64e-7701" name="Heavily Laden" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
@@ -249,23 +254,28 @@ Cannot Sprint.</description>
     </rule>
     <rule id="4a91-87e6-88c5-5e1d" name="Magic Level 2" publicationId="cffa-cd51-pubN65537" page="86" hidden="false">
       <description>
-Spell Caster/Wizard Level 2.</description>
+Spell Caster/Wizard Level 2.
+</description>
     </rule>
     <rule id="2e1b-4169-af1f-71e5" name="Magic Level 3" publicationId="cffa-cd51-pubN65537" page="86" hidden="false">
       <description>
-Spell Caster/Wizard Level 3.</description>
+Spell Caster/Wizard Level 3.
+</description>
     </rule>
     <rule id="78d3-886d-5fc6-bac4" name="Spirit" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
       <description>
-Can be sacrificed for a re-roll. Destroyed if wizard is slain.</description>
+Can be sacrificed for a reroll. Destroyed if wizard is slain.
+</description>
     </rule>
     <rule id="d055-98ce-6f28-1600" name="Deadeye Shot" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
-Re-roll one missed shot.</description>
+Re-roll one missed attack.
+</description>
     </rule>
-    <rule id="160b-fca8-adb7-3d5b" name="Pavisse" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
+    <rule id="160b-fca8-adb7-3d5b" name="Pavise" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
-Cannot be given Run order. -3 Agility. Counts as in cover with +2 Res bonus.</description>
+Cannot be given Run order. -3 Agility. Counts as in cover with +2 Res bonus.
+</description>
     </rule>
     <rule id="8a4d-4dea-f005-ddc5" name="Surly" publicationId="cffa-cd51-pubN65537" page="75" hidden="false">
       <description>
@@ -273,137 +283,184 @@ Cannot benefit from Command, Hero abilities.</description>
     </rule>
     <rule id="7f3d-fbf8-9f49-2031" name="Large" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
-Can draw LOS to body. (+1) to hit shooting. Can draw LOS over non-large models.</description>
+Can draw LOS to body. +1 to hit when shooting at model. Can draw LOS over non-large models.
+</description>
     </rule>
     <rule id="e406-ffab-b352-fc9b" name="Insufferably Sactimonious" hidden="false">
       <description>
-Increase from Tough to Tough 2.</description>
+Increase from Tough to Tough 2.
+</description>
     </rule>
     <rule id="b0ed-8f0b-633c-2f06" name="Command" publicationId="cffa-cd51-pubN65537" page="64" hidden="false">
       <description>
-Friendly units within 10&quot; can use the model&apos;s CO stat to take command based tests.</description>
+Friendly units within 10&quot; can use the model&apos;s CO stat to take command based tests.
+</description>
     </rule>
     <rule id="a447-d495-b7ab-1477" name="Divine Intervention" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
-Can steal an order dice from an enemy unit within 20&quot; with successful Command test. If fail, take 1 pin instead. Max 1 attempt in any turn.</description>
+Can steal an order dice from an enemy unit within 20&quot; with a successful Command test and use it itself immediately.
+If it fails, take 1 pin instead. 
+Max 1 attempt per turn per Warband regardless of success.
+If successful, unit that the die was stolen from counts as having received an order.
+</description>
     </rule>
     <rule id="342b-a482-cb16-67e0" name="Wound 2" publicationId="cffa-cd51-pubN65537" page="80" hidden="false">
       <description>
 Model can sustain 2 wounds instead of dying immediately.
 Each sustained wound counts as a permanent pin that can&apos;t be removed.
-Unit can still be auto-destroyed by pins.</description>
+Unit can still be auto-destroyed by pins.
+</description>
     </rule>
     <rule id="bb63-e7db-89cf-19e6" name="Challenge" publicationId="cffa-cd51-pubN65537" page="64" hidden="false">
       <description>
-May initiate a &apos;Challenge to the death&apos;.</description>
+May initiate a &apos;Challenge to the death&apos;.
+</description>
     </rule>
     <rule id="3536-db5c-4e89-87d7" name="Tough 3" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
-Re-roll three failed RES tests from a single attack. A die may only be re-rolled once, you must accept the second result.</description>
+Re-roll three failed RES tests from a single attack. A die may only be re-rolled once, you must accept the second result.
+</description>
     </rule>
     <rule id="2724-2057-e745-23a3" name="Wound 3" publicationId="cffa-cd51-pubN65537" page="80" hidden="false">
       <description>
 Model can sustain 3 wounds instead of dying immediately.
 Each sustained wound counts as a permanent pin that can&apos;t be removed.
-Unit can still be auto-destroyed by pins.</description>
+Unit can still be auto-destroyed by pins.
+</description>
     </rule>
     <rule id="566e-a1c6-9f62-3218" name="Hero" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
-Friendly units within 10&quot; can use the model&apos;s Init stat to take Reaction Tests.</description>
+Friendly units within 10&quot; can use the model&apos;s Init stat to take Reaction tests.
+</description>
     </rule>
     <rule id="83d2-f89c-33a4-258d" name="Follow" publicationId="cffa-cd51-pubN65537" page="69" hidden="false">
       <description>
-Friendly un-pinned units within 5&quot; can follow the unit&apos;s order immediately.</description>
+Friendly un-pinned units within 5&quot; can follow the unit&apos;s order immediately.
+Draw an order die for each unit following.
+Move the initiating unit first and resolve its action, then do the same for each unit following.
+</description>
     </rule>
     <rule id="1c49-276e-425d-0999" name="Frenzied Charge" publicationId="cffa-cd51-pubN65537" page="69" hidden="false">
       <description>
-+1 Extra Attack when charging.</description>
++1 Extra Attack when charging. Bonus attacks are never doubled, e.g. via Berserk.
+</description>
     </rule>
     <rule id="c3b6-8870-61d6-7aaf" name="Savage" publicationId="cffa-cd51-pubN65537" page="73" hidden="false">
       <description>
-Re-Roll STR to hit in first round of combat in game.</description>
+Reroll all misses in first round of combat in game.
+
+</description>
     </rule>
     <rule id="86b2-7051-4b5c-d149" name="Irresistible Charge" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
-D3 SV bonus when charging.</description>
+D3 SV bonus when charging. Does not apply in follow-on combat round.
+</description>
     </rule>
     <rule id="1d07-520b-6918-03fd" name="Flies" publicationId="cffa-cd51-pubN65537" page="68" hidden="false">
       <description>
-Move over any terrain/obstacle without test or penalty.
-Enemy cannot charge/countercharge or follow-on in combat unless they can also fly, unless flyers are down.</description>
+Move over any terrain/obstacle without test or penalty. 
+Can move through friendly or enemy units.
+Enemy cannot charge/countercharge or follow-on in combat unless they can also fly or unless flyers are down.
+Flying machines are auto-destroyed if going Down over impassable terrain.
+Reroll all shooting hits against flyers.
+Cannot be hit by overhead weapons unless they are Down.
+</description>
     </rule>
     <rule id="5e63-c99b-00b4-24eb" name="Vengeful" publicationId="cffa-cd51-pubN65537" page="77" hidden="false">
       <description>
 If unit wins the first round of close combat then it MUST elect to fight a follow on combat where it can do so.
-In follow-on combat, vengeful troops always fight with double their attacks.</description>
+In follow-on combat unit fights with double attacks.
+</description>
     </rule>
     <rule id="e5df-1d6a-1034-7c77" name="Undead" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
 Cannot be routed.
 Auto-resist choking attacks.
+Ignore bonus hits from Venomous attacks.
 Immune to Dread.
-Immune to Terror.</description>
+Immune to Terror.
+</description>
     </rule>
     <rule id="fd2c-3cba-cafa-62aa" name="Zombie Master" publicationId="cffa-cd51-pubN65537" page="81" hidden="false">
       <description>
-Can use Hero/Follow/Command rules for Zombie units.</description>
+Can use Hero/Follow/Command rules for Zombie units.
+</description>
     </rule>
     <rule id="3dfb-f407-ff46-9b1f" name="Spectral Undead" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
       <description>
-In addition to Undead rule, also hits from flaming attacks are ignored (auto-resisted) and inflict no pins.
-All difficult ground/obstacles count as open terrain for movement.</description>
+In addition to Undead rule, hits from flaming attacks are auto-resisted and inflict no extra pins.
+All difficult ground/obstacles count as open terrain for movement.
+</description>
     </rule>
     <rule id="c738-3360-de3b-34a9" name="Deathly Chill" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
-No armour bonus allowed.</description>
+Attacks ignore armour.
+</description>
     </rule>
     <rule id="0bf9-a070-b56b-ca4e" name="Dread" publicationId="cffa-cd51-pubN65537" page="66" hidden="false">
       <description>
--1 to hit shooting/close combat.
--1 to break test if defeated by enemy with Dread.</description>
+-1 to hit shooting and HtH.
+-1 to break test if defeated by enemy with Dread.
+Unaffected by opponents with Dread.
+</description>
     </rule>
     <rule id="612a-20b6-14a2-97e4" name="Zombie" publicationId="cffa-cd51-pubN65537" page="81" hidden="false">
       <description>
 A failed order test is an advance order and not down.  
 Cannot sprint.
-Cannot benefit from the Hero/Follow/Command unless character is Zombie Master.</description>
+Must test Agility after Run order.
+Cannot benefit from the Hero/Follow/Command unless character is Zombie Master.
+</description>
     </rule>
     <rule id="4d2b-eef9-9776-1480" name="Slow" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
       <description>
-Move at the basic rate indicated.</description>
+Move at the basic rate indicated.
+</description>
     </rule>
     <rule id="c246-93aa-3909-26ee" name="Fast" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>
-Move at the basic rate indicated.</description>
+Move at the basic rate indicated.
+Reroll shooting hits against unit if it has a Run order.
+</description>
     </rule>
     <rule id="79ff-cb92-cea8-886f" name="Howling Horror Ammunition" publicationId="cffa-cd51-pubN65537" page="71" hidden="false">
       <description>
-Target suffers D3 additional pins.</description>
+Target suffers D3 additional pins. Affects Undead.
+</description>
     </rule>
     <rule id="a8bf-f48c-1b08-58e6" name="Unstoppable" publicationId="cffa-cd51-pubN65537" page="77" hidden="false">
       <description>
-Shot penetrates the unit hit and can strike others beyond so long as the target is hit each time.</description>
+Shot penetrates the unit hit and can strike others beyond so long as the target is hit each time.
+Monstrosities roll twice on the damage chart for each hit from an Unstoppable weapon.
+</description>
     </rule>
     <rule id="6650-1e8e-9f7d-d242" name="Undead Army Special Rule" publicationId="cffa-cd51-pubN65537" page="226" hidden="false">
       <description>
-If your warlord is slain, then no further pins are removed from your units. Orders can still be issued as normal.</description>
+If your warlord is slain, then no further pins are removed from your units. Orders can still be issued as normal.
+</description>
     </rule>
     <rule id="0056-a41e-408e-1673" name="Disciplined" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
-Lose all pins when pass a rally test.</description>
+Lose all pins when passing a Rally test. 
+Routing units lose all pins if passing a Command test due to nearby units making a Rally order.
+</description>
     </rule>
     <rule id="93f9-d132-d71b-ab39" name="Shieldwall" publicationId="cffa-cd51-pubN65537" page="73" hidden="false">
       <description>
-In shieldwall formation cannot sprint and suffer -1 Agility and Initiative. 
-Enemy suffers -1 to hit in ranged and hand-to-hand.</description>
+Can only be used if all models in unit touch base with another model to lock shields.
+Cannot sprint and suffer -1 Agility and Initiative. 
+Enemy suffers -1 to hit in ranged and HtH.
+</description>
     </rule>
     <rule id="0b0f-1de6-7017-9097" name="Berserk" publicationId="cffa-cd51-pubN65537" page="62" hidden="false">
       <description>
-Until defeated or fail a break test, double attacks in HTH. Automatically pass orders to charge.</description>
+Until defeated or fail a break test: double attacks in HtH and automatically pass orders to charge including reactions.
+</description>
     </rule>
     <rule id="5da1-1bfa-9b8d-6b82" name="MoD2" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
-Unit has 2 Order Dice.</description>
+Unit has 2 Order Dice. See page 56 for rules.
+</description>
     </rule>
     <rule id="1e90-54e2-dd77-c4e3" name="Rapid Sprint" publicationId="cffa-cd51-pubN65537" page="73" hidden="false">
       <description>
@@ -412,15 +469,20 @@ Sprint at 4M.</description>
     <rule id="45b3-c028-8c8c-43ae" name="Stampede" publicationId="cffa-cd51-pubN65537" page="75" hidden="false">
       <description>
 Stampede on failed order test of 10. D10&quot;+2M in direction shown by dice.
-Each unit in path is attacked as if charged. unit goes down and gains 1 pin per unit trampled.</description>
+Each unit in path and within 1&quot; of final location is trampled on (counts as being charged).
+Unit goes down and gains 1 pin per unit trampled.
+</description>
     </rule>
     <rule id="2b40-80c8-12cf-8f44" name="Crazed Psychotics" publicationId="cffa-cd51-pubN65537" page="65" hidden="false">
       <description>
-Automatically pass charge orders, cannot be routed, immune to fear and terror.</description>
+Automatically pass charge orders. Cannot be routed. Immune to Dread and Terror.
+
+</description>
     </rule>
     <rule id="8eba-5940-fd9b-254c" name="Drop" publicationId="cffa-cd51-pubN65537" page="66" hidden="false">
       <description>
-Drop attacks ignore cover modifiers.</description>
+Drop attacks ignore cover modifiers.
+</description>
     </rule>
     <rule id="b61d-3471-1ce6-6878" name="Fire" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>
@@ -428,39 +490,50 @@ Fire attacks add an extra pin to targets they hit.</description>
     </rule>
     <rule id="57f2-e9b1-c3c1-7c74" name="Mechanical Genius" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
-Add +1 ACC to all artillery in 10&quot;, +/-1 from any Monstrosity (machine) damage chart result within 10&quot;.</description>
+Add +1 ACC to all artillery attacks in 10&quot;. 
++/-1 for any Monstrosity (machine) damage chart result within 10&quot;.
+</description>
     </rule>
     <rule id="182e-9b37-17f3-5b45" name="Ramshackle Contraption" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
-On a failed order result of a 10 roll on the Monstrosity damage chart.</description>
+On a failed order result of a 10 roll on the Monstrosity damage chart.
+</description>
     </rule>
     <rule id="4440-376a-8093-35b8" name="Stubborn" publicationId="cffa-cd51-pubN65537" page="75" hidden="false">
       <description>
-Recover +1 pin each time an order test is taken.</description>
+Remove +1 pin if order test is successful.
+</description>
     </rule>
     <rule id="4808-d708-bb73-97e8" name="Enchanted Steed" publicationId="cffa-cd51-pubN65537" page="66" hidden="false">
       <description>
-All water terrain counts as open terrain and adds +1 RES to mounted units.</description>
+All water terrain counts as open terrain and adds +1 RES to mounted units.
+Reroll failed RES tests against shooting attacks (does not apply to chariots).
+</description>
     </rule>
     <rule id="6a8d-ef1b-6f78-e15c" name="Haughty Disdain" publicationId="cffa-cd51-pubN65537" page="69" hidden="false">
       <description>
-Automatically pass first Break Test.</description>
+Automatically pass first Break Test in the game.
+</description>
     </rule>
     <rule id="e1f3-7817-0e4e-5cb9" name="Woodsman" publicationId="cffa-cd51-pubN65537" page="80" hidden="false">
       <description>
-Wooded terrain counts as open terrain. +1 RES cover bonus in wooden terrain.</description>
+Wooded terrain counts as open terrain. +1 RES cover bonus in wooden terrain.
+</description>
     </rule>
     <rule id="dcb2-de55-1fca-e0a8" name="Stealthy" publicationId="cffa-cd51-pubN65537" page="75" hidden="false">
       <description>
-Re-roll missile hits if in cover.</description>
+Re-roll shooting hits against unit if in cover.
+</description>
     </rule>
     <rule id="9855-31c9-3745-714d" name="Baleful Glare" publicationId="cffa-cd51-pubN65537" page="62" hidden="false">
       <description>
-Ranged Attack 20&quot;, No damage but inflicts 1+D3 pins and unit takes a Break test.</description>
+Ranged Attack 20&quot;. No damage but inflicts 1+D3 pins and unit takes a Break test.
+</description>
     </rule>
     <rule id="53b9-a3e9-0e9f-2d77" name="Venomous" publicationId="cffa-cd51-pubN65537" page="77" hidden="false">
       <description>
-Add one hit if any hits are scored.</description>
+Add one hit if any hits are scored.
+</description>
     </rule>
     <rule id="37e8-d658-01a9-6916" name="Flaming Breath" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>
@@ -468,39 +541,47 @@ Ranged Attack 20&quot;. Fire Attack (+1 pin). As Stats.</description>
     </rule>
     <rule id="087e-dfda-76c2-09bf" name="Blundering" publicationId="cffa-cd51-pubN65537" page="63" hidden="false">
       <description>
-Cannot Sprint. Must test Agility for a run. Crosses obstacles as chariot/artillery.</description>
+Cannot Sprint. Must test Agility for a Run action. Crosses obstacles as chariot/artillery.
+</description>
     </rule>
     <rule id="0a0c-ed4c-9647-4398" name="Regenerate" publicationId="cffa-cd51-pubN65537" page="73" hidden="false">
       <description>
-Re-roll failed RES and take pin if successful.</description>
+Must re-roll one failed RES test per attack and take pin if successful. Does not work against Fire attacks.
+</description>
     </rule>
     <rule id="14ff-225a-4ec5-f56d" name="Beastly Breath" publicationId="cffa-cd51-pubN65537" page="62" hidden="false">
       <description>
-D6 Ranged attacks, 20&quot;, SV3 Choking.</description>
+D6 Ranged attacks, 20&quot;, SV3 Choking.
+</description>
     </rule>
     <rule id="46d2-d008-8225-bcff" name="Chunder" publicationId="cffa-cd51-pubN65537" page="64" hidden="false">
       <description>
-Ranged Attack 10&quot;, Opponent&apos;s RES 5.  Chunder goes empty on a roll of 6+.</description>
+Ranged Attack 10&quot;. Opponent&apos;s RES is always 5.  Chunder goes empty on a roll of 6+.
+</description>
     </rule>
     <rule id="583a-fa53-11ff-7b40" name="Terror" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
 A unit within 15&quot; removes NO pins when making an order test. 
 A unit failing a break test within 5&quot; is automatically destroyed.
 A routing unit within 5&quot; is automatically destroyed.
-Terrifying units and units with the Crazed Psychotic/Undead rules are immune to terror.</description>
+Terrifying units and units with the Crazed Psychotic/Undead rules are immune to terror.
+</description>
     </rule>
     <rule id="7ff2-1650-fc0e-5a3a" name="Choking" publicationId="cffa-cd51-pubN65537" page="64" hidden="false">
       <description>
-No armour bonus or cover bonus allowed.</description>
+No armour bonus or cover bonus allowed.
+</description>
     </rule>
     <rule id="ae37-06b2-7f4c-ec52" name="Allied Monster" publicationId="cffa-cd51-pubN65537" page="62" hidden="false">
       <description>
-Cannot benefit from Command, Hero, or Follow special rules.</description>
+Cannot benefit from Command, Hero, or Follow special rules.
+</description>
     </rule>
     <rule id="2e98-ee7b-558a-81ef" name="Bound Monster" publicationId="cffa-cd51-pubN65537" page="63" hidden="false">
       <description>
 Cannot benefit from Command, Hero, or Follow special rules.
-Take D6 pins if a 10 is rolled for its order test. Can be auto-destroyed via pins as a result.</description>
+Take D6 pins if a 10 is rolled for its order test. Can be auto-destroyed via pins as a result.
+</description>
     </rule>
     <rule id="3a29-1b97-6c21-75e7" name="Flaming Wheel" publicationId="cffa-cd51-pubN65537" page="68" hidden="false">
       <description>
@@ -510,27 +591,35 @@ Fire order to shoot (or rather push).</description>
     </rule>
     <rule id="a8ca-ba71-db97-bc20" name="MoD3" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
-Unit has 3 Order Dice.</description>
+Unit has 3 Order Dice. See page 56 for rules.
+</description>
     </rule>
     <rule id="9d78-2294-d4fd-9efd" name="Slow 3" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
       <description>
-Move at a base rate of 3&quot;.</description>
+Move at a base rate of 3&quot;.
+</description>
     </rule>
     <rule id="ade7-83de-c555-3df3" name="Slow 4" publicationId="cffa-cd51-pubN65537" page="74" hidden="false">
       <description>
-Move at a base rate of 4&quot;.</description>
+Move at a base rate of 4&quot;.
+</description>
     </rule>
     <rule id="7753-3806-9cf1-0a6c" name="Fast 6" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>
-Move at a base rate of 6&quot;.</description>
+Move at a base rate of 6&quot;.
+Reroll shooting hits against unit if it has a Run order.
+</description>
     </rule>
     <rule id="105b-036d-9a8f-edac" name="Fast 8" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>
-Move at a base rate of 8&quot;.</description>
+Move at a base rate of 8&quot;.
+Reroll shooting hits against unit if it has a Run order.
+</description>
     </rule>
     <rule id="0034-82ae-f695-d446" name="Fast 10" publicationId="cffa-cd51-pubN65537" page="67" hidden="false">
       <description>
-Move at a base rate of 10&quot;.</description>
+Move at a base rate of 10&quot;.
+Reroll shooting hits against unit if it has a Run order.</description>
     </rule>
     <rule id="6016-006f-a999-c64c" name="Whirling Dervishes" publicationId="cffa-cd51-pubN65537" page="77" hidden="false">
       <description>
@@ -538,17 +627,25 @@ Loose unit formation: Stay at least 1&quot; apart, max 2&quot;.
 Can only be given Run order (including Sprint).
 On result of 10 for order test, move randomly. Touching other units counts as charge.
 Re-roll all shooting hits on unit.
-Enemies don&apos;t counter-attack in close combat. Saved hits (successful RES rolls) count as casualties for the dervish unit.
+Enemies don&apos;t attack in close combat. Saved hits (successful RES rolls) count as casualties for the dervish unit.
 Unit is automatically destroyed if close combat is not won.
 Consolidation move is random, may initiate immediate combat if touching different unit than that just fought. 
-May make consolidation move through unit it just fought.</description>
+May make consolidation move through unit it just fought.
+</description>
     </rule>
     <rule id="e2ce-cefd-9949-02fd" name="Wild Monster" publicationId="cffa-cd51-pubN65537" page="80" hidden="false">
       <description>
 Goes wild if 10 is rolled for order test.
 Add D6 pins to check for auto-destruction as normal. If not auto-destroyed, remove all pins.
 Replace all order dice by one die of different color.
-When order die is drawn, players dice for control.</description>
+When order die is drawn, players dice for control.
+</description>
+    </rule>
+    <rule id="03c8-e023-d3fe-8b64" name="Warhorse" publicationId="cffa-cd51-pubN65537" page="77" hidden="false">
+      <description>
+Cancels Heavily Laden.
+Restores Agility and Initiative to previous values (usually included in the stat line).
+</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
@@ -657,13 +754,13 @@ When order die is drawn, players dice for control.</description>
     <profile id="f367-10de-49e2-acff" name="Heavy Armour" hidden="false" typeId="726e-70e6-d94e-c9ac" typeName="Armour Profile">
       <characteristics>
         <characteristic name="Res" typeId="f05e-0dc4-2f61-ffb6">5(8)</characteristic>
-        <characteristic name="Special" typeId="b446-8296-adef-b370"></characteristic>
+        <characteristic name="Special" typeId="b446-8296-adef-b370"/>
       </characteristics>
     </profile>
     <profile id="1f70-2881-7206-2fe9" name="Cudgel" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
     <profile id="ef46-1d4c-7c9d-d938" name="Pitchfork, Bills, or Glaives" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
@@ -741,7 +838,7 @@ When order die is drawn, players dice for control.</description>
     <profile id="556d-4839-8be4-b724" name="Hair Shirt" hidden="false" typeId="726e-70e6-d94e-c9ac" typeName="Armour Profile">
       <characteristics>
         <characteristic name="Res" typeId="f05e-0dc4-2f61-ffb6">5(6)</characteristic>
-        <characteristic name="Special" typeId="b446-8296-adef-b370"></characteristic>
+        <characteristic name="Special" typeId="b446-8296-adef-b370"/>
       </characteristics>
     </profile>
     <profile id="2221-3571-075e-ae84" name="Morning Star" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
@@ -765,13 +862,13 @@ When order die is drawn, players dice for control.</description>
     <profile id="41c3-e1df-53b7-ed79" name="Huge Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
     <profile id="e977-49ab-1207-d301" name="Big Axe" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
     <profile id="8aea-0ac0-030a-5da1" name="Improbably Vast Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
@@ -789,7 +886,7 @@ When order die is drawn, players dice for control.</description>
     <profile id="0b17-24e8-fb18-654e" name="Club" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
     <profile id="7723-e7c2-30a5-43ee" name="Chariot Scythes" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
@@ -1091,7 +1188,7 @@ When order die is drawn, players dice for control.</description>
     <profile id="6f59-6125-456e-38c3" name="Naginata" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
     <profile id="c35f-a7c3-0b86-a39f" name="Nunchaku" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
@@ -1103,7 +1200,7 @@ When order die is drawn, players dice for control.</description>
     <profile id="7ae9-8e9a-85e9-e68b" name="Hanbo, Cane, Scroll or Tea Service" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
     <profile id="bdba-151e-81e7-3b45" name="Shuriken" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -5,7 +5,7 @@
   </publications>
   <costTypes>
     <costType id="points" name="pts" defaultCostLimit="-1.0"/>
-    <costType id="6354-8c83-d4ad-3053" name=" order dice" defaultCostLimit="-1.0"/>
+    <costType id="orderDice" name=" order dice" defaultCostLimit="-1.0"/>
   </costTypes>
   <profileTypes>
     <profileType id="2f17-7b0c-7f4e-2baf" name="Model">
@@ -111,7 +111,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6ce7-b3cb-cc54-c24f" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -120,7 +120,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8041-8d76-f770-6872" name="Mace" hidden="false" collective="false" type="upgrade">
@@ -129,7 +129,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f1ad-8666-d5b5-021b" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -138,7 +138,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1689-c2e6-a3a5-4234" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -147,7 +147,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="83cf-506e-8f65-96e6" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -156,7 +156,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a419-3818-8175-2ebb" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -165,7 +165,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2826-f657-3cef-8c48" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -174,7 +174,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9e42-ba82-d1dc-30b1" name="Bow" hidden="false" collective="false" type="upgrade">
@@ -183,7 +183,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bd1d-fe59-12c3-dbb4" name="Longbow" hidden="false" collective="false" type="upgrade">
@@ -192,7 +192,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f757-c0e6-07f7-f84d" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -201,7 +201,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aa5c-b0e1-1af7-e32f" name="Spells" page="" hidden="false" collective="false" type="upgrade">
@@ -209,31 +209,31 @@
         <selectionEntry id="51b3-07a1-434a-388f" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9578-c92c-d9b9-a468" name="Chill Wind" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7f13-6bfa-a7d1-f1c0" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6fac-ec35-3592-0209" name="Endow Strength" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+            <cost name=" order dice" typeId="orderDice" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
+        <cost name=" order dice" typeId="orderDice" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="cffa-cd51-33d5-b2c6" name="Warlords of Erehwon" revision="3" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="cffa-cd51-33d5-b2c6" name="Warlords of Erehwon" revision="4" battleScribeVersion="2.02" authorName="The3DWargamer" authorContact="the3dwargamer@outlook.com" authorUrl="http://www.facebook.com/the3dwargamer" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="cffa-cd51-pubN65537" name="WoE"/>
   </publications>
   <costTypes>
     <costType id="points" name="pts" defaultCostLimit="-1.0"/>
+    <costType id="6354-8c83-d4ad-3053" name=" order dice" defaultCostLimit="-1.0"/>
   </costTypes>
   <profileTypes>
     <profileType id="2f17-7b0c-7f4e-2baf" name="Model">
@@ -110,6 +111,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6ce7-b3cb-cc54-c24f" name="Sword" hidden="false" collective="false" type="upgrade">
@@ -118,6 +120,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8041-8d76-f770-6872" name="Mace" hidden="false" collective="false" type="upgrade">
@@ -126,6 +129,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f1ad-8666-d5b5-021b" name="Warhammers" hidden="false" collective="false" type="upgrade">
@@ -134,6 +138,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1689-c2e6-a3a5-4234" name="Massive Mace" hidden="false" collective="false" type="upgrade">
@@ -142,6 +147,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="83cf-506e-8f65-96e6" name="Halberds" hidden="false" collective="false" type="upgrade">
@@ -150,6 +156,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a419-3818-8175-2ebb" name="Spears" hidden="false" collective="false" type="upgrade">
@@ -158,6 +165,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2826-f657-3cef-8c48" name="Long Spears" hidden="false" collective="false" type="upgrade">
@@ -166,6 +174,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9e42-ba82-d1dc-30b1" name="Bow" hidden="false" collective="false" type="upgrade">
@@ -174,6 +183,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bd1d-fe59-12c3-dbb4" name="Longbow" hidden="false" collective="false" type="upgrade">
@@ -182,6 +192,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="f757-c0e6-07f7-f84d" name="Dagger" hidden="false" collective="false" type="upgrade">
@@ -190,6 +201,7 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aa5c-b0e1-1af7-e32f" name="Spells" page="" hidden="false" collective="false" type="upgrade">
@@ -197,26 +209,31 @@
         <selectionEntry id="51b3-07a1-434a-388f" name="Fiery Balls" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="9578-c92c-d9b9-a468" name="Chill Wind" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="7f13-6bfa-a7d1-f1c0" name="Peculiar Portal" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="6fac-ec35-3592-0209" name="Endow Strength" hidden="false" collective="false" type="upgrade">
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <costs>
         <cost name="pts" typeId="points" value="0.0"/>
+        <cost name=" order dice" typeId="6354-8c83-d4ad-3053" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>

--- a/Warlords_of_Erehwon.gst
+++ b/Warlords_of_Erehwon.gst
@@ -32,7 +32,7 @@
         <characteristicType id="83b9-69ea-35a1-5148" name="Special Rules"/>
       </characteristicTypes>
     </profileType>
-    <profileType id="4e9d-173a-314b-a7c5" name="Weapon Profile HTH">
+    <profileType id="4e9d-173a-314b-a7c5" name="Weapon Profile HtH">
       <characteristicTypes>
         <characteristicType id="1b55-d6e6-1944-708a" name="Strike Value"/>
         <characteristicType id="dad6-5d39-6880-25a5" name="Special Rules"/>
@@ -221,9 +221,9 @@
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedRules>
-    <rule id="b9e1-fea5-9095-b1cf" name="Tough" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
+    <rule id="b9e1-fea5-9095-b1cf" name="Tough 1" publicationId="cffa-cd51-pubN65537" page="76" hidden="false">
       <description>
-Re-roll a failed RES test. Only one failed RES test can be re-rolled at a time from a single shooting/HTH attack.</description>
+Re-roll one failed RES test. Only one failed RES test can be re-rolled at a time from a single shooting/HtH attack.</description>
     </rule>
     <rule id="8784-9f2f-1a5b-be21" name="Wound 1" publicationId="cffa-cd51-pubN65537" page="80" hidden="false">
       <description>
@@ -399,7 +399,7 @@ Enemy suffers -1 to hit in ranged and hand-to-hand.</description>
     </rule>
     <rule id="0b0f-1de6-7017-9097" name="Berserk" publicationId="cffa-cd51-pubN65537" page="62" hidden="false">
       <description>
-Until defeated or fail a break test, double attacks in HTH. Automatically pass orders to charge.</description>
+Until defeated or fail a break test, double attacks in HtH. Automatically pass orders to charge.</description>
     </rule>
     <rule id="5da1-1bfa-9b8d-6b82" name="MoD2" publicationId="cffa-cd51-pubN65537" page="72" hidden="false">
       <description>
@@ -552,49 +552,49 @@ When order die is drawn, players dice for control.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="2447-8f38-dd07-d089" name="Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="2447-8f38-dd07-d089" name="Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">STR +1</characteristic>
       </characteristics>
     </profile>
-    <profile id="f47a-0e7b-e210-5d54" name="Stave" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="f47a-0e7b-e210-5d54" name="Stave" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">STR +1</characteristic>
       </characteristics>
     </profile>
-    <profile id="abab-c6f8-5036-1cb4" name="Mace" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="abab-c6f8-5036-1cb4" name="Mace" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR</characteristic>
       </characteristics>
     </profile>
-    <profile id="6132-3227-d7f3-41ee" name="Massive Mace" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="6132-3227-d7f3-41ee" name="Massive Mace" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
-    <profile id="096c-a0fe-df46-77c4" name="Warhammer" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="096c-a0fe-df46-77c4" name="Warhammer" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
-    <profile id="595c-60a6-3a30-b259" name="Halberds" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="595c-60a6-3a30-b259" name="Halberds" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR</characteristic>
       </characteristics>
     </profile>
-    <profile id="c79a-48d1-9b48-2c68" name="Spear" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="c79a-48d1-9b48-2c68" name="Spear" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Can also be thrown during exchange of missiles.</characteristic>
       </characteristics>
     </profile>
-    <profile id="8c77-0a0d-0097-c499" name="Long Spear" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="8c77-0a0d-0097-c499" name="Long Spear" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Cancels Charge bonus.</characteristic>
@@ -606,7 +606,7 @@ When order die is drawn, players dice for control.</description>
         <characteristic name="Special" typeId="b446-8296-adef-b370"/>
       </characteristics>
     </profile>
-    <profile id="5514-08ba-d190-bf84" name="Dagger" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="5514-08ba-d190-bf84" name="Dagger" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
@@ -657,16 +657,16 @@ When order die is drawn, players dice for control.</description>
     <profile id="f367-10de-49e2-acff" name="Heavy Armour" hidden="false" typeId="726e-70e6-d94e-c9ac" typeName="Armour Profile">
       <characteristics>
         <characteristic name="Res" typeId="f05e-0dc4-2f61-ffb6">5(8)</characteristic>
-        <characteristic name="Special" typeId="b446-8296-adef-b370"></characteristic>
+        <characteristic name="Special" typeId="b446-8296-adef-b370"/>
       </characteristics>
     </profile>
-    <profile id="1f70-2881-7206-2fe9" name="Cudgel" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="1f70-2881-7206-2fe9" name="Cudgel" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
-    <profile id="ef46-1d4c-7c9d-d938" name="Pitchfork, Bills, or Glaives" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="ef46-1d4c-7c9d-d938" name="Pitchfork, Bills, or Glaives" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Cancels Charge Bonus</characteristic>
@@ -690,7 +690,7 @@ When order die is drawn, players dice for control.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Flaming wheel, D6 SV6 Fire hits struck on units in its path. (see special rules page 68)</characteristic>
       </characteristics>
     </profile>
-    <profile id="3f74-469a-cb98-f949" name="Scourge" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="3f74-469a-cb98-f949" name="Scourge" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Can also be &apos;cracked&apos; during the exchange of missiles.</characteristic>
@@ -732,7 +732,7 @@ When order die is drawn, players dice for control.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">Overhead, Fire order to shoot, D6 Hits</characteristic>
       </characteristics>
     </profile>
-    <profile id="e601-dcfc-7485-2164" name="Lance" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="e601-dcfc-7485-2164" name="Lance" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1/3</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">SV3 on Charge</characteristic>
@@ -741,58 +741,58 @@ When order die is drawn, players dice for control.</description>
     <profile id="556d-4839-8be4-b724" name="Hair Shirt" hidden="false" typeId="726e-70e6-d94e-c9ac" typeName="Armour Profile">
       <characteristics>
         <characteristic name="Res" typeId="f05e-0dc4-2f61-ffb6">5(6)</characteristic>
-        <characteristic name="Special" typeId="b446-8296-adef-b370"></characteristic>
+        <characteristic name="Special" typeId="b446-8296-adef-b370"/>
       </characteristics>
     </profile>
-    <profile id="2221-3571-075e-ae84" name="Morning Star" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="2221-3571-075e-ae84" name="Morning Star" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Armour +1 Max Bonus</characteristic>
       </characteristics>
     </profile>
-    <profile id="4f07-5005-3329-5095" name="Chain Mace" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="4f07-5005-3329-5095" name="Chain Mace" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Armour +1 Max  bonus.</characteristic>
       </characteristics>
     </profile>
-    <profile id="a1ad-5715-ceb1-e77e" name="Axe" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="a1ad-5715-ceb1-e77e" name="Axe" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR</characteristic>
       </characteristics>
     </profile>
-    <profile id="41c3-e1df-53b7-ed79" name="Huge Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="41c3-e1df-53b7-ed79" name="Huge Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
-    <profile id="e977-49ab-1207-d301" name="Big Axe" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="e977-49ab-1207-d301" name="Big Axe" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
-    <profile id="8aea-0ac0-030a-5da1" name="Improbably Vast Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="8aea-0ac0-030a-5da1" name="Improbably Vast Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">3</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Heavily Laden</characteristic>
       </characteristics>
     </profile>
-    <profile id="91a1-fed7-8323-b2c8" name="Bloomin&apos; big axe" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="91a1-fed7-8323-b2c8" name="Bloomin&apos; big axe" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">3</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Heavily Laden</characteristic>
       </characteristics>
     </profile>
-    <profile id="0b17-24e8-fb18-654e" name="Club" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="0b17-24e8-fb18-654e" name="Club" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
-    <profile id="7723-e7c2-30a5-43ee" name="Chariot Scythes" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="7723-e7c2-30a5-43ee" name="Chariot Scythes" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">D6 SV1 Impact hits on charge</characteristic>
@@ -816,7 +816,7 @@ When order die is drawn, players dice for control.</description>
         <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="88d0-6821-ceff-0382" name="Rocks (HTH)" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="88d0-6821-ceff-0382" name="Rocks (HtH)" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Can also be thrown as ranged weapon.</characteristic>
@@ -905,31 +905,31 @@ When order die is drawn, players dice for control.</description>
         <characteristic name="Special" typeId="68b3-e6ca-5920-ff4e">-</characteristic>
       </characteristics>
     </profile>
-    <profile id="3848-b5eb-4efb-796f" name="Flail" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="3848-b5eb-4efb-796f" name="Flail" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">Armour +1 Max Bonus</characteristic>
       </characteristics>
     </profile>
-    <profile id="193c-09f8-234d-adab" name="(Magic Weapon) Foe Striker Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="193c-09f8-234d-adab" name="(Magic Weapon) Foe Striker Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR</characteristic>
       </characteristics>
     </profile>
-    <profile id="3246-1376-d94d-d544" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="3246-1376-d94d-d544" name="(Magic Weapon) Helm Cleaver Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">3</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR</characteristic>
       </characteristics>
     </profile>
-    <profile id="190e-3de5-0e71-c97f" name="(Magic Weapon) War Bringer Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="190e-3de5-0e71-c97f" name="(Magic Weapon) War Bringer Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR, HTH Attacks +1</characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+1 STR, HtH Attacks +1</characteristic>
       </characteristics>
     </profile>
-    <profile id="454c-1957-36be-2d2b" name="(Magic Weapon) Battle Smiter Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="454c-1957-36be-2d2b" name="(Magic Weapon) Battle Smiter Sword" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">1</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+2 STR</characteristic>
@@ -941,7 +941,7 @@ When order die is drawn, players dice for control.</description>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
         <characteristic name="Range Extreme" typeId="49d3-642a-08be-5817">-</characteristic>
         <characteristic name="Strike Value" typeId="47c7-dced-6203-6b76">2</characteristic>
-        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">+1 STR in HTH only, Magically Returns to hand of user if thrown. Can be used in Exchange of Missiles.</characteristic>
+        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">+1 STR in HtH only, Magically Returns to hand of user if thrown. Can be used in Exchange of Missiles.</characteristic>
       </characteristics>
     </profile>
     <profile id="d305-e931-5819-04bb" name="(Magic Weapon) Lightning Spear" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
@@ -950,7 +950,7 @@ When order die is drawn, players dice for control.</description>
         <characteristic name="Range Long" typeId="93c3-2707-51ef-b304">-</characteristic>
         <characteristic name="Range Extreme" typeId="49d3-642a-08be-5817">-</characteristic>
         <characteristic name="Strike Value" typeId="47c7-dced-6203-6b76">2</characteristic>
-        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">HTH weapon that can be thrown in Exchange of Missiles.</characteristic>
+        <characteristic name="Special Rules" typeId="83b9-69ea-35a1-5148">HtH weapon that can be thrown in Exchange of Missiles.</characteristic>
       </characteristics>
     </profile>
     <profile id="9f0d-4729-2ca1-43d8" name="(Magic Weapon) Bow of Burning Gold" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">
@@ -992,10 +992,10 @@ When order die is drawn, players dice for control.</description>
     <profile id="a1be-15b4-9c73-9b6f" name="(Spell) Endow Strength" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">8</characteristic>
-        <characteristic name="Range" typeId="74f4-f123-678d-019c">Cast upon Wizard and also automatically affects all friendly units in HTH combat within 10&quot; of the wizard.</characteristic>
-        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">All friendly units within 10&quot; that are fighting HTH combat.</characteristic>
+        <characteristic name="Range" typeId="74f4-f123-678d-019c">Cast upon Wizard and also automatically affects all friendly units in HtH combat within 10&quot; of the wizard.</characteristic>
+        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">All friendly units within 10&quot; that are fighting HtH combat.</characteristic>
         <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">All models affected by the spell receive a STR bonus of +1 per Magic Level of caster as long as spell is in effect.</characteristic>
-        <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Lasts until the end of turn.  Also immediately ends if the caster moves, attempts to dispel and enemy spell, or is killed. (does NOT end if caster is in HTH fighting)</characteristic>
+        <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Lasts until the end of turn.  Also immediately ends if the caster moves, attempts to dispel and enemy spell, or is killed. (does NOT end if caster is in HtH fighting)</characteristic>
       </characteristics>
     </profile>
     <profile id="29a5-e36b-7b3f-c197" name="(Spell) Enchanted Shield" hidden="false" typeId="ec63-2857-95d8-a720" typeName="Spell">
@@ -1074,8 +1074,8 @@ When order die is drawn, players dice for control.</description>
       <characteristics>
         <characteristic name="Casting Value" typeId="0c1b-8aba-291c-6e28">6</characteristic>
         <characteristic name="Range" typeId="74f4-f123-678d-019c">10&quot;</characteristic>
-        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">All enemy units in HTH combat within 10&quot; of caster.</characteristic>
-        <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">All models affected by the spell receive a STR penalty of -1 per magic level of caster and no enemy may make more than 1 attack during HTH fighting.</characteristic>
+        <characteristic name="Target" typeId="878a-e6bf-fe34-2254">All enemy units in HtH combat within 10&quot; of caster.</characteristic>
+        <characteristic name="Effect" typeId="0bac-89db-b85c-4be1">All models affected by the spell receive a STR penalty of -1 per magic level of caster and no enemy may make more than 1 attack during HtH fighting.</characteristic>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Lasts until end of turn, also ends immediately if the caster moves, attempts to dispel an enemy&apos;s spell or is Killed.</characteristic>
       </characteristics>
     </profile>
@@ -1088,22 +1088,22 @@ When order die is drawn, players dice for control.</description>
         <characteristic name="Duration" typeId="c6d1-7fec-d74c-e6ac">Instant</characteristic>
       </characteristics>
     </profile>
-    <profile id="6f59-6125-456e-38c3" name="Naginata" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="6f59-6125-456e-38c3" name="Naginata" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">2</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
-    <profile id="c35f-a7c3-0b86-a39f" name="Nunchaku" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="c35f-a7c3-0b86-a39f" name="Nunchaku" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
         <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5">+2 STR</characteristic>
       </characteristics>
     </profile>
-    <profile id="7ae9-8e9a-85e9-e68b" name="Hanbo, Cane, Scroll or Tea Service" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HTH">
+    <profile id="7ae9-8e9a-85e9-e68b" name="Hanbo, Cane, Scroll or Tea Service" hidden="false" typeId="4e9d-173a-314b-a7c5" typeName="Weapon Profile HtH">
       <characteristics>
         <characteristic name="Strike Value" typeId="1b55-d6e6-1944-708a">0</characteristic>
-        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"></characteristic>
+        <characteristic name="Special Rules" typeId="dad6-5d39-6880-25a5"/>
       </characteristics>
     </profile>
     <profile id="bdba-151e-81e7-3b45" name="Shuriken" hidden="false" typeId="2c2c-0dd3-c341-b2ef" typeName="Weapon profile Ranged">


### PR DESCRIPTION
I've reviewed and updated all army lists except for the Knights which require a tad bit more work.

**Contents of this pull request:**

- Add order dice as a cost factor - this displays order dice on the army list and also allows people to set a max for this.
- Fixed a large amount of typos and errors, unified army list entries.
- Fixed missing information in skills.
- Enforced proper force restrictions for all modified army lists
- Added group selection for Magic Weapons, instead of replicating the same entry every single time
- Moved replicated skill tags higher in the root of each entry so we don't have unnecessary data replication.
- 

**Future plans (or rather not yet done):**

- Fix Knights
- Create more shared selection entries for commonly used entities (Tough Upgrade, Wound Upgrade
- Fix Monster list restriction errors (currently BS complains about a missing Warlord).
- Merge Sword and Axe weapon profile into one - this will require cleaning up a bunch of weapon selections in all army lists.